### PR TITLE
Avoid creating multiple assessments when user navigates back.

### DIFF
--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -102,7 +102,7 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
         if (assessmentId == null) {
             userService.addAssessment(assessment)
                 .then(response => {
-                    this.props.route.params.assessmentId = response.data.id
+                    this.props.navigation.setParams({assessmentId: response.data.id})
                     this.props.navigation.navigate('HowYouFeel', {currentPatient, assessmentId: response.data.id})
                 })
                 .catch(err => {

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -102,7 +102,7 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
         if (assessmentId == null) {
             userService.addAssessment(assessment)
                 .then(response => {
-                    this.props.navigation.setParams({assessmentId: response.data.id})
+                    this.props.navigation.setParams({assessmentId: response.data.id});
                     this.props.navigation.navigate('HowYouFeel', {currentPatient, assessmentId: response.data.id})
                 })
                 .catch(err => {

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -102,6 +102,7 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
         if (assessmentId == null) {
             userService.addAssessment(assessment)
                 .then(response => {
+                    this.props.route.params.assessmentId = response.data.id
                     this.props.navigation.navigate('HowYouFeel', {currentPatient, assessmentId: response.data.id})
                 })
                 .catch(err => {

--- a/src/features/assessment/HealthWorkerExposureScreen.tsx
+++ b/src/features/assessment/HealthWorkerExposureScreen.tsx
@@ -65,15 +65,14 @@ export default class HealthWorkerExposureScreen extends Component<HealthWorkerEx
         if (assessmentId == null) {
             userService.addAssessment(assessment)
                 .then(response => {
-                    this.props.navigation.setParams({assessmentId: response.data.id})
-                    this.props.navigation.navigate('CovidTest', {
-                        currentPatient, assessmentId: response.data.id
-                })})
+                    this.props.navigation.setParams({assessmentId: response.data.id});
+                    this.props.navigation.navigate('CovidTest', {currentPatient, assessmentId: response.data.id});
+                })
                 .catch(err => this.setState({errorMessage: i18n.t("something-went-wrong")}));
         } else {
             userService.updateAssessment(assessmentId, assessment)
                 .then(response => {
-                    this.props.navigation.navigate('CovidTest', {currentPatient, assessmentId: assessmentId})
+                    this.props.navigation.navigate('CovidTest', {currentPatient, assessmentId: assessmentId});
                 })
                 .catch(err => this.setState({errorMessage: i18n.t("something-went-wrong")}));
         }

--- a/src/features/assessment/HealthWorkerExposureScreen.tsx
+++ b/src/features/assessment/HealthWorkerExposureScreen.tsx
@@ -65,7 +65,7 @@ export default class HealthWorkerExposureScreen extends Component<HealthWorkerEx
         if (assessmentId == null) {
             userService.addAssessment(assessment)
                 .then(response => {
-                    this.props.route.params.assessmentId = response.data.id;
+                    this.props.navigation.setParams({assessmentId: response.data.id})
                     this.props.navigation.navigate('CovidTest', {
                         currentPatient, assessmentId: response.data.id
                 })})

--- a/src/features/assessment/HealthWorkerExposureScreen.tsx
+++ b/src/features/assessment/HealthWorkerExposureScreen.tsx
@@ -58,14 +58,25 @@ export default class HealthWorkerExposureScreen extends Component<HealthWorkerEx
 
     handleUpdate(formData: HealthWorkerExposureData) {
         const currentPatient = this.props.route.params.currentPatient;
+        const assessmentId = this.props.route.params.assessmentId;
         const userService = new UserService();
         var assessment = this.createAssessment(formData);
 
-        userService.addAssessment(assessment)
-            .then(response => this.props.navigation.navigate('CovidTest', {
-                currentPatient, assessmentId: response.data.id
-            }))
-            .catch(err => this.setState({errorMessage: i18n.t("something-went-wrong")}));
+        if (assessmentId == null) {
+            userService.addAssessment(assessment)
+                .then(response => {
+                    this.props.route.params.assessmentId = response.data.id;
+                    this.props.navigation.navigate('CovidTest', {
+                        currentPatient, assessmentId: response.data.id
+                })})
+                .catch(err => this.setState({errorMessage: i18n.t("something-went-wrong")}));
+        } else {
+            userService.updateAssessment(assessmentId, assessment)
+                .then(response => {
+                    this.props.navigation.navigate('CovidTest', {currentPatient, assessmentId: assessmentId})
+                })
+                .catch(err => this.setState({errorMessage: i18n.t("something-went-wrong")}));
+        }
     }
 
     private createAssessment(formData: HealthWorkerExposureData) {

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -65,7 +65,10 @@ export default class LevelOfIsolationScreen extends Component<LocationProps> {
         } else {
             promise = userService.updateAssessment(assessmentId, assessment)
         }
-        promise.then(response => assessmentId = response.data.id)
+        promise.then(response => {
+            this.props.route.params.assessmentId = response.data.id
+            assessmentId = response.data.id
+        })
         .then(() => this.updatePatientsLastAskedDate(currentPatient)
         .then(() => this.navigateToStart(currentPatient, assessmentId as string)))
         .catch(err => {

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -66,8 +66,8 @@ export default class LevelOfIsolationScreen extends Component<LocationProps> {
             promise = userService.updateAssessment(assessmentId, assessment)
         }
         promise.then(response => {
-            this.props.navigation.setParams({assessmentId: response.data.id})
-            assessmentId = response.data.id
+            this.props.navigation.setParams({assessmentId: response.data.id});
+            assessmentId = response.data.id;
         })
         .then(() => this.updatePatientsLastAskedDate(currentPatient)
         .then(() => this.navigateToStart(currentPatient, assessmentId as string)))

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -66,7 +66,7 @@ export default class LevelOfIsolationScreen extends Component<LocationProps> {
             promise = userService.updateAssessment(assessmentId, assessment)
         }
         promise.then(response => {
-            this.props.route.params.assessmentId = response.data.id
+            this.props.navigation.setParams({assessmentId: response.data.id})
             assessmentId = response.data.id
         })
         .then(() => this.updatePatientsLastAskedDate(currentPatient)


### PR DESCRIPTION
This PR:

- Keeps track of the newly created `assessmentId` on the first page of assessments (either `CovidTestScreen` or `HealthWorkerExposureScreen`)

This avoids creating new assessments whenever the user navigates back to the first page. Instead the existing one will be patched.