### PR TITLE
Skip retrieving push tokens when in expo client 

### DIFF
--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -13,7 +13,7 @@ import {ScreenParamList} from "../ScreenParamList";
 import {PiiRequest} from "../../core/user/dto/UserAPIContracts";
 import {PushNotificationService} from "../../core/PushNotificationService";
 import {AsyncStorageService} from "../../core/AsyncStorageService";
-
+import Constants from 'expo-constants';
 
 type PropsType = {
     navigation: StackNavigationProp<ScreenParamList, 'OptionalInfo'>
@@ -65,13 +65,15 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
             })
         };
 
-        const pushToken = await PushNotificationService.getPushToken(false);
-        if (pushToken) {
-            try {
-                await userService.savePushToken(pushToken);
-                AsyncStorageService.setPushToken(pushToken);
-            } catch (error) {
-                this.setState({errorMessage: 'Something went wrong... try again later'});
+        if (Constants.appOwnership !== 'expo') {
+            const pushToken = await PushNotificationService.getPushToken(false);
+            if (pushToken) {
+                try {
+                    await userService.savePushToken(pushToken);
+                    AsyncStorageService.setPushToken(pushToken);
+                } catch (error) {
+                    this.setState({errorMessage: 'Something went wrong... try again later'});
+                }
             }
         }
 


### PR DESCRIPTION
We're hampered with Android testing with the expo client because of an error in the client when trying to retrieve push tokens. This leaves our QA testing stuck in that they cannot proceed past the OptionalInfo screen when creating an account.

I've found a `Constants.appOwnership` value in Expo we can use to just skip that bit of code while in the Expo client, but run it normally in the full app. This enables our QA testers and us to test on Android without waiting for an app build.

We can revert it when the expo client is working properly again. It's supposedly down to some configuration change in Firebase...
