### PR TITLE
Fix 'ask for rating' always being set to true on ViralThankYou

### DIFF
--- a/src/components/CovidRating.tsx
+++ b/src/components/CovidRating.tsx
@@ -27,6 +27,14 @@ const ModalContainer = (props: any) => (
     </Modal>
 );
 
+export async function shouldAskForRating() {
+    const userService = new UserService();
+    const profile = await userService.getProfile();
+    const eligibleToAskForRating = profile.ask_for_rating;
+    const askedToRateStatus = await userService.getAskedToRateStatus();
+    return (!askedToRateStatus && eligibleToAskForRating);
+}
+
 export class CovidRating extends Component<PropsType, State> {
     state = {
         isModalOpen: true,

--- a/src/features/ThankYouScreen.tsx
+++ b/src/features/ThankYouScreen.tsx
@@ -10,7 +10,7 @@ import {StackNavigationProp} from "@react-navigation/stack";
 import {covidIcon} from "../../assets";
 import i18n from "../locale/i18n"
 import {Linking} from "expo";
-import { CovidRating } from "../components/CovidRating";
+import { CovidRating, shouldAskForRating } from "../components/CovidRating";
 import UserService from "../core/user/UserService";
 
 type RenderProps = {
@@ -39,11 +39,7 @@ export default class ThankYouScreen extends Component<RenderProps, {askForRating
 
     async componentDidMount() {
         // Ask for rating if not asked before and server indicates eligible.
-        const userService = new UserService();
-        const profile = await userService.getProfile();
-        const eligibleToAskForRating = profile.ask_for_rating;
-        const askedToRateStatus = await userService.getAskedToRateStatus();
-        if (!askedToRateStatus && eligibleToAskForRating) {this.setState({askForRating: true})}
+        if (await shouldAskForRating()) {this.setState({askForRating: true})}
     }
 
 

--- a/src/features/ViralThankYouScreen.tsx
+++ b/src/features/ViralThankYouScreen.tsx
@@ -170,8 +170,6 @@ export default class ViralThankYouScreen extends Component<Props, State> {
             </Text>
         );
 
-        console.log("This state ask for rating:", this.state.askForRating);
-
         return (
             <>
              {this.state.askForRating && <CovidRating /> }

--- a/src/features/ViralThankYouScreen.tsx
+++ b/src/features/ViralThankYouScreen.tsx
@@ -24,7 +24,7 @@ import UserService from "../core/user/UserService";
 import {AreaStatsResponse} from "../core/user/dto/UserAPIContracts";
 import BrandedSpinner from "../components/Spinner";
 import moment from "moment";
-import { CovidRating } from "../components/CovidRating";
+import { CovidRating, shouldAskForRating } from "../components/CovidRating";
 import I18n from "i18n-js";
 
 
@@ -55,15 +55,10 @@ export default class ViralThankYouScreen extends Component<Props, State> {
     }
 
     async componentDidMount() {
-
-
         const userService = new UserService();
         const profile = await userService.getProfile();
 
-        // Ask for rating if not asked before and server indicates eligible.
-        const eligibleToAskForRating = profile.ask_for_rating;
-        const askedToRateStatus = await userService.getAskedToRateStatus();
-        if (!askedToRateStatus && eligibleToAskForRating) {this.setState({askForRating: true})}
+        if (await shouldAskForRating()) {this.setState({askForRating: true})}
 
         userService.getAreaStats(profile.patients[0]) // todo: multipatient
             .then(response => this.setState({
@@ -174,6 +169,8 @@ export default class ViralThankYouScreen extends Component<Props, State> {
                 today
             </Text>
         );
+
+        console.log("This state ask for rating:", this.state.askForRating);
 
         return (
             <>


### PR DESCRIPTION
Also, extract the logic of checking if a user should be asked to rate into it's own function.