### PR TITLE
Optionally hide buttons on consent screens

### DIFF
--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -63,7 +63,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
                 <Text style={fontStyles.h2Reg}>{i18n.t('faqs')}</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.iconNameRow} onPress={() => {
-                isGBLocale() ? props.navigation.navigate("PrivacyPolicyUK") : props.navigation.navigate("PrivacyPolicyUS")
+                isGBLocale() ? props.navigation.navigate("PrivacyPolicyUK", {viewOnly: true}) : props.navigation.navigate("PrivacyPolicyUS", {viewOnly: true})
             }}>
                 <Text style={fontStyles.h2Reg}>{i18n.t('privacy-policy')}</Text>
             </TouchableOpacity>

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -1,5 +1,5 @@
 import {UserResponse} from "../core/user/dto/UserAPIContracts";
-import { PatientStateType } from "../core/patient/PatientState";
+import {PatientStateType} from "../core/patient/PatientState";
 
 export enum ConsentType {
     Adult = "adult",
@@ -13,16 +13,16 @@ export type ScreenParamList = {
     Welcome: undefined;
     WelcomeUS: undefined;
     Welcome2US: undefined;
-    WelcomeRepeat: { patientId: string};
-    WelcomeRepeatUS: { patientId: string};
+    WelcomeRepeat: { patientId: string };
+    WelcomeRepeatUS: { patientId: string };
 
     // Terms & consent screens
-    Terms: undefined;
-    NursesConsentUS: undefined;
+    Terms: { viewOnly: boolean };
+    NursesConsentUS: { viewOnly: boolean };
     BeforeWeStartUS: undefined;
-    TermsOfUse: undefined;
-    PrivacyPolicyUK: undefined;
-    PrivacyPolicyUS: undefined;
+    TermsOfUse: { viewOnly: boolean };
+    PrivacyPolicyUK: { viewOnly: boolean };
+    PrivacyPolicyUS: { viewOnly: boolean };
 
     // User profile screens
     ResetPassword: undefined;
@@ -42,18 +42,18 @@ export type ScreenParamList = {
 
     // Assessment screens
     HealthWorkerExposure: { currentPatient: PatientStateType }; // How do people normally get here?
-    CovidTest: { currentPatient: PatientStateType, assessmentId: string | null};
+    CovidTest: { currentPatient: PatientStateType, assessmentId: string | null };
     HowYouFeel: { currentPatient: PatientStateType, assessmentId: string };
     DescribeSymptoms: { currentPatient: PatientStateType, assessmentId: string };
     WhereAreYou: { currentPatient: PatientStateType, assessmentId: string };
     LevelOfIsolation: { currentPatient: PatientStateType, assessmentId: string };
-    TreatmentSelection:  { currentPatient: PatientStateType, assessmentId: string, location?: string };
+    TreatmentSelection: { currentPatient: PatientStateType, assessmentId: string, location?: string };
     TreatmentOther: { currentPatient: PatientStateType, assessmentId: string, location?: string };
 
     // Multi patient screens
-    ConsentForOther: { profileName: string, avatarName?: string, consentType: ConsentType},
+    ConsentForOther: { profileName: string, avatarName?: string, consentType: ConsentType },
     AdultOrChild: { profileName: string, avatarName?: string };
-    CreateProfile: {avatarName?: string };
+    CreateProfile: { avatarName?: string };
     ReportForOther: undefined;
     SelectProfile: undefined;
 

--- a/src/features/multi-profile/ConsentForOtherScreen.tsx
+++ b/src/features/multi-profile/ConsentForOtherScreen.tsx
@@ -48,13 +48,13 @@ export default class ConsentForOtherScreen extends Component<RenderProps, Consen
     secondaryText = this.isAdultConsent() ? (
         <RegularText>
             Please confirm that you have shown or read our{" "}
-            <ClickableText onPress={() => this.props.navigation.navigate("Terms")}>consent</ClickableText>
+            <ClickableText onPress={() => this.props.navigation.navigate("Terms", {viewOnly: true})}>consent</ClickableText>
             {" "}screen to the individual on whose behalf you are entering the data, that they are 18 or over, and that they have given their consent for you to share their data with us.
         </RegularText>
     ) : (
         <RegularText>
             If your child is old enough to understand our{" "}
-            <ClickableText onPress={() => this.props.navigation.navigate("Terms")}>consent</ClickableText>
+            <ClickableText onPress={() => this.props.navigation.navigate("Terms", {viewOnly: true})}>consent</ClickableText>
             {" "}requirements, please explain to them that you are sharing information about them with us and we are going to do with it. If you think that your child is old enough to make their own decisions, please confirm that they have consented to your sharing their data with us.
         </RegularText>
     );

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -11,6 +11,7 @@ import moment from "moment";
 import {profile1, profile2, profile3, profile4, profile5, profile6, profile7, profile8, profile9, profile10, addProfile, NUMBER_OF_PROFILE_AVATARS} from "../../../assets";
 import {Card} from "native-base";
 import '../../../assets';
+import key from "weak-key";
 
 type RenderProps = {
     navigation: StackNavigationProp<ScreenParamList, 'SelectProfile'>
@@ -18,7 +19,7 @@ type RenderProps = {
 }
 
 type Patient = {
-    id?: string,
+    id: string,
     name?: string,
     avatar_name?: string,
     reported_by_another?: boolean,
@@ -103,8 +104,8 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
                             <View style={styles.profileList}>
                                 {
                                     this.state.patients.map((patient, i) =>
-                                      <View style={styles.cardContainer}>
-                                        <TouchableOpacity key={i} onPress={() => this.props.navigation.navigate(this.getNextReportScreen())}>
+                                      <View style={styles.cardContainer}  key={key(patient)}>
+                                        <TouchableOpacity onPress={() => this.props.navigation.navigate(this.getNextReportScreen())}>
                                             <Card style={styles.card}>
                                                 <Image source={this.getAvatar(patient)} style={styles.avatar} resizeMode={'contain'} />
                                                 <RegularText>{patient.name}</RegularText>

--- a/src/features/register/TermsScreen.tsx
+++ b/src/features/register/TermsScreen.tsx
@@ -7,10 +7,12 @@ import {BrandedButton, ClickableText, RegularBoldText, RegularText} from "../../
 import UserService, {isUSLocale} from "../../core/user/UserService";
 import {ScreenParamList} from "../ScreenParamList";
 import {consentVersionUK, consentVersionUS, privacyPolicyVersionUK, privacyPolicyVersionUS} from "./constants";
+import {RouteProp} from "@react-navigation/native";
 
 
 type PropsType = {
     navigation: StackNavigationProp<ScreenParamList, 'Terms'>
+    route: RouteProp<ScreenParamList, 'Terms'>;
 }
 
 interface TermsState {
@@ -29,14 +31,15 @@ export class TermsScreen extends Component<PropsType, TermsState> {
         }
     }
 
+    viewOnly = this.props.route.params.viewOnly;
+
     handleProcessingChange = () => {
         this.setState({processingChecked: !this.state.processingChecked})
-
-    }
+    };
 
     handleTermsOfUseChange = () => {
         this.setState({termsOfUseChecked: !this.state.termsOfUseChecked})
-    }
+    };
 
     handleUSAgreeClicked = async () => {
         if (this.state.processingChecked && this.state.termsOfUseChecked) {
@@ -52,15 +55,14 @@ export class TermsScreen extends Component<PropsType, TermsState> {
 
 
     render() {
-        // get us or UK
-
+        // Get US or UK
         return (
-            isUSLocale() ? (
+            !isUSLocale() ? (
                 <View style={styles.rootContainer}>
                     <ScrollView>
                         <RegularText>
                             If you are in an existing research or clinical study (e.g. Nurses’ Health Studies) and you want your data to be shared with investigators on that study, <ClickableText
-                            onPress={() => this.props.navigation.navigate('NursesConsentUS')}>click here</ClickableText>
+                            onPress={() => this.props.navigation.navigate('NursesConsentUS', {viewOnly: this.viewOnly})}>click here</ClickableText>
                             {"\n"}
                         </RegularText>
 
@@ -90,49 +92,57 @@ export class TermsScreen extends Component<PropsType, TermsState> {
                             By checking the box below, you consent to our using the personal information we collect through your use of this app in the way we have described.
                             {"\n\n"}
                             For more information about how we use and share personal information about you, please see our {" "}
-                            <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>privacy policy</ClickableText>.{"\n\n"}
+                            <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>privacy policy</ClickableText>.{"\n\n"}
                             You may withdraw your consent at any time by emailing <RegularBoldText>leavecovidtracking-us@joinzoe.com</RegularBoldText>
                             {"\n\n"}
                             Any questions may be sent to <RegularBoldText>covidtrackingquestions-us@joinzoe.com</RegularBoldText>
                         </RegularText>
 
-
-                        <ListItem style={styles.permission}>
-                            <CheckBox
-                                checked={this.state.processingChecked}
-                                onPress={this.handleProcessingChange}
-                            />
-                            <Body style={styles.label}>
-                                <RegularText>
-                                    I consent to the processing of my personal data (including without limitation data I provide relating to my health)
-                                    as set forth in this consent and in the{" "}
-                                    <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>Privacy Policy</ClickableText>
-                                    .
-                                </RegularText>
-                            </Body>
-                        </ListItem>
-                        <ListItem>
-                            <CheckBox
-                                checked={this.state.termsOfUseChecked}
-                                onPress={this.handleTermsOfUseChange}
-                            />
-                            <Body style={styles.label}>
-                                <RegularText>
-                                    I have read and accept Zoe Global’s {" "}
-                                    <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUse')}>Terms of Use</ClickableText>{" "}
-                                    and{" "}
-                                    <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>Privacy Policy</ClickableText>.
-                                </RegularText>
-                            </Body>
-                        </ListItem>
+                        {
+                            !this.viewOnly && (
+                                <View>
+                                    <ListItem style={styles.permission}>
+                                        <CheckBox
+                                            checked={this.state.processingChecked}
+                                            onPress={this.handleProcessingChange}
+                                        />
+                                        <Body style={styles.label}>
+                                            <RegularText>
+                                                I consent to the processing of my personal data (including without limitation data I provide relating to my health)
+                                                as set forth in this consent and in the{" "}
+                                                <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy Policy</ClickableText>
+                                                .
+                                            </RegularText>
+                                        </Body>
+                                    </ListItem>
+                                    <ListItem>
+                                        <CheckBox
+                                            checked={this.state.termsOfUseChecked}
+                                            onPress={this.handleTermsOfUseChange}
+                                        />
+                                        <Body style={styles.label}>
+                                            <RegularText>
+                                                I have read and accept Zoe Global’s {" "}
+                                                <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUse', {viewOnly: this.viewOnly})}>Terms of Use</ClickableText>{" "}
+                                                and{" "}
+                                                <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy Policy</ClickableText>.
+                                            </RegularText>
+                                        </Body>
+                                    </ListItem>
+                                </View>
+                            )
+                        }
 
                     </ScrollView>
 
-                    <BrandedButton style={styles.button}
-                                   enable={this.state.processingChecked && this.state.termsOfUseChecked}
-                                   hideLoading={true}
-                                   onPress={this.handleUSAgreeClicked}>I Agree</BrandedButton>
-
+                    {
+                        !this.viewOnly &&
+                        <BrandedButton
+                          style={styles.button}
+                          enable={this.state.processingChecked && this.state.termsOfUseChecked}
+                          hideLoading={true}
+                          onPress={this.handleUSAgreeClicked}>I Agree</BrandedButton>
+                    }
                 </View>
             ) : (
                 <View style={styles.rootContainer}>
@@ -150,8 +160,8 @@ export class TermsScreen extends Component<PropsType, TermsState> {
                         <RegularText>
                             This app is designed by doctors and scientists at Kings’ College London, Guys and St Thomas’ Hospitals and Zoe Global Limited, a health technology company.
                             They have access to the information you enter, which may also be shared with the NHS and other medical researchers as outlined in our
-                            {" "}<ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUK')}>privacy notice</ClickableText>.{"\n\n"}
-                            {"\n\n"}
+                            {" "}<ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUK', {viewOnly: this.viewOnly})}>privacy notice</ClickableText>.{"\n\n"}
+                            {"\n"}
                             No information you share will be used for commercial purposes. An anonymous code will be used to replace your personal details when sharing information with other researchers.
                         </RegularText>
 
@@ -168,7 +178,7 @@ export class TermsScreen extends Component<PropsType, TermsState> {
                             your personal information on this basis.
                             {"\n\n"}
                             We adhere to the General Data Protection Regulation ‘GDPR’. For more information about how we use and share personal information about you, please see our
-                            {" "}<ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUK')}>privacy notice</ClickableText>.{"\n\n"}
+                            {" "}<ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUK', {viewOnly: this.viewOnly})}>privacy notice</ClickableText>.{"\n\n"}
                             You may withdraw your consent at any time by emailing <RegularBoldText>leavecovidtracking@joinzoe.com</RegularBoldText>
                             {"\n\n"}
                             Any questions may be sent to <RegularBoldText>covidtrackingquestions@joinzoe.com</RegularBoldText>
@@ -176,7 +186,10 @@ export class TermsScreen extends Component<PropsType, TermsState> {
 
                     </ScrollView>
 
-                    <BrandedButton style={styles.button} onPress={this.handleUKAgreeClicked}>I Agree</BrandedButton>
+                    {
+                        !this.viewOnly &&
+                        <BrandedButton style={styles.button} onPress={this.handleUKAgreeClicked}>I Agree</BrandedButton>
+                    }
 
                 </View>
             )

--- a/src/features/register/TermsScreen.tsx
+++ b/src/features/register/TermsScreen.tsx
@@ -57,7 +57,7 @@ export class TermsScreen extends Component<PropsType, TermsState> {
     render() {
         // Get US or UK
         return (
-            !isUSLocale() ? (
+            isUSLocale() ? (
                 <View style={styles.rootContainer}>
                     <ScrollView>
                         <RegularText>

--- a/src/features/register/gb/PrivacyPolicyUKScreen.tsx
+++ b/src/features/register/gb/PrivacyPolicyUKScreen.tsx
@@ -5,19 +5,21 @@ import {colors} from "../../../../theme";
 import {BrandedButton, ClickableText, RegularBoldText, RegularText} from "../../../components/Text";
 import {ScreenParamList} from "../../ScreenParamList";
 import {ApplicationVersion} from "../../../components/AppVersion";
+import {RouteProp} from "@react-navigation/native";
 
 type PropsType = {
     navigation: StackNavigationProp<ScreenParamList, 'PrivacyPolicyUK'>
+    route: RouteProp<ScreenParamList, 'PrivacyPolicyUK'>;
 }
 
 export class PrivacyPolicyUKScreen extends Component<PropsType, {}> {
 
-    // todo julien: add links
+    viewOnly = this.props.route.params.viewOnly;
+
     render() {
         return (
             <View style={styles.rootContainer}>
                 <ScrollView>
-
 
                     <RegularBoldText>Your consent{"\n"}</RegularBoldText>
                     <RegularBoldText>European General Data Protection Regulation{"\n"}</RegularBoldText>
@@ -101,7 +103,6 @@ export class PrivacyPolicyUKScreen extends Component<PropsType, {}> {
                         {"\n"}
                     </RegularText>
 
-
                     <RegularBoldText>Third party processors for both kinds of information{"\n"}</RegularBoldText>
                     <RegularText>
                         We use third parties to process some of your personal data on our behalf. When we allow them access to your data, we do not permit them to use it for their own purposes. We have in place with each processor, a contract that requires them only to process the data on our
@@ -169,7 +170,6 @@ export class PrivacyPolicyUKScreen extends Component<PropsType, {}> {
 
                     <RegularBoldText>Institutions we share data with{"\n"}</RegularBoldText>
 
-
                     <RegularText>
                         King’s College London{"\n"}
                         Guys & St Thomas' Hospitals{"\n"}
@@ -185,7 +185,10 @@ export class PrivacyPolicyUKScreen extends Component<PropsType, {}> {
                     </RegularText>
                 </ScrollView>
 
-                <BrandedButton style={styles.button} onPress={() => this.props.navigation.goBack()}>Back</BrandedButton>
+                {
+                    !this.viewOnly && <BrandedButton style={styles.button} onPress={() => this.props.navigation.goBack()}>Back</BrandedButton>
+                }
+
 
                 <ApplicationVersion/>
             </View>
@@ -209,5 +212,4 @@ const styles = StyleSheet.create({
     button: {
         marginTop: 20,
     }
-
 });

--- a/src/features/register/gb/WelcomeRepeatScreen.tsx
+++ b/src/features/register/gb/WelcomeRepeatScreen.tsx
@@ -102,7 +102,7 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
                         <RegularText style={styles.privacyPolicyText}>
                             <ClickableText
                                 style={styles.privacyPolicyClickText}
-                                onPress={() => this.props.navigation.navigate('PrivacyPolicyUK')}
+                                onPress={() => this.props.navigation.navigate('PrivacyPolicyUK', {viewOnly: true})}
                             >Privacy policy</ClickableText> (incl. how to delete your data)
                         </RegularText>
                     </View>

--- a/src/features/register/gb/WelcomeScreen.tsx
+++ b/src/features/register/gb/WelcomeScreen.tsx
@@ -69,7 +69,7 @@ export class WelcomeScreen extends Component<PropsType, WelcomeScreenState> {
 
                         <Image source={partnersLogo} style={styles.partnersLogo} resizeMode="contain"/>
 
-                        <BrandedButton onPress={() => this.props.navigation.navigate('Terms')}>{i18n.t("create-account-btn")}</BrandedButton>
+                        <BrandedButton onPress={() => this.props.navigation.navigate('Terms', {viewOnly: false})}>{i18n.t("create-account-btn")}</BrandedButton>
                         <ClickableText onPress={() => Linking.openURL('https://covid.joinzoe.com/')} style={styles.moreInfo}>
                             {"For more info "}
                             <RegularText style={styles.moreInfoHighlight}>visit our website</RegularText>

--- a/src/features/register/us/BeforeWeStartUS.tsx
+++ b/src/features/register/us/BeforeWeStartUS.tsx
@@ -38,13 +38,13 @@ export default class BeforeWeStart extends Component<HowYouFeelProps, State> {
 
                 <Form style={styles.form}>
                     <FieldWrapper style={styles.fieldWrapper}>
-                        <BigButton onPress={() => this.props.navigation.navigate('NursesConsentUS')}>
+                        <BigButton onPress={() => this.props.navigation.navigate('NursesConsentUS', {viewOnly: false})}>
                             <Text style={[fontStyles.bodyLight, styles.buttonText]}>Yes, I am</Text>
                         </BigButton>
                     </FieldWrapper>
 
                     <FieldWrapper style={styles.fieldWrapper}>
-                        <BigButton onPress={() => this.props.navigation.navigate('Terms')}>
+                        <BigButton onPress={() => this.props.navigation.navigate('Terms', {viewOnly: false})}>
                             <Text style={[fontStyles.bodyLight, styles.buttonText]}>No, I am not</Text>
                         </BigButton>
                     </FieldWrapper>

--- a/src/features/register/us/NursesConsentUS.tsx
+++ b/src/features/register/us/NursesConsentUS.tsx
@@ -7,10 +7,12 @@ import {BrandedButton, ClickableText, RegularBoldText, RegularText} from "../../
 import {ScreenParamList} from "../../ScreenParamList";
 import UserService from "../../../core/user/UserService";
 import {NursesConsentVersionUS, privacyPolicyVersionUS} from "../constants";
+import {RouteProp} from "@react-navigation/native";
 
 
 type PropsType = {
     navigation: StackNavigationProp<ScreenParamList, 'NursesConsentUS'>
+    route: RouteProp<ScreenParamList, 'NursesConsentUS'>;
 }
 
 interface TermsState {
@@ -28,6 +30,8 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
             termsOfUseChecked: false,
         }
     }
+
+    viewOnly = this.props.route.params.viewOnly;
 
     handleProcessingChange = () => {
         this.setState({processingChecked: !this.state.processingChecked})
@@ -163,7 +167,8 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
                     <RegularBoldText>Who may see, use, and share your identifiable health information and why they may need to do so:
                         {"\n"}</RegularBoldText>
                     <RegularText>
-                        For complete details of the data we collect, who may see, use, and share your data and the reasons for doing so, please see the <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>Privacy Policy</ClickableText>. In brief, the privacy plan details
+                        For complete details of the data we collect, who may see, use, and share your data and the reasons for doing so, please see the <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy Policy</ClickableText>. In
+                        brief, the privacy plan details
                         that we may share your data with the researchers involved with this study which includes Zoe , other researchers and medical centers that are part of this study and their ethics boards, in addition to other individuals.
                         {"\n"}
                         No information you share will be used for commercial purposes. We will not use or share your information for any mailing or marketing list.
@@ -193,7 +198,7 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
                         {"\n"}{"\n"}
                         By clicking below, you consent to our using the personal information we collect through your use of this app in the way we have described.
                         {"\n"}{"\n"}
-                        For more information about how we use and share personal information about you, please see our <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>privacy notice</ClickableText>.
+                        For more information about how we use and share personal information about you, please see our <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>privacy notice</ClickableText>.
                         {"\n"}{"\n"}
                     </RegularText>
 
@@ -219,44 +224,53 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
                         {"\n"}
                     </RegularText>
 
-                    <ListItem style={styles.permission}>
-                        <CheckBox
-                            checked={this.state.processingChecked}
-                            onPress={this.handleProcessingChange}
-                        />
-                        <Body style={styles.label}>
-                            <RegularText>
-                                I consent to the processing of my personal data (including without limitation data I
-                                provide relating to my health) as set forth in this consent and in the{" "}
-                                <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>Privacy
-                                    Policy</ClickableText>
-                                .
-                            </RegularText>
-                        </Body>
-                    </ListItem>
-                    <ListItem>
-                        <CheckBox
-                            checked={this.state.termsOfUseChecked}
-                            onPress={this.handleTermsOfUseChange}
-                        />
-                        <Body style={styles.label}>
-                            <RegularText>
-                                I have read and accept Zoe Global’s {" "}
-                                <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUse')}>Terms of
-                                    Use</ClickableText>{" "}
-                                and{" "}
-                                <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>Privacy
-                                    Policy</ClickableText>.
-                            </RegularText>
-                        </Body>
-                    </ListItem>
-
+                    {
+                        !this.viewOnly && (
+                            <View>
+                                <ListItem style={styles.permission}>
+                                    <CheckBox
+                                        checked={this.state.processingChecked}
+                                        onPress={this.handleProcessingChange}
+                                    />
+                                    <Body style={styles.label}>
+                                        <RegularText>
+                                            I consent to the processing of my personal data (including without limitation data I
+                                            provide relating to my health) as set forth in this consent and in the{" "}
+                                            <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy
+                                                Policy</ClickableText>
+                                            .
+                                        </RegularText>
+                                    </Body>
+                                </ListItem>
+                                <ListItem>
+                                    <CheckBox
+                                        checked={this.state.termsOfUseChecked}
+                                        onPress={this.handleTermsOfUseChange}
+                                    />
+                                    <Body style={styles.label}>
+                                        <RegularText>
+                                            I have read and accept Zoe Global’s {" "}
+                                            <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUse', {viewOnly: this.viewOnly})}>Terms of
+                                                Use</ClickableText>{" "}
+                                            and{" "}
+                                            <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy
+                                                Policy</ClickableText>.
+                                        </RegularText>
+                                    </Body>
+                                </ListItem>
+                            </View>
+                        )
+                    }
                 </ScrollView>
 
-                <BrandedButton style={styles.button}
-                               hideLoading={true}
-                               enable={this.state.processingChecked && this.state.termsOfUseChecked}
-                               onPress={this.handleAgreeClicked}>I agree</BrandedButton>
+                {
+                    !this.viewOnly &&
+                    <BrandedButton style={styles.button}
+                                   hideLoading={true}
+                                   enable={this.state.processingChecked && this.state.termsOfUseChecked}
+                                   onPress={this.handleAgreeClicked}>I agree</BrandedButton>
+                }
+
             </View>
 
         );

--- a/src/features/register/us/NursesConsentUS.tsx
+++ b/src/features/register/us/NursesConsentUS.tsx
@@ -226,7 +226,7 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
 
                     {
                         !this.viewOnly && (
-                            <View>
+                            <>
                                 <ListItem style={styles.permission}>
                                     <CheckBox
                                         checked={this.state.processingChecked}
@@ -258,7 +258,7 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
                                         </RegularText>
                                     </Body>
                                 </ListItem>
-                            </View>
+                            </>
                         )
                     }
                 </ScrollView>

--- a/src/features/register/us/PrivacyPolicyUSScreen.tsx
+++ b/src/features/register/us/PrivacyPolicyUSScreen.tsx
@@ -5,10 +5,12 @@ import {colors} from "../../../../theme";
 import {BrandedButton, ClickableText, RegularBoldText, RegularText} from "../../../components/Text";
 import {ScreenParamList} from "../../ScreenParamList";
 import {ApplicationVersion} from "../../../components/AppVersion";
+import {RouteProp} from "@react-navigation/native";
 
 
 type PropsType = {
-    navigation: StackNavigationProp<ScreenParamList, 'PrivacyPolicyUK'>
+    navigation: StackNavigationProp<ScreenParamList, 'PrivacyPolicyUS'>
+    route: RouteProp<ScreenParamList, 'PrivacyPolicyUS'>;
 }
 
 const HeaderText = (props: { text: string }) => {
@@ -17,10 +19,11 @@ const HeaderText = (props: { text: string }) => {
             {props.text}{"\n"}
         </RegularBoldText>
     )
-}
-
+};
 
 export class PrivacyPolicyUSScreen extends Component<PropsType, {}> {
+
+    viewOnly = this.props.route.params.viewOnly;
 
     render() {
         return (
@@ -327,7 +330,6 @@ The General Data Protection Regulation also gives you the right to lodge a compl
                 <BrandedButton style={styles.button} onPress={() => this.props.navigation.goBack()}>Back</BrandedButton>
 
                 <ApplicationVersion/>
-
 
             </View>
         );

--- a/src/features/register/us/TermsOfUseScreen.tsx
+++ b/src/features/register/us/TermsOfUseScreen.tsx
@@ -1,18 +1,14 @@
 import {StackNavigationProp} from "@react-navigation/stack";
 import React, {Component} from "react";
-import {Linking, ScrollView, StyleSheet, View} from "react-native";
+import {ScrollView, StyleSheet, View} from "react-native";
 import {colors} from "../../../../theme";
 import {BrandedButton, ClickableText, RegularBoldText, RegularText} from "../../../components/Text";
 import {ScreenParamList} from "../../ScreenParamList";
+import {RouteProp} from "@react-navigation/native";
 
 type PropsType = {
-    navigation: StackNavigationProp<ScreenParamList, 'Terms'>
-}
-
-// TODO - Delete this....
-interface TermsState {
-    processingChecked: boolean,
-    termsOfUseChecked: boolean
+    navigation: StackNavigationProp<ScreenParamList, 'TermsOfUse'>
+    route: RouteProp<ScreenParamList, 'TermsOfUse'>;
 }
 
 const styles = StyleSheet.create({
@@ -30,14 +26,12 @@ const styles = StyleSheet.create({
 });
 
 
-export default class TermsOfUseScreen extends Component<PropsType, TermsState> {
+export default class TermsOfUseScreen extends Component<PropsType> {
     constructor(props: PropsType) {
         super(props);
-        this.state = {
-            processingChecked: false,
-            termsOfUseChecked: false,
-        }
     }
+
+    viewOnly = this.props.route.params.viewOnly;
 
     render() {
         return (
@@ -54,7 +48,7 @@ export default class TermsOfUseScreen extends Component<PropsType, TermsState> {
 
                             These Terms of Use (the “Terms”) are a binding contract between you and us. Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. These Terms include the provisions in this document as well as those in our
                             {" "}
-                        <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}>Privacy Policy.</ClickableText>
+                        <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy Policy.</ClickableText>
                         {"\n"}
                     </RegularText>
 
@@ -120,8 +114,7 @@ export default class TermsOfUseScreen extends Component<PropsType, TermsState> {
                             THE SERVICES SHOULD NEVER BE USED AS A SUBSTITUTE FOR EMERGENCY CARE. IF YOU HAVE A MEDICAL OR MENTAL HEALTH EMERGENCY, ARE THINKING ABOUT SUICIDE OR TAKING ACTIONS THAT MAY CAUSE HARM TO YOU OR TO OTHERS, YOU SHOULD SEEK EMERGENCY TREATMENT AT THE NEAREST EMERGENCY ROOM OR DIAL 911.
                             {"\n\n"}
                             You will only use the Services for your own internal, personal, non-commercial use, and not on behalf of or for the benefit of any third party, and only in a manner that complies with all laws that apply to you. If your use of the Services is prohibited by applicable laws, then you aren’t authorized to use the Services. We can’t and won’t be responsible for your using the Services in a way that breaks the law.
-                        </RegularText>
-
+                    </RegularText>
 
                     <RegularBoldText>
                         {"\n"}
@@ -137,7 +130,6 @@ export default class TermsOfUseScreen extends Component<PropsType, TermsState> {
                             Will Zoe ever change the Services?
                             {"\n"}
                     </RegularBoldText>
-
 
                     <RegularText>
                         We’re always trying to improve our Services, so they may change over time. We may suspend or discontinue any part of the Services, or we may introduce new features or impose limits on certain features or restrict access to parts or all of the Services.
@@ -161,7 +153,6 @@ export default class TermsOfUseScreen extends Component<PropsType, TermsState> {
                             {"\n"}
                     </RegularBoldText>
 
-
                     <RegularText>
                         You acknowledge and agree that the availability of our mobile application is dependent on the third party stores from which you download the application, e.g., the App Store from Apple or the Android app market from Google (each an “App Store”). Each App Store may have its own terms and conditions to which you must agree before downloading mobile applications from such store, including the specific terms relating to Apple App Store set forth below. You agree to comply with, and your license to use our application is conditioned upon your compliance with, such App Store terms and conditions. To the extent such other terms and conditions from such App Store are less restrictive than, or otherwise conflict with, the terms and conditions of these Terms of Use, the more restrictive or conflicting terms and conditions in these Terms of Use apply.
                         </RegularText>
@@ -171,6 +162,7 @@ export default class TermsOfUseScreen extends Component<PropsType, TermsState> {
                             I use the Zoe App available via the Apple App Store – should I know anything about that?
                             {"\n"}
                     </RegularBoldText>
+
                     <RegularText>
 
                         A. Both you and Zoe acknowledge that the Terms are concluded between you and Zoe only, and not with Apple, and that Apple is not responsible for the Application;
@@ -242,21 +234,13 @@ Miscellaneous.
                             {"\n"}
 Except as expressly set forth in the sections above regarding the Apple Application and the arbitration agreement, you and Zoe agree there are no third-party beneficiaries intended under these Terms.
 
-
-
-
-
                         </RegularText>
                 </ScrollView>
 
-                <BrandedButton style={styles.button} onPress={() => this.props.navigation.replace('Terms')}>BACK</BrandedButton>
-
+                <BrandedButton style={styles.button} onPress={() => this.props.navigation.replace('Terms', {viewOnly: this.viewOnly})}>Back</BrandedButton>
 
             </View>
         )
     }
 
-    private openUrl(link: string) {
-        Linking.openURL(link);
-    }
 }

--- a/src/features/register/us/WelcomeRepeatUSScreen.tsx
+++ b/src/features/register/us/WelcomeRepeatUSScreen.tsx
@@ -105,7 +105,7 @@ export class WelcomeRepeatUSScreen extends Component<PropsType, WelcomeRepeatUSS
                         <RegularText style={styles.privacyPolicyText}>
                             <ClickableText
                                 style={styles.privacyPolicyClickText}
-                                onPress={() => this.props.navigation.navigate('PrivacyPolicyUS')}
+                                onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: true})}
                             >Privacy policy</ClickableText> (incl. how to delete your data)
                         </RegularText>
                     </View>


### PR DESCRIPTION
Pass in viewOnly route props to all Privacy & Terms screens to hide the buttons.