### PR TITLE
Fix excessive whitespace at end of screens

### DIFF
--- a/src/features/assessment/DescribeSymptomsScreen.tsx
+++ b/src/features/assessment/DescribeSymptomsScreen.tsx
@@ -206,7 +206,7 @@ export default class DescribeSymptomsScreen extends Component<SymptomProps, Stat
               >
                   {props => {
                       return (
-                        <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                        <KeyboardAvoidingView>
                             <Form>
 
                                 <DropdownField

--- a/src/features/assessment/HealthWorkerExposureScreen.tsx
+++ b/src/features/assessment/HealthWorkerExposureScreen.tsx
@@ -163,7 +163,7 @@ export default class HealthWorkerExposureScreen extends Component<HealthWorkerEx
                 >
                     {props => {
                         return (
-                            <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                            <KeyboardAvoidingView>
                                 <Form>
 
                                     <View>

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -87,7 +87,7 @@ export class LoginScreen extends Component<PropsType, StateType> {
 
         return (
             <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-                <KeyboardAvoidingView style={styles.rootContainer} behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                <KeyboardAvoidingView style={styles.rootContainer}>
                     <View>
                         <HeaderLightText style={styles.titleText}>{i18n.t("login-title")}</HeaderLightText>
 

--- a/src/features/password-reset/ResetPassword.tsx
+++ b/src/features/password-reset/ResetPassword.tsx
@@ -58,7 +58,7 @@ export class ResetPasswordScreen extends Component<PropsType, State> {
     render() {
         return (
             <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-                <KeyboardAvoidingView style={styles.rootContainer} behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                <KeyboardAvoidingView style={styles.rootContainer}>
 
                     <Formik
                         initialValues={{email: ""}}

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -258,7 +258,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                     }}>
                     {props => {
                         return (
-                            <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                            <KeyboardAvoidingView>
                                 <Form>
 
                                     <FieldWrapper>

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -253,7 +253,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
                 >
                     {props => {
                         return (
-                            <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                            <KeyboardAvoidingView>
                                 <Form>
 
                                     <DropdownField

--- a/src/features/patient/YourStudyScreen.tsx
+++ b/src/features/patient/YourStudyScreen.tsx
@@ -131,7 +131,7 @@ export default class YourStudyScreen extends Component<YourStudyProps, State> {
                 >
                     {props => {
                         return (
-                            <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                            <KeyboardAvoidingView>
                                 <Form>
 
 

--- a/src/features/patient/YourWorkScreen.tsx
+++ b/src/features/patient/YourWorkScreen.tsx
@@ -225,7 +225,7 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
                             (!!props.values.isCarer && props.values.isCarer === 'yes'
                         );
                         return (
-                            <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                            <KeyboardAvoidingView>
                                 <Form>
 
 

--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -115,7 +115,7 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
     render() {
         return (
             <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-                <KeyboardAvoidingView style={styles.rootContainer} behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                <KeyboardAvoidingView style={styles.rootContainer}>
 
                     <Formik
                         initialValues={{name: "", phone: ""}}

--- a/src/features/register/RegisterScreen.tsx
+++ b/src/features/register/RegisterScreen.tsx
@@ -117,7 +117,7 @@ export class RegisterScreen extends Component<PropsType, State> {
                 {props => {
                     return (
                 <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-                    <KeyboardAvoidingView style={styles.rootContainer} behavior={Platform.OS === "ios" ? "padding" : undefined}>
+                    <KeyboardAvoidingView style={styles.rootContainer}>
                         <View>
 
                             <View style={styles.loginHeader}>


### PR DESCRIPTION
This PR removes the behavior prop from KeyboardAvoidingView. 

While the [docs](https://reactnative.dev/docs/keyboardavoidingview#behavior) specify that this prop is recommended for both iOS and Android, at present we only pass it for iOS (where the issue occurs) and it's removal prevents the additional padding from appearing without any obvious side effects that affect usability of the screen. 