### PR TITLE
Rename legal screens

### DIFF
--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -13,7 +13,7 @@ import { SplashScreen } from "./features/SplashScreen";
 import YourHealthScreen from "./features/patient/YourHealthScreen";
 import HowYouFeelScreen from "./features/assessment/HowYouFeelScreen";
 import { PrivacyPolicyUKScreen } from "./features/register/gb/PrivacyPolicyUKScreen";
-import { TermsScreen } from "./features/register/TermsScreen";
+import { ConsentScreen } from "./features/register/ConsentScreen";
 import { OptionalInfoScreen } from "./features/register/OptionalInfoScreen";
 import CovidTestScreen from './features/assessment/CovidTestScreen';
 import DescribeSymptomsScreen from './features/assessment/DescribeSymptomsScreen';
@@ -101,7 +101,7 @@ export default class ZoeApp extends Component<{}, State> {
                 <Stack.Screen name="Welcome2US" component={Welcome2USScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="WelcomeRepeat" component={WelcomeRepeatScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="WelcomeRepeatUS" component={WelcomeRepeatUSScreen} options={{headerShown: false}}/>
-                <Stack.Screen name="Terms" component={TermsScreen} options={{headerShown: true, title: 'Consent'}}/>
+                <Stack.Screen name="Consent" component={ConsentScreen} options={{headerShown: true, title: 'Consent'}}/>
                 <Stack.Screen name="TermsOfUse" component={TermsOfUseScreen} options={{headerShown: true, title: 'Terms of Use'}}/>
                 <Stack.Screen name="PrivacyPolicyUK" component={PrivacyPolicyUKScreen} options={{headerShown: true, title: 'Privacy notice'}}/>
                 <Stack.Screen name="PrivacyPolicyUS" component={PrivacyPolicyUSScreen} options={{headerShown: true, title: 'Privacy policy'}}/>

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -26,7 +26,7 @@ import { WelcomeRepeatScreen } from "./features/register/gb/WelcomeRepeatScreen"
 import { Welcome1USScreen } from "./features/register/us/Welcome1USScreen";
 import { Welcome2USScreen } from "./features/register/us/Welcome2USScreen";
 import { WelcomeRepeatUSScreen } from "./features/register/us/WelcomeRepeatUSScreen";
-import TermsOfUseScreen from "./features/register/us/TermsOfUseScreen";
+import TermsOfUseUSScreen from "./features/register/us/TermsOfUseUSScreen";
 import { PrivacyPolicyUSScreen } from "./features/register/us/PrivacyPolicyUSScreen";
 import {CountrySelectScreen} from "./features/CountrySelectScreen";
 import YourWorkScreen from './features/patient/YourWorkScreen';
@@ -102,7 +102,7 @@ export default class ZoeApp extends Component<{}, State> {
                 <Stack.Screen name="WelcomeRepeat" component={WelcomeRepeatScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="WelcomeRepeatUS" component={WelcomeRepeatUSScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="Consent" component={ConsentScreen} options={{headerShown: true, title: 'Consent'}}/>
-                <Stack.Screen name="TermsOfUse" component={TermsOfUseScreen} options={{headerShown: true, title: 'Terms of Use'}}/>
+                <Stack.Screen name="TermsOfUseUS" component={TermsOfUseUSScreen} options={{headerShown: true, title: 'Terms of Use'}}/>
                 <Stack.Screen name="PrivacyPolicyUK" component={PrivacyPolicyUKScreen} options={{headerShown: true, title: 'Privacy notice'}}/>
                 <Stack.Screen name="PrivacyPolicyUS" component={PrivacyPolicyUSScreen} options={{headerShown: true, title: 'Privacy policy'}}/>
                 <Stack.Screen name="NursesConsentUS" component={NursesConsentUSScreen} options={{headerShown: true, title: 'Research Consent'}}/>

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -18,10 +18,10 @@ export type ScreenParamList = {
 
     // Terms & consent screens
     Consent: { viewOnly: boolean };
-    NursesConsentUS: { viewOnly: boolean };
-    BeforeWeStartUS: undefined;
-    TermsOfUse: { viewOnly: boolean };
     PrivacyPolicyUK: { viewOnly: boolean };
+    BeforeWeStartUS: undefined;
+    NursesConsentUS: { viewOnly: boolean };
+    TermsOfUseUS: { viewOnly: boolean };
     PrivacyPolicyUS: { viewOnly: boolean };
 
     // User profile screens

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -17,7 +17,7 @@ export type ScreenParamList = {
     WelcomeRepeatUS: { patientId: string };
 
     // Terms & consent screens
-    Terms: { viewOnly: boolean };
+    Consent: { viewOnly: boolean };
     NursesConsentUS: { viewOnly: boolean };
     BeforeWeStartUS: undefined;
     TermsOfUse: { viewOnly: boolean };

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -83,7 +83,7 @@ export class LoginScreen extends Component<PropsType, StateType> {
     // todo: validation for email
 
     render() {
-        const registerStartPage = isUSLocale() ? 'BeforeWeStartUS' : 'Terms';
+        const registerStartPage = isUSLocale() ? 'BeforeWeStartUS' : 'Consent';
 
         return (
             <TouchableWithoutFeedback onPress={Keyboard.dismiss}>

--- a/src/features/multi-profile/ConsentForOtherScreen.tsx
+++ b/src/features/multi-profile/ConsentForOtherScreen.tsx
@@ -50,13 +50,13 @@ export default class ConsentForOtherScreen extends Component<RenderProps, Consen
     secondaryText = this.isAdultConsent() ? (
         <RegularText>
             Please confirm that you have shown or read our{" "}
-            <ClickableText onPress={() => this.props.navigation.navigate("Terms", {viewOnly: true})}>consent</ClickableText>
+            <ClickableText onPress={() => this.props.navigation.navigate("Consent", {viewOnly: true})}>consent</ClickableText>
             {" "}screen to the individual on whose behalf you are entering the data, that they are 18 or over, and that they have given their consent for you to share their data with us.
         </RegularText>
     ) : (
         <RegularText>
             If your child is old enough to understand our{" "}
-            <ClickableText onPress={() => this.props.navigation.navigate("Terms", {viewOnly: true})}>consent</ClickableText>
+            <ClickableText onPress={() => this.props.navigation.navigate("Consent", {viewOnly: true})}>consent</ClickableText>
             {" "}requirements, please explain to them that you are sharing information about them with us and we are going to do with it. If you think that your child is old enough to make their own decisions, please confirm that they have consented to your sharing their data with us.
         </RegularText>
     );

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -123,7 +123,7 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
                                         <Body style={styles.label}>
                                             <RegularText>
                                                 I have read and accept Zoe Global’s {" "}
-                                                <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUse', {viewOnly: this.viewOnly})}>Terms of Use</ClickableText>{" "}
+                                                <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUseUS', {viewOnly: this.viewOnly})}>Terms of Use</ClickableText>{" "}
                                                 and{" "}
                                                 <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy Policy</ClickableText>.
                                             </RegularText>

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -11,8 +11,8 @@ import {RouteProp} from "@react-navigation/native";
 
 
 type PropsType = {
-    navigation: StackNavigationProp<ScreenParamList, 'Terms'>
-    route: RouteProp<ScreenParamList, 'Terms'>;
+    navigation: StackNavigationProp<ScreenParamList, 'Consent'>
+    route: RouteProp<ScreenParamList, 'Consent'>;
 }
 
 interface TermsState {
@@ -20,7 +20,7 @@ interface TermsState {
     termsOfUseChecked: boolean
 }
 
-export class TermsScreen extends Component<PropsType, TermsState> {
+export class ConsentScreen extends Component<PropsType, TermsState> {
     private userService = new UserService();
 
     constructor(props: PropsType) {

--- a/src/features/register/CountryIpModal.tsx
+++ b/src/features/register/CountryIpModal.tsx
@@ -95,7 +95,7 @@ export default class CountryIpModal extends Component<PropsType, StateType> {
             } else {
                 return [
                     {name: 'Welcome', params: {}},
-                    {name: 'Terms', params: {}},
+                    {name: 'Consent', params: {}},
                 ]
             }
         };

--- a/src/features/register/gb/WelcomeScreen.tsx
+++ b/src/features/register/gb/WelcomeScreen.tsx
@@ -81,7 +81,7 @@ export class WelcomeScreen extends Component<PropsType, WelcomeScreenState> {
                             if (await this.userService.shouldAskCountryConfirmation()) {
                                 this.setState({ipModalVisible: true})
                             } else {
-                                this.props.navigation.navigate('Terms', {viewOnly: false})
+                                this.props.navigation.navigate('Consent', {viewOnly: false})
                             }
                         }}>
                             {i18n.t("create-account-btn")}

--- a/src/features/register/us/BeforeWeStartUS.tsx
+++ b/src/features/register/us/BeforeWeStartUS.tsx
@@ -44,7 +44,7 @@ export default class BeforeWeStart extends Component<HowYouFeelProps, State> {
                     </FieldWrapper>
 
                     <FieldWrapper style={styles.fieldWrapper}>
-                        <BigButton onPress={() => this.props.navigation.navigate('Terms', {viewOnly: false})}>
+                        <BigButton onPress={() => this.props.navigation.navigate('Consent', {viewOnly: false})}>
                             <Text>No, I am not</Text>
                         </BigButton>
                     </FieldWrapper>

--- a/src/features/register/us/NursesConsentUS.tsx
+++ b/src/features/register/us/NursesConsentUS.tsx
@@ -250,7 +250,7 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
                                     <Body style={styles.label}>
                                         <RegularText>
                                             I have read and accept Zoe Global’s {" "}
-                                            <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUse', {viewOnly: this.viewOnly})}>Terms of
+                                            <ClickableText onPress={() => this.props.navigation.navigate('TermsOfUseUS', {viewOnly: this.viewOnly})}>Terms of
                                                 Use</ClickableText>{" "}
                                             and{" "}
                                             <ClickableText onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', {viewOnly: this.viewOnly})}>Privacy

--- a/src/features/register/us/TermsOfUseScreen.tsx
+++ b/src/features/register/us/TermsOfUseScreen.tsx
@@ -237,7 +237,7 @@ Except as expressly set forth in the sections above regarding the Apple Applicat
                         </RegularText>
                 </ScrollView>
 
-                <BrandedButton style={styles.button} onPress={() => this.props.navigation.replace('Terms', {viewOnly: this.viewOnly})}>Back</BrandedButton>
+                <BrandedButton style={styles.button} onPress={() => this.props.navigation.replace('Consent', {viewOnly: this.viewOnly})}>Back</BrandedButton>
 
             </View>
         )

--- a/src/features/register/us/TermsOfUseUSScreen.tsx
+++ b/src/features/register/us/TermsOfUseUSScreen.tsx
@@ -7,8 +7,8 @@ import {ScreenParamList} from "../../ScreenParamList";
 import {RouteProp} from "@react-navigation/native";
 
 type PropsType = {
-    navigation: StackNavigationProp<ScreenParamList, 'TermsOfUse'>
-    route: RouteProp<ScreenParamList, 'TermsOfUse'>;
+    navigation: StackNavigationProp<ScreenParamList, 'TermsOfUseUS'>
+    route: RouteProp<ScreenParamList, 'TermsOfUseUS'>;
 }
 
 const styles = StyleSheet.create({
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 });
 
 
-export default class TermsOfUseScreen extends Component<PropsType> {
+export default class TermsOfUseUSScreen extends Component<PropsType> {
     constructor(props: PropsType) {
         super(props);
     }


### PR DESCRIPTION
[1] This changes the name of the consent screen (currently used by US and UK) from confusing `TermsScreen` to `ConsentScreen` and also updates it's label in Screen Stack to be `Consent` instead of `Terms`

[2] This changes the name of the TermsOfUse screen (currently used by US only) from possibly confusing and generic `TermsOfUseScreen` to `TermsOfUseUSScreen` and also updates it's label in Screen Stack to be `TermsOfUseUS` instead of `TermsOfUse`