### PR TITLE
change replace to goBack on US Terms screen

### DIFF
--- a/src/features/register/us/TermsOfUseScreen.tsx
+++ b/src/features/register/us/TermsOfUseScreen.tsx
@@ -237,7 +237,7 @@ Except as expressly set forth in the sections above regarding the Apple Applicat
                         </RegularText>
                 </ScrollView>
 
-                <BrandedButton style={styles.button} onPress={() => this.props.navigation.replace('Terms', {viewOnly: this.viewOnly})}>Back</BrandedButton>
+                <BrandedButton style={styles.button} onPress={() => this.props.navigation.goBack()}>Back</BrandedButton>
 
             </View>
         )


### PR DESCRIPTION
Fixes a bug where Users on the ResearchConsent would open the Terms Of Use but then go back into the general consent ('Terms') page, rather than their appropriate page, without noticing.