### PR TITLE
Default smoker status to never -- the default option that exists.

### DIFF
--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -54,7 +54,7 @@ const initialFormValues = {
     hasHeartDisease: 'no',
     hasDiabetes: 'no',
     hasLungDisease: 'no',
-    smokerStatus: 'no',
+    smokerStatus: 'never',
     smokedYearsAgo: '',
     hasKidneyDisease: 'no',
 


### PR DESCRIPTION
initial value of `smokerStatus` is `no`, an option that doesn't exist in the dropdown, so no default value is displayed to the user. The backend, however is sent the value of `never` in this case. This PR fixes the discrepancy between what the user sees on the screen (blank), and what is sent to the server (`never`).