### PR TITLE
Add avatarName as optional parameter to CreateProfile screen.

### DIFF
--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -37,7 +37,7 @@ export type ScreenParamList = {
     // Profile screens
     ReportForOther: undefined;
     SelectProfile: undefined;
-    CreateProfile: undefined;
+    CreateProfile: { avatarName?: string };
     AdultOrChild: { profileName: string, avatarName?: string };
     ConsentForOther: { profileName: string, avatarName?: string, consentType: ConsentType};
 


### PR DESCRIPTION
Typescript is raising errors because the CreateProfile screen is getting `avatarName` from `this.props`, and it isn't defined as a param on ScreenListParams. This fixes that.