### PR TITLE
add StartPatient to direct all Patient flows to.

### DIFF
--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -47,6 +47,7 @@ import CreateProfileScreen from "./features/multi-profile/CreateProfileScreen";
 import ConsentForOther from "./features/multi-profile/ConsentForOtherScreen";
 import AdultOrChildScreen from "./features/multi-profile/AdultOrChildScreen";
 import StartAssessmentScreen from './features/assessment/StartAssessment';
+import StartPatientScreen from './features/patient/StartPatient';
 
 const Stack = createStackNavigator<ScreenParamList>();
 const Drawer = createDrawerNavigator();
@@ -111,11 +112,13 @@ export default class ZoeApp extends Component<{}, State> {
                 <Stack.Screen name="ResetPasswordConfirm" component={ResetPasswordConfirmScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="Register" component={RegisterScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="OptionalInfo" component={OptionalInfoScreen} options={{headerShown: false}}/>
+                <Stack.Screen name="StartPatient" component={StartPatientScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="YourStudy" component={YourStudyScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="YourWork" component={YourWorkScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="YourHealth" component={YourHealthScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="AboutYou" component={AboutYouScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="StartAssessment" component={StartAssessmentScreen} options={{headerShown: false}}/>
+                <Stack.Screen name="HealthWorkerExposure" component={HealthWorkerExposureScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="CovidTest" component={CovidTestScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="HowYouFeel" component={HowYouFeelScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="DescribeSymptoms" component={DescribeSymptomsScreen} options={{headerShown: false}}/>
@@ -126,7 +129,6 @@ export default class ZoeApp extends Component<{}, State> {
                 <Stack.Screen name="ThankYou" component={ThankYouScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="ViralThankYou" component={ViralThankYouScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="Login" component={LoginScreen} options={{headerShown: false}}/>
-                <Stack.Screen name="HealthWorkerExposure" component={HealthWorkerExposureScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="NearYou" component={NearYouScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="CreateProfile" component={CreateProfileScreen} options={{headerShown: false}}/>
                 <Stack.Screen name="ConsentForOther" component={ConsentForOther} options={{headerShown: false}}/>

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -42,6 +42,7 @@ export type ScreenParamList = {
     ConsentForOther: { profileName: string, avatarName?: string, consentType: ConsentType};
 
     // Patient screens
+    StartPatient: { currentPatient: PatientStateType };
     YourStudy: { currentPatient: PatientStateType };
     YourWork: { currentPatient: PatientStateType };
     AboutYou: { currentPatient: PatientStateType };

--- a/src/features/assessment/StartAssessment.tsx
+++ b/src/features/assessment/StartAssessment.tsx
@@ -1,28 +1,12 @@
 import React, {Component} from "react";
-import {Platform, StyleSheet} from "react-native";
-import Screen, {Header, ProgressBlock, screenWidth} from "../../components/Screen";
-import {BrandedButton, ErrorText, HeaderText} from "../../components/Text";
-import {Form, Text} from "native-base";
-
-import ProgressStatus from "../../components/ProgressStatus";
-
-import {Formik} from "formik";
-import * as Yup from "yup";
-
-import {colors, fontStyles} from "../../../theme"
-import i18n from "../../locale/i18n"
 import {StackNavigationProp} from "@react-navigation/stack";
 import {ScreenParamList} from "../ScreenParamList";
 import {RouteProp} from "@react-navigation/native";
-import UserService from "../../core/user/UserService";
-import {AssessmentInfosRequest} from "../../core/user/dto/UserAPIContracts";
-import DropdownField from "../../components/DropdownField";
-import { ValidationErrors } from "../../components/ValidationError";
 
 
 type StartAssessmentProps = {
-    navigation: StackNavigationProp<ScreenParamList, 'CovidTest'>
-    route: RouteProp<ScreenParamList, 'CovidTest'>;
+    navigation: StackNavigationProp<ScreenParamList, 'StartAssessment'>
+    route: RouteProp<ScreenParamList, 'StartAssessment'>;
 }
 
 
@@ -37,8 +21,7 @@ export default class StartAssessmentScreen extends Component<StartAssessmentProp
                 this.props.navigation.replace('CovidTest', {currentPatient, assessmentId})
             }
         } else {
-            // TODO: refactor as "StartPatient" screen/controller
-            this.props.navigation.replace('YourWork', {currentPatient});
+            this.props.navigation.replace('StartPatient', {currentPatient});
         }
     }
 

--- a/src/features/patient/StartPatient.tsx
+++ b/src/features/patient/StartPatient.tsx
@@ -1,0 +1,22 @@
+import React, {Component} from "react";
+import {StackNavigationProp} from "@react-navigation/stack";
+import {ScreenParamList} from "../ScreenParamList";
+import {RouteProp} from "@react-navigation/native";
+
+
+type StartPatientProps = {
+    navigation: StackNavigationProp<ScreenParamList, 'StartPatient'>
+    route: RouteProp<ScreenParamList, 'StartPatient'>;
+}
+
+
+export default class StartPatientScreen extends Component<StartPatientProps> {
+    async componentDidMount() {
+        const currentPatient = this.props.route.params.currentPatient;
+        this.props.navigation.replace('YourWork', {currentPatient});
+    }
+
+    render() {
+        return null;
+    }
+}

--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -53,6 +53,8 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
         const currentPatient = await userService.getCurrentPatient(patientId);
         const consent = await userService.getConsentSigned();
 
+        // TODO: refactor this to PatientScreen. After we understand why other routes
+        // don't have this branching logic.
         const nextScreen = ((isUSLocale() && consent && consent.document === "US Nurses") || isGBLocale())
             ? {name: "YourStudy", params: {currentPatient}}
             : {name: "YourWork", params: {currentPatient}};


### PR DESCRIPTION
Create a StartPatient pseudo-screen to host the logic of which Patient screen to show first, and space to clean up the navigation stack possibly.

Left a todo note on OptionalInfoScreen since there's US-specific logic as to what the first screen is here that isn't replicated elsewhere, so uncertain whether this logic should be consistent across all routes into the Patient screens.