### PR TITLE
Truncate navigation stack of future screens in profile creation/selection

### DIFF
--- a/src/features/multi-profile/ConsentForOtherScreen.tsx
+++ b/src/features/multi-profile/ConsentForOtherScreen.tsx
@@ -8,7 +8,7 @@ import {colors} from "../../../theme"
 import UserService from "../../core/user/UserService";
 import {StackNavigationProp} from "@react-navigation/stack";
 import {ConsentType, ScreenParamList} from "../ScreenParamList";
-import {RouteProp} from "@react-navigation/native";
+import {CommonActions, RouteProp} from "@react-navigation/native";
 import {PatientInfosRequest} from "../../core/user/dto/UserAPIContracts";
 
 
@@ -65,44 +65,24 @@ export default class ConsentForOtherScreen extends Component<RenderProps, Consen
         "I confirm that I am the child's legal guardian and that I have done the above"
     );
 
-    cleanNavigationStack(navigation: StackNavigationProp<ScreenParamList>) {
-        const navState = navigation.dangerouslyGetState();
-
-        // Second pass - take a slice up to the SelectProfile page.
-        let foundRoute = false;
-        const newStack = navState.routes.filter(route => {
-            if (foundRoute) {
-                return false;
-            }
-            if (route.name === "SelectProfile") {
-                foundRoute = true;
-            }
-            return true;
-        })
-        return {
-            index: navState.index,
-            routes: newStack
-        };
-    }
-
-    pushToCleanNavStack(navigation: any, nextRoute: any) {
-        const navStack = this.cleanNavigationStack(navigation);
-        return {
-            index: navStack.index + 1,
-            routes: [
-                ...navStack.routes,
-                nextRoute
-            ]
-        }
-    }
-
     async startAssessment(patientId: string) {
         const userService = new UserService();
         const currentPatient = await userService.getCurrentPatient(patientId);
 
-        const nextRoute = {name: 'StartAssessment', params: {currentPatient}};
-        const newStack = this.pushToCleanNavStack(this.props.navigation, nextRoute);
-        this.props.navigation.reset(newStack);
+        this.props.navigation.dispatch(state => {
+            const newStack = state.routes;
+            while (newStack[newStack.length-1].name != 'SelectProfile') {
+                newStack.pop()
+            }
+
+            return CommonActions.reset({
+                index: 1,
+                routes: [
+                    ...newStack,
+                    {name: 'StartAssessment', params: {currentPatient}}
+                ]
+            });
+        });
     }
 
     createProfile() {

--- a/src/features/multi-profile/ConsentForOtherScreen.tsx
+++ b/src/features/multi-profile/ConsentForOtherScreen.tsx
@@ -65,13 +65,44 @@ export default class ConsentForOtherScreen extends Component<RenderProps, Consen
         "I confirm that I am the child's legal guardian and that I have done the above"
     );
 
+    cleanNavigationStack(navigation: StackNavigationProp<ScreenParamList>) {
+        const navState = navigation.dangerouslyGetState();
+
+        // Second pass - take a slice up to the SelectProfile page.
+        let foundRoute = false;
+        const newStack = navState.routes.filter(route => {
+            if (foundRoute) {
+                return false;
+            }
+            if (route.name === "SelectProfile") {
+                foundRoute = true;
+            }
+            return true;
+        })
+        return {
+            index: navState.index,
+            routes: newStack
+        };
+    }
+
+    pushToCleanNavStack(navigation: any, nextRoute: any) {
+        const navStack = this.cleanNavigationStack(navigation);
+        return {
+            index: navStack.index + 1,
+            routes: [
+                ...navStack.routes,
+                nextRoute
+            ]
+        }
+    }
+
     async startAssessment(patientId: string) {
         const userService = new UserService();
         const currentPatient = await userService.getCurrentPatient(patientId);
-        this.props.navigation.reset({
-            index: 0,
-            routes: [{name: 'StartAssessment', params: {currentPatient: currentPatient}}]
-        });
+
+        const nextRoute = {name: 'StartAssessment', params: {currentPatient}};
+        const newStack = this.pushToCleanNavStack(this.props.navigation, nextRoute);
+        this.props.navigation.reset(newStack);
     }
 
     createProfile() {

--- a/src/features/multi-profile/ReportForOtherScreen.tsx
+++ b/src/features/multi-profile/ReportForOtherScreen.tsx
@@ -9,7 +9,8 @@ import {StackNavigationProp} from "@react-navigation/stack";
 import {profilesIcon} from "../../../assets";
 import {Text} from "native-base";
 import {getLocalThankYou} from "../Navigation";
-import UserService from "../../core/user/UserService";
+import UserService, {isUSLocale} from "../../core/user/UserService";
+import { CommonActions } from '@react-navigation/native';
 
 type RenderProps = {
     navigation: StackNavigationProp<ScreenParamList, 'ReportForOther'>
@@ -43,7 +44,18 @@ export default class ReportForOtherScreen extends Component<RenderProps, {}> {
                                     <RegularText style={styles.innerContainer}>You can now report on behalf of someone else.</RegularText>
                                 </View>
 
-                                <BrandedButton onPress={() => this.props.navigation.navigate('CreateProfile', {avatarName: 'profile2'})}>
+                                <BrandedButton onPress={() => {
+                                    this.props.navigation.dispatch(state => {
+                                        return CommonActions.reset({
+                                            index: 2,
+                                            routes: [
+                                                state.routes[0],
+                                                {name: 'SelectProfile', params: {avatarName: 'profile2'}},
+                                                {name: 'CreateProfile', params: {avatarName: 'profile2'}}
+                                            ]
+                                        });
+                                    });
+                                }}>
                                     <Text style={[fontStyles.bodyLight, styles.buttonText]}>Add profiles</Text>
                                 </BrandedButton>
                             </View>

--- a/src/features/multi-profile/ReportForOtherScreen.tsx
+++ b/src/features/multi-profile/ReportForOtherScreen.tsx
@@ -50,8 +50,8 @@ export default class ReportForOtherScreen extends Component<RenderProps, {}> {
                                             index: 2,
                                             routes: [
                                                 state.routes[0],
-                                                {name: 'SelectProfile', params: {avatarName: 'profile2'}},
-                                                {name: 'CreateProfile', params: {avatarName: 'profile2'}}
+                                                {name: 'SelectProfile', params: {}},
+                                                {name: 'CreateProfile', params: {avatarName: 'New Profile'}}
                                             ]
                                         });
                                     });

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -56,36 +56,10 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
             });
     }
 
-    cleanNavigationStack(navigation: StackNavigationProp<ScreenParamList>) {
-        const navState = navigation.dangerouslyGetState();
-
-        // First pass - take a slice up to the current page.
-        const newStack = navState.routes.slice(0, navState.index + 1);
-        return {
-            index: navState.index,
-            routes: newStack
-        };
-    }
-
-    pushToCleanNavStack(navigation: any, nextRoute: any) {
-        const navStack = this.cleanNavigationStack(navigation);
-        return {
-            index: navStack.index + 1,
-            routes: [
-                ...navStack.routes,
-                nextRoute
-            ]
-        }
-    }
-
     async startAssessment(patientId: string) {
         const userService = new UserService();
         const currentPatient = await userService.getCurrentPatient(patientId);
-
-        // Clean up existing route stack, and plonk StartAssessment on as next route
-        const nextRoute = {name: 'StartAssessment', params: {currentPatient}};
-        const newStack = this.pushToCleanNavStack(this.props.navigation, nextRoute);
-        this.props.navigation.reset(newStack);
+        this.props.navigation.navigate('StartAssessment', {currentPatient});
     }
 
     getNextAvatarName() {


### PR DESCRIPTION
Attempts to fix the issues of users navigating backwards through profile creation pages, and solving the issue of revisiting patient screens to see them already populated by previous flows through the pages. This latter is a navigation issue in that if a page already exists on the navigation stack, then navigating to that screen redisplays that screen, rather than showing a new one. So the approach originally taken is correct, but it's important to preserve the stack before the Select profile page, which this PR attempts to do.

I've hit the limit of my TypeScript + generics knowledge, and patience, so I'll need help to refactor the `pushToCleanNavStack` and `cleanNavigationStack` methods into plain utility functions. So I've duplicated the code in SelectProfileScreen and ConsentForOtherScreen, and there's a few `: any` floating around.