### PR TITLE
Show in dev channel

### DIFF
--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -75,7 +75,11 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
             <TouchableOpacity style={styles.iconNameRow} onPress={() => logout()}>
                 <HeaderText>{i18n.t('logout')}</HeaderText>
             </TouchableOpacity>
-            <CaptionText style={[styles.versionText]}>{Constants.manifest.version} : {Constants.manifest.revisionId}</CaptionText>
+            <CaptionText style={[styles.versionText]}>
+                {Constants.manifest.version}
+                {Constants.manifest.revisionId && ` : ${Constants.manifest.revisionId}`}
+                {Constants.manifest.releaseChannel && ` (${Constants.manifest.releaseChannel})`}
+            </CaptionText>
         </View>
     </SafeAreaView>
 }

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -78,7 +78,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
             <CaptionText style={[styles.versionText]}>
                 {Constants.manifest.version}
                 {Constants.manifest.revisionId && ` : ${Constants.manifest.revisionId}`}
-                {Constants.manifest.releaseChannel && ` (${Constants.manifest.releaseChannel})`}
+                {(Constants.manifest.releaseChannel === 'dev') && ` (DEV)`}
             </CaptionText>
         </View>
     </SafeAreaView>


### PR DESCRIPTION
In the drawer menu when there's a release-channel available (in published and app-builds), display `DEV` if the app is pointing to the `dev` release channel.

This is to allow QA testers to know they are using the correct testflight version of the app which points correctly to the dev release channel for testing.

UPDATE: Decided to only display (DEV) if the release channel is dev. That way it's not leaking any release-channel info (security through obscurity). That alleviates my discomfort security-wise.