### PR TITLE
Fix first added profile avatar image

### DIFF
--- a/src/features/multi-profile/ReportForOtherScreen.tsx
+++ b/src/features/multi-profile/ReportForOtherScreen.tsx
@@ -51,7 +51,7 @@ export default class ReportForOtherScreen extends Component<RenderProps, {}> {
                                             routes: [
                                                 state.routes[0],
                                                 {name: 'SelectProfile', params: {}},
-                                                {name: 'CreateProfile', params: {avatarName: 'New Profile'}}
+                                                {name: 'CreateProfile', params: {avatarName: 'profile2'}}
                                             ]
                                         });
                                     });

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,7 +1,8 @@
 import * as AvatarImages from "../../assets";
 
 export type AvatarName = 'profile1' | 'profile2' | 'profile3' | 'profile4' | 'profile5' | 'profile6' | 'profile7' | 'profile8' | 'profile9' | 'profile10';
+const DEFAULT_PROFILE = 'profile10';
 
 export const getAvatarByName = (name: AvatarName) => {
-    return AvatarImages[name];
+    return AvatarImages[name] || AvatarImages[DEFAULT_PROFILE];
 }


### PR DESCRIPTION
Fix the navigate link to creating first profile to set the avatar image to "profile2". The create profile screen expects this value to be set by the previous page.

Then, when a patient arrives with an invalid avatar image, the header just displays the name of the currently selected patient, and not the avatar image. In those cases, I default to returning "profile10" as the avatar image.