### PR TITLE
SelectProfile page: refresh profiles on returning via a back navigation

### DIFF
--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -31,7 +31,8 @@ type Patient = {
 
 interface State {
     patients: Patient[],
-    errorMessage: string
+    errorMessage: string,
+    shouldRefresh: boolean,
 }
 
 export default class SelectProfileScreen extends Component<RenderProps, State> {
@@ -39,12 +40,19 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
         super(props);
         this.state = {
             patients: [],
-            errorMessage: ""
+            errorMessage: "",
+            shouldRefresh: false
         };
     }
 
     async componentDidMount() {
+        this.props.navigation.addListener('focus', e => {
+            if (this.state.shouldRefresh) {
+                this.listProfiles();
+            };
+        });
         this.listProfiles();
+        this.setState({shouldRefresh: true});
     }
 
     listProfiles() {


### PR DESCRIPTION
When creating a new Profile and starting an assessment, navigating back to the Select Profile screen, it doesn't update to show this newly created profile.

Navigation fires events, one is a focus event when a screen receives focus. I listen for that event, and trigger a listProfiles call when it fires.

However, the focus event also fires when the screen is first entered. Which means componentDidMount also runs, populating the listProfiles. To avoid this duplicate call, I use a flag in the state, to ensure I don't  call the backend twice quickly.

But, removing the call from componentDidMount instead would have the effect in development of making a change, the screen refreshes, and the profiles disappear: because a reload won't trigger the 'focus' event, because it's not a navigation event. So the call in componentDidMount is necessary to capture this flow.
