### PR TITLE
Fix nav on I'm at home option of WhereAreYouScreen. 

### DIFF
--- a/src/features/assessment/WhereAreYouScreen.tsx
+++ b/src/features/assessment/WhereAreYouScreen.tsx
@@ -31,7 +31,7 @@ export default class WhereAreYouScreen extends Component<LocationProps> {
 
     handleAtHome() {
         this.updateAssessment('home')
-            .then(response => this.props.navigation.navigate(getLocalThankYou()))
+            .then(response => navigateAfterFinishingAssessment(this.props.navigation))
             .catch(err => this.setState({errorMessage: "Something went wrong, please try again later"}));
     }
 


### PR DESCRIPTION
This PR is to use new navigateAfterFinishingAssessment on WhereAreYouScreen for the "home" option - it was previously directing straight to the Thank You pages rather than showing the screen to suggest adding new profiles.