### PR TITLE
Fix double GET on first-time Select Profile page.

### DIFF
--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -47,22 +47,24 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
     }
 
     async componentDidMount() {
-        this.props.navigation.addListener('focus', e => {
+        this.props.navigation.addListener('focus', async (e) => {
             if (this.state.shouldRefresh) {
-                this.listProfiles();
+                await this.listProfiles();
             };
         });
-        this.listProfiles();
+
+        await this.listProfiles();
         this.setState({shouldRefresh: true});
     }
 
-    listProfiles() {
+    async listProfiles() {
         const userService = new UserService();
-        userService.listPatients()
-            .then(response => this.setState({patients: response.data}))
-            .catch(err => {
-                this.setState({errorMessage: i18n.t("something-went-wrong")})
-            });
+        try {
+            const response = await userService.listPatients();
+            this.setState({patients: response.data});
+        } catch (err) {
+            this.setState({errorMessage: i18n.t("something-went-wrong")});
+        }
     }
 
     async startAssessment(patientId: string) {


### PR DESCRIPTION
On first-entry to the Select Profile page, if the backend isn't zippy in its response, we end up doing two HTTP calls to the backend patient_list API endpoint. It's because I'm setting the `shouldRefresh` flag to true before the HTTP request promise has resolved.

So the fix is to await the first HTTP request to return before setting the flag, which enables the focus listener to do its work of updating the profiles when a user returns to the Select profile page.