### PR TITLE
validate max length of postcode.

### DIFF
--- a/assets/lang/en-US.json
+++ b/assets/lang/en-US.json
@@ -2,6 +2,7 @@
   "your-postcode": "Your zipcode?",
   "placeholder-postcode": "zipcode",
   "required-postcode": "Please enter your zipcode",
+  "postcode-too-long": "Please correct your zipcode",
 
   "where-are-you-picker-location-home": "I'm at home. I haven't been to a clinic or hospital for suspected COVID-19 symptoms.",
   "where-are-you-picker-location-hospital": "I am at the clinic or hospital with suspected COVID-19 symptoms.",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -91,6 +91,7 @@
   "your-postcode": "Your postcode?",
   "placeholder-postcode": "Postcode",
   "required-postcode": "Please enter your postcode (first part is sufficient)",
+  "postcode-too-long": "Please correct your postcode (first part is sufficient)",
 
   "are-you-a-member-of-twins": "Are you a member of the UK Twins Study?",
   "placeholder-twins": "isTwinsStudy",
@@ -265,5 +266,5 @@
   "select-profile-button": "New profile",
 
   "validation-error-text": "Please fill in or correct the above information: %{info}",
-  "validation-error-text-no-info": "Please fill in or correct the above information",
+  "validation-error-text-no-info": "Please fill in or correct the above information"
 }

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -206,7 +206,9 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
             then: Yup.number().required("Please enter your weight in pounds")
         }),
 
-        postcode: Yup.string().required(i18n.t("required-postcode")),
+        postcode: Yup.string()
+            .required(i18n.t("required-postcode"))
+            .max(8, i18n.t("postcode-too-long")),
 
         everExposed: Yup.string().required("Please indicate if you've been exposed to someone with COVID-19 infection"),
         houseboundProblems: Yup.string().required(),


### PR DESCRIPTION
Entering a postcode of > 8 characters results in a server 500 error, and no visible error on the page as to the issue.

The server returns a 500 error, and a null response. Because this is the response that's also returned when the server has an issue, it's impossible to tell the two states apart. But we know that the postcode is stored as an 8 character string, and it raises an exception when we attempt to put a longer string in it.

So in the meantime, this fix adds a max length validation rule to the postcode field to at least help the user towards entering a postcode the server can handle.

This is just a first step towards improving the User experience on this page. At least there's a fighting chance the user will correct the postcode field, knowing that that's the field with a validation error in it.
