### PR TITLE
Wrap getStartupInfo in a try/catch

### DIFF
--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -30,12 +30,16 @@ export class SplashScreen extends Component<Props, {}> {
 
     private bootstrapAsync = async () => {
         const {navigation} = this.props;
+        let country: string|null = null;
 
-        await this.userService.getStartupInfo();
+        try {
+            await this.userService.getStartupInfo();
+            country = await this.userService.getUserCountry();
+        } catch (err) {
+            // TODO: how to deal with the user_startup info endpoint failing?
+        }
 
-        const countryPromise = this.userService.getUserCountry();
         let {userToken, userId} = await AsyncStorageService.GetStoredData();
-        const country = await countryPromise;
 
         if (userToken && userId) {
             ApiClientBase.setToken(userToken, userId);


### PR DESCRIPTION
Noticed that the call to backend API getStartupInfo isn't wrapped in a try catch, so when it fails, users are left with a dark blue screen. Which a few 1-star reviewers have mentioned happening since Saturday.

I've wrapped it in a try catch block, and default to GB when it fails, so users at least get to the welcome screen.

I guess this is where we need to check for online status.

The only reason I stumbled on this was adding some API endpoints to the mock-server, and this endpoint was the first one I hit that was missing...