### PR TITLE
SWEDEN: Hide Cohorts and Race/Ethnicity

### DIFF
--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -7,6 +7,7 @@ export type ConfigType = {
     country: string,
     enableMultiplePatients: boolean,        // Enables select/create profile feature
     enablePersonalInformation: boolean,     // Enables Personal Information screen
+    enableCohorts: boolean,                 // Enables cohort/YourStudy screen
 }
 
 const configs = new Map<string, ConfigType>([

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -8,6 +8,9 @@ export type ConfigType = {
     enableMultiplePatients: boolean,        // Enables select/create profile feature
     enablePersonalInformation: boolean,     // Enables Personal Information screen
     enableCohorts: boolean,                 // Enables cohort/YourStudy screen
+
+    showEthnicityQuestion: boolean,         // Shows ethnicity question
+    showRaceQuestion: boolean,              // Shows race question
 }
 
 const configs = new Map<string, ConfigType>([

--- a/src/core/config/SE.json
+++ b/src/core/config/SE.json
@@ -2,5 +2,8 @@
     "country": "SE",
     "enableMultiplePatients": false,
     "enablePersonalInformation": false,
-    "enableCohorts": true
+    "enableCohorts": true,
+
+    "showEthnicityQuestion": false,
+    "showRaceQuestion": false
 }

--- a/src/core/config/SE.json
+++ b/src/core/config/SE.json
@@ -1,5 +1,6 @@
 {
     "country": "SE",
     "enableMultiplePatients": false,
-    "enablePersonalInformation": false
+    "enablePersonalInformation": false,
+    "enableCohorts": true
 }

--- a/src/core/config/US.json
+++ b/src/core/config/US.json
@@ -1,3 +1,6 @@
 {
-    "country": "US"
+    "country": "US",
+
+    "showEthnicityQuestion": true,
+    "showRaceQuestion": false
 }

--- a/src/core/config/default.json
+++ b/src/core/config/default.json
@@ -1,5 +1,6 @@
 {
     "country": "ZZ",
     "enableMultiplePatients": true,
-    "enablePersonalInformation": true
+    "enablePersonalInformation": true,
+    "enableCohorts": true
 }

--- a/src/core/config/default.json
+++ b/src/core/config/default.json
@@ -2,5 +2,8 @@
     "country": "ZZ",
     "enableMultiplePatients": true,
     "enablePersonalInformation": true,
-    "enableCohorts": true
+    "enableCohorts": true,
+
+    "showEthnicityQuestion": false,
+    "showRaceQuestion": true
 }

--- a/src/features/Navigation.ts
+++ b/src/features/Navigation.ts
@@ -72,17 +72,8 @@ class Navigator {
     }
 
     async gotoStartPatient(currentPatient: PatientStateType) {
-        const patientId = currentPatient.patientId;
         const nextPage = await this.getStartPatientScreenName(currentPatient);
-
-        // OptionalInfo nav-stack cleanup.
-        this.navigation.reset({
-            index: 0,
-            routes: [
-                {name: this.getWelcomeRepeatScreenName(), params: {patientId}},
-                {name: nextPage, params: {currentPatient}}
-            ],
-        })
+        this.gotoScreen(nextPage, {currentPatient});
     }
 
     async gotoEndAssessment() {

--- a/src/features/assessment/StartAssessment.tsx
+++ b/src/features/assessment/StartAssessment.tsx
@@ -2,6 +2,7 @@ import React, {Component} from "react";
 import {StackNavigationProp} from "@react-navigation/stack";
 import {ScreenParamList} from "../ScreenParamList";
 import {RouteProp} from "@react-navigation/native";
+import Navigator from "../Navigation";
 
 
 type StartAssessmentProps = {
@@ -12,6 +13,7 @@ type StartAssessmentProps = {
 
 export default class StartAssessmentScreen extends Component<StartAssessmentProps> {
     async componentDidMount() {
+        Navigator.setNavigation(this.props.navigation);
         const currentPatient = this.props.route.params.currentPatient;
         const assessmentId = this.props.route.params.assessmentId || null;
 
@@ -27,7 +29,8 @@ export default class StartAssessmentScreen extends Component<StartAssessmentProp
                 }
             }
         } else {
-            this.props.navigation.replace('StartPatient', {currentPatient});
+            const nextPage = await Navigator.getStartPatientScreenName(currentPatient);
+            Navigator.replaceScreen(nextPage, {currentPatient});
         }
     }
 

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -22,9 +22,6 @@ import {CheckboxItem, CheckboxList} from "../../components/Checkbox";
 import {cloneDeep} from 'lodash';
 
 
-
-const PICKER_WIDTH = (Platform.OS === 'ios') ? undefined : '100%';
-
 const initialFormValues = {
     yearOfBirth: "",
     sex: "",
@@ -90,19 +87,33 @@ type AboutYouProps = {
 type State = {
     errorMessage: string;
     enableSubmit: boolean;
+
+    showRaceQuestion: boolean;
+    showEthnicityQuestion: boolean;
 }
 
 const initialState: State = {
     errorMessage: "",
     enableSubmit: true,
+
+    showRaceQuestion: false,
+    showEthnicityQuestion: false,
 };
 
 
 export default class AboutYouScreen extends Component<AboutYouProps, State> {
-
     constructor(props: AboutYouProps) {
         super(props);
         this.state = initialState;
+    }
+
+    async componentDidMount() {
+        const userService = new UserService();
+        const features = await userService.getConfig();
+        this.setState({
+            showRaceQuestion: features.showRaceQuestion,
+            showEthnicityQuestion: features.showEthnicityQuestion,
+        });
     }
 
     handleUpdateHealth(formData: AboutYouData) {
@@ -362,7 +373,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                                         />
                                     )}
 
-                                    {isGBLocale() && (
+                                    {this.state.showRaceQuestion && (
                                         <FieldWrapper>
                                             <Item stackedLabel style={styles.textItemStyle}>
                                                 <Label>{i18n.t("race-question")}</Label>
@@ -373,7 +384,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                                         </FieldWrapper>
                                     )}
 
-                                    {isUSLocale() && (
+                                    {this.state.showEthnicityQuestion && (
                                         <FieldWrapper>
                                             <Item stackedLabel style={styles.textItemStyle}>
                                                 <Label>{i18n.t("race-question")}</Label>


### PR DESCRIPTION
Both using a country-specific feature flag.

* Skip over the cohort screen (Population Studies, Your Clinical Study) in the StartPatient screenflow if the `enableCohorts` flag is false
* Add `showEthnicityQuestion` and `showRaceQuestion` feature flags, and disable both for Sweden.

I'm not happy with the async dependency on get country to get the  config file. It just means having to use component state to populate the values when they are retrieved. Otherwise we hit a race-condition, because render doesn't wait for componentDidMount'ed promise.

Also, props.navigation might be stateful, even though it just looks like a group of methods. So maybe passing it in on the SplashScreen is insufficient, and we need to pass it in on each component. running `Navigator.replaceScreen` had issues without passing in the more recent props.navigation.