### PR TITLE
fix(Password managers): Attempt to fix password managers on iOS

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,9 +24,10 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true,
+      "associatedDomains": ["webcredentials:covid-zoe.joinzoe.com"],
+      "buildNumber": "0.0.27",
       "bundleIdentifier": "com.joinzoe.covid-zoe",
-      "buildNumber": "0.0.27"
+      "supportsTablet": true
     },
     "android": {
       "package": "com.joinzoe.covid_zoe",


### PR DESCRIPTION
# Description

Attempt to fix password managers not saving credentials on iOS. Struggling to get this working in a non-production environment. This could fix https://github.com/zoe/covid-tracker-react-native/issues/34

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [X] iOS - Physical device

## Screenshots

N/A

## Out of scope and potential follow-up

This may need further testing and a follow up PR. Documentation followed: 
https://docs.expo.io/workflow/configuration/?redirected#ios
https://gist.github.com/amcvitty/42cbe072184fe72485ad17cd7120bb89#add-the-associated-domains-entitlement

```js
/*
      An array that contains Associated Domains for the standalone app. See apple's docs for config: https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/enabling_universal_links

      Entries must follow the format "applinks:<fully qualified domain>[:port number]". See Apple's docs for details -> https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains

      ExpoKit: use Xcode to set this.
    */
    "associatedDomains": ARRAY,
```
### This may also need to be done:

https://gist.github.com/amcvitty/42cbe072184fe72485ad17cd7120bb89#add-the-apple-app-site-association-file-to-your-website
