### PR TITLE
prepend "Last report" to date on select profile card

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -413,6 +413,7 @@
   "select-profile-title": "Select profile you want to report for",
   "select-profile-text": "Or add more profiles",
   "select-profile-button": "New profile",
+  "select-profile-last-report": "Last report:",
 
   "validation-error-text": "Please fill in or correct the above information: %{info}",
   "validation-error-text-no-info": "Please fill in or correct the above information",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -390,7 +390,7 @@
   "select-profile-title": "Välj den profil du vill rapportera åt",
   "select-profile-text": "Eller lägg till fler profiler",
   "select-profile-button": "Ny profil",
-
+  "select-profile-last-report": "Sista rapport:",
 
   "next-question": "Nästa fråga",
   "completed": "Klar",

--- a/src/components/DaysAgo.tsx
+++ b/src/components/DaysAgo.tsx
@@ -21,10 +21,11 @@ export default class DaysAgo extends Component<ProgressProps> {
             } else {
                 text = i18n.t("days-ago", {diffDays: diffDays});
             }
+            text = i18n.t("select-profile-last-report") + " " + text
         }
 
         return (
-            <SecondaryText style={{textAlign: "center"}}>{text}</SecondaryText>
+            <SecondaryText style={{textAlign: "center", fontSize: 12}}>{text}</SecondaryText>
         );
     }
 }

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -173,7 +173,8 @@ const styles = StyleSheet.create({
         width: "100%",
         borderRadius: 16,
         minHeight: 200,
-        padding: 20,
+        paddingVertical: 20,
+        paddingHorizontal: 12,
         alignItems: "center"
     },
 


### PR DESCRIPTION
# Description

This prepends "Last report: " to the date that is displayed on the cards on the select profile screen. This is due to user's reporting confusion as to what this date meant. 

## On what platform have you tested the change?
- [ ] iOS - Emulator

## Screenshots

<img src="https://user-images.githubusercontent.com/52913482/80225820-845f7280-8643-11ea-9220-5a9b22273eb2.png" width=150> <img src="https://user-images.githubusercontent.com/52913482/80225827-86293600-8643-11ea-97a4-10ac492923e1.png" width=150>

## Out of scope and potential follow-up

Not planned
