### PR TITLE
refix Welcome Repeat Screen

### DIFF
--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -126,7 +126,7 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
             </TouchableOpacity>
           </View>
         </ScrollView>
-        <View>
+        <View style={styles.reportContainer}>
           <BrandedButton style={styles.reportButton} onPress={this.handleButtonPress}>
             {i18n.t('welcome.report-button')}
           </BrandedButton>
@@ -222,8 +222,10 @@ const styles = StyleSheet.create({
     width: 20,
     tintColor: colors.white,
   },
+  reportContainer: {
+    padding: 20,
+  },
   reportButton: {
-    marginVertical: 10,
     textAlign: 'center',
     backgroundColor: colors.purple,
     alignSelf: 'center',

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -92,38 +92,41 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
   render() {
     return (
       <SafeAreaView style={styles.safeView}>
-        <View style={styles.rootContainer}>
-          <View style={styles.headerRow}>
-            <TouchableOpacity
-              onPress={() => {
-                this.props.navigation.toggleDrawer();
-              }}>
-              <Image source={menuIcon} style={styles.menuIcon} />
+        <ScrollView>
+          <View style={styles.rootContainer}>
+            <View style={styles.headerRow}>
+              <TouchableOpacity
+                onPress={() => {
+                  this.props.navigation.toggleDrawer();
+                }}>
+                <Image source={menuIcon} style={styles.menuIcon} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.covidIconBackground}>
+              <Image source={covidIcon} style={styles.covidIcon} resizeMode="contain" />
+            </View>
+
+            <Text style={styles.appName}>{i18n.t('welcome.title')}</Text>
+
+            <RegularText style={styles.subtitle}>{i18n.t('welcome.take-a-minute')}</RegularText>
+
+            <ContributionCounter variant={2} count={this.state.userCount} />
+
+            <Image style={styles.partnersLogo} source={this.partnersLogos()} />
+
+            <View style={{ flex: 1 }} />
+
+            <TouchableOpacity style={styles.discoveriesContainer} onPress={this.openWebsite}>
+              <View style={styles.discoveriesTitleBackground}>
+                <RegularText style={styles.discoveriesTitle}>{i18n.t('welcome.research')}</RegularText>
+              </View>
+              <RegularText style={styles.discoveriesText}>{i18n.t('welcome.see-how-your-area-is-affected')}</RegularText>
+              <RegularText style={styles.discoveriesVisitText}>{i18n.t('welcome.visit-the-website')}</RegularText>
             </TouchableOpacity>
           </View>
-
-          <View style={styles.covidIconBackground}>
-            <Image source={covidIcon} style={styles.covidIcon} resizeMode="contain" />
-          </View>
-
-          <Text style={styles.appName}>{i18n.t('welcome.title')}</Text>
-
-          <RegularText style={styles.subtitle}>{i18n.t('welcome.take-a-minute')}</RegularText>
-
-          <ContributionCounter variant={2} count={this.state.userCount} />
-
-          <Image style={styles.partnersLogo} source={this.partnersLogos()} />
-
-          <View style={{ flex: 1 }} />
-
-          <TouchableOpacity style={styles.discoveriesContainer} onPress={this.openWebsite}>
-            <View style={styles.discoveriesTitleBackground}>
-              <RegularText style={styles.discoveriesTitle}>{i18n.t('welcome.research')}</RegularText>
-            </View>
-            <RegularText style={styles.discoveriesText}>{i18n.t('welcome.see-how-your-area-is-affected')}</RegularText>
-            <RegularText style={styles.discoveriesVisitText}>{i18n.t('welcome.visit-the-website')}</RegularText>
-          </TouchableOpacity>
-
+        </ScrollView>
+        <View>
           <BrandedButton style={styles.reportButton} onPress={this.handleButtonPress}>
             {i18n.t('welcome.report-button')}
           </BrandedButton>
@@ -207,6 +210,7 @@ const styles = StyleSheet.create({
     borderColor: colors.backgroundSecondary,
     alignItems: 'center',
     justifyContent: 'space-between',
+    marginBottom: 36,
   },
   partnersLogo: {
     width: '95%',
@@ -219,7 +223,7 @@ const styles = StyleSheet.create({
     tintColor: colors.white,
   },
   reportButton: {
-    marginTop: 48,
+    marginVertical: 10,
     textAlign: 'center',
     backgroundColor: colors.purple,
     alignSelf: 'center',


### PR DESCRIPTION
# Description

3rd attempt to fix Welcome Repeat screen. Currently on smaller screen devices the Report button -- the primary call-to-action -- is off the screen, and the screen is unscrollable. This fixes it so the button is permanently fixed to the bottom of the screen -- so always visible -- and the over long welcome screen scrolls underneath it.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 7 - 2020-04-25 at 22 47 39](https://user-images.githubusercontent.com/61784325/80291624-143a1500-8747-11ea-811d-9a397c089693.png)


## Out of scope and potential follow-up

N/A