### PR TITLE
Fix dropdown translation bugs

### DIFF
--- a/src/features/patient/YourWorkScreen/helpers.ts
+++ b/src/features/patient/YourWorkScreen/helpers.ts
@@ -1,7 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 
-import { isAndroid } from '../../../components/Screen';
 import {
   HealthCareStaffOptions,
   EquipmentUsageOptions,
@@ -10,104 +9,12 @@ import {
   AvailabilityNeverOptions,
   PatientInteractions,
 } from '../../../core/user/dto/UserAPIContracts';
-import i18n from '../../../locale/i18n';
 import { ScreenParamList } from '../../ScreenParamList';
 
-const androidOption = isAndroid && {
-  label: i18n.t('choose-one-of-these-options'),
-  value: '',
-};
-
-interface IOption {
+export interface IOption {
   label: string;
   value: string | number;
 }
-
-export const healthcareStaffOptions = [
-  androidOption,
-  { label: i18n.t('picker-no'), value: HealthCareStaffOptions.NO },
-  {
-    label: i18n.t('yes-interacting-patients'),
-    value: HealthCareStaffOptions.DOES_INTERACT,
-  },
-  {
-    label: i18n.t('yes-not-interacting-patients'),
-    value: HealthCareStaffOptions.DOES_NOT_INTERACT,
-  },
-].filter(Boolean) as IOption[];
-
-export const equipmentUsageOptions = [
-  androidOption,
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-always'),
-    value: EquipmentUsageOptions.ALWAYS,
-  },
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-sometimes'),
-    value: EquipmentUsageOptions.SOMETIMES,
-  },
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-never'),
-    value: EquipmentUsageOptions.NEVER,
-  },
-].filter(Boolean) as IOption[];
-
-export const availabilityAlwaysOptions = [
-  androidOption,
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-always-all-needed'),
-    value: AvailabilityAlwaysOptions.ALL_NEEDED,
-  },
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-always-reused'),
-    value: AvailabilityAlwaysOptions.REUSED,
-  },
-].filter(Boolean) as IOption[];
-
-export const availabilitySometimesOptions = [
-  androidOption,
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-sometimes-all-needed'),
-    value: AvailabilitySometimesOptions.ALL_NEEDED,
-  },
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-sometimes-not-enough'),
-    value: AvailabilitySometimesOptions.NOT_ENOUGH,
-  },
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-sometimes-reused'),
-    value: AvailabilitySometimesOptions.REUSED,
-  },
-].filter(Boolean) as IOption[];
-
-export const availabilityNeverOptions = [
-  androidOption,
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-never-not-needed'),
-    value: AvailabilityNeverOptions.NOT_NEEDED,
-  },
-  {
-    label: i18n.t('health-worker-exposure-picker-ppe-never-not-available'),
-    value: AvailabilityNeverOptions.NOT_AVAILABLE,
-  },
-].filter(Boolean) as IOption[];
-
-export const patientInteractionOptions = [
-  androidOption,
-  {
-    label: i18n.t('exposed-yes-documented'),
-    value: PatientInteractions.YES_DOCUMENTED,
-  },
-  {
-    label: i18n.t('exposed-yes-undocumented'),
-    value: PatientInteractions.YES_SUSPECTED,
-  },
-  {
-    label: i18n.t('exposed-both'),
-    value: PatientInteractions.YES_DOCUMENTED_SUSPECTED,
-  },
-  { label: i18n.t('exposed-no'), value: PatientInteractions.NO },
-].filter(Boolean) as IOption[];
 
 export const initialFormValues: Partial<YourWorkData> = {
   inHospitalInpatient: false,

--- a/src/features/patient/YourWorkScreen/index.tsx
+++ b/src/features/patient/YourWorkScreen/index.tsx
@@ -7,25 +7,21 @@ import * as Yup from 'yup';
 import { CheckboxItem, CheckboxList } from '../../../components/Checkbox';
 import DropdownField from '../../../components/DropdownField';
 import ProgressStatus from '../../../components/ProgressStatus';
-import Screen, { FieldWrapper, Header, ProgressBlock } from '../../../components/Screen';
+import Screen, { FieldWrapper, Header, isAndroid, ProgressBlock } from '../../../components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '../../../components/Text';
 import { ValidationErrors } from '../../../components/ValidationError';
 import UserService from '../../../core/user/UserService';
-import { PatientInfosRequest, HealthCareStaffOptions } from '../../../core/user/dto/UserAPIContracts';
-import i18n from '../../../locale/i18n';
 import {
-  healthcareStaffOptions,
-  equipmentUsageOptions,
-  availabilityAlwaysOptions,
-  availabilitySometimesOptions,
-  patientInteractionOptions,
-  availabilityNeverOptions,
-  YourWorkProps,
-  State,
-  initialState,
-  YourWorkData,
-  initialFormValues,
-} from './helpers';
+  PatientInfosRequest,
+  HealthCareStaffOptions,
+  EquipmentUsageOptions,
+  AvailabilityAlwaysOptions,
+  AvailabilitySometimesOptions,
+  AvailabilityNeverOptions,
+  PatientInteractions,
+} from '../../../core/user/dto/UserAPIContracts';
+import i18n from '../../../locale/i18n';
+import { IOption, YourWorkProps, State, initialState, YourWorkData, initialFormValues } from './helpers';
 
 export default class YourWorkScreen extends Component<YourWorkProps, State> {
   constructor(props: YourWorkProps) {
@@ -127,6 +123,100 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
 
   render() {
     const currentPatient = this.props.route.params.currentPatient;
+
+    const androidOption = isAndroid && {
+      label: i18n.t('choose-one-of-these-options'),
+      value: '',
+    };
+
+    const healthcareStaffOptions = [
+      androidOption,
+      {
+        label: i18n.t('picker-no'),
+        value: HealthCareStaffOptions.NO,
+      },
+      {
+        label: i18n.t('yes-interacting-patients'),
+        value: HealthCareStaffOptions.DOES_INTERACT,
+      },
+      {
+        label: i18n.t('yes-not-interacting-patients'),
+        value: HealthCareStaffOptions.DOES_NOT_INTERACT,
+      },
+    ].filter(Boolean) as IOption[];
+
+    const equipmentUsageOptions = [
+      androidOption,
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-always'),
+        value: EquipmentUsageOptions.ALWAYS,
+      },
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-sometimes'),
+        value: EquipmentUsageOptions.SOMETIMES,
+      },
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-never'),
+        value: EquipmentUsageOptions.NEVER,
+      },
+    ].filter(Boolean) as IOption[];
+
+    const availabilityAlwaysOptions = [
+      androidOption,
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-always-all-needed'),
+        value: AvailabilityAlwaysOptions.ALL_NEEDED,
+      },
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-always-reused'),
+        value: AvailabilityAlwaysOptions.REUSED,
+      },
+    ].filter(Boolean) as IOption[];
+
+    const availabilitySometimesOptions = [
+      androidOption,
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-sometimes-all-needed'),
+        value: AvailabilitySometimesOptions.ALL_NEEDED,
+      },
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-sometimes-not-enough'),
+        value: AvailabilitySometimesOptions.NOT_ENOUGH,
+      },
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-sometimes-reused'),
+        value: AvailabilitySometimesOptions.REUSED,
+      },
+    ].filter(Boolean) as IOption[];
+
+    const availabilityNeverOptions = [
+      androidOption,
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-never-not-needed'),
+        value: AvailabilityNeverOptions.NOT_NEEDED,
+      },
+      {
+        label: i18n.t('health-worker-exposure-picker-ppe-never-not-available'),
+        value: AvailabilityNeverOptions.NOT_AVAILABLE,
+      },
+    ].filter(Boolean) as IOption[];
+
+    const patientInteractionOptions = [
+      androidOption,
+      {
+        label: i18n.t('exposed-yes-documented'),
+        value: PatientInteractions.YES_DOCUMENTED,
+      },
+      {
+        label: i18n.t('exposed-yes-undocumented'),
+        value: PatientInteractions.YES_SUSPECTED,
+      },
+      {
+        label: i18n.t('exposed-both'),
+        value: PatientInteractions.YES_DOCUMENTED_SUSPECTED,
+      },
+      { label: i18n.t('exposed-no'), value: PatientInteractions.NO },
+    ].filter(Boolean) as IOption[];
 
     return (
       <Screen profile={currentPatient.profile} navigation={this.props.navigation}>


### PR DESCRIPTION
# Description

Fixes dropdown option translations. These options are were previously defined in `YourWorkScree/helpers.ts` and imported before i18n.locale is initialised  and so the default `en` is used. Super odd though, as I would assume this would be called lazily and my ReactJS is not strong enough to figure out a better solution. 

```
Logging:

In helpers.ts
Locale: en
Running application on Pixel 2 XL.
Call to getConfig() in GetPatient
Locale: sv-SE
```

This only happens when you first launch the app. If you do an Expo live-reload, it no longer presents itself. Again ... not sure why? 

What do you think @jamesbrooks94 ?

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device
