### PR TITLE
Fix se links

### DIFF
--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -310,8 +310,8 @@
     "title": "COVID Symptom Tracker",
     "sign-in": "Logga in",
     "take-a-minute": "Lägg 1 minut om dagen på att hjälpa oss bekämpa COVID-19.",
-    "disclaimer": "Med den här appen kan du hjälpa andra, men den ger dig inga hälsoråd. För hälsorådgivning ber vi dig",
-    "disclaimer-link": "besöka 1177.se",
+    "disclaimer": "Med den här appen kan du hjälpa andra, men den ger dig inga hälsoråd. För hälsorådgivning ber vi dig besöka",
+    "disclaimer-link": "1177.se",
     "tell-me-more": "Berätta mer",
     "more-info": "%{link} för mer information",
     "more-info-link": "Besök vår webbplats",
@@ -348,11 +348,11 @@
   },
 
   "thank-you-title": "Stort tack för din hjälp och ditt värdefulla bidrag till forskningen.",
-  "blog-link": "https://covid.joinzoe.com/blog",
+  "blog-link": "http://covid19app.lu.se/",
   "thank-you-body": "Tack, du är nu en av de miljontals människor som hjälper forskare på Lunds universitet och King’s College London att bekämpa COVID-19.",
   "check-in-tomorrow": "Om du har möjlighet uppskattar vi verkligen om du rapporterar hur du mår igen i morgon.",
   "check-news-feed" : "Håll gärna utkik efter uppdateringar i vårt <b>nyhetsflöde</b>.",
-  "faq-link": "https://covid.joinzoe.com/faq",
+  "faq-link": "https://www.covid19app.lu.se/faq",
 
   "rating": {
     "how-are-we-doing": "Vad tycker du om vårt arbete?",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -348,7 +348,7 @@
   },
 
   "thank-you-title": "Stort tack för din hjälp och ditt värdefulla bidrag till forskningen.",
-  "blog-link": "http://covid19app.lu.se/",
+  "blog-link": "https://covid19app.lu.se/",
   "thank-you-body": "Tack, du är nu en av de miljontals människor som hjälper forskare på Lunds universitet och King’s College London att bekämpa COVID-19.",
   "check-in-tomorrow": "Om du har möjlighet uppskattar vi verkligen om du rapporterar hur du mår igen i morgon.",
   "check-news-feed" : "Håll gärna utkik efter uppdateringar i vårt <b>nyhetsflöde</b>.",

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -7,7 +7,7 @@ import { Alert, Image, Linking, StyleSheet, Text, TouchableOpacity, View, SafeAr
 import { closeIcon } from '../../assets';
 import { colors, fontStyles } from '../../theme';
 import { CaptionText, HeaderText } from '../components/Text';
-import UserService, { isGBCountry, isUSCountry } from '../core/user/UserService';
+import UserService, { isGBCountry, isUSCountry, isSECountry } from '../core/user/UserService';
 import i18n from '../locale/i18n';
 
 export function DrawerMenu(props: DrawerContentComponentProps) {
@@ -71,6 +71,8 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
           onPress={() => {
             isGBCountry()
               ? props.navigation.navigate('PrivacyPolicyUK', { viewOnly: true })
+              : isSECountry()
+              ? props.navigation.navigate('PrivacyPolicySV', { viewOnly: true })
               : props.navigation.navigate('PrivacyPolicyUS', { viewOnly: true });
           }}>
           <HeaderText>{i18n.t('privacy-policy')}</HeaderText>

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -401,8 +401,8 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
               />
               <Body style={styles.label}>
                 <RegularText>
-                  Jag samtycker till att personuppgifter om mig behandlas på det sätt som beskrivs i
-                  informationen till studiedeltagare ovan.
+                  Jag samtycker till att personuppgifter om mig behandlas på det sätt som beskrivs i informationen till
+                  studiedeltagare ovan.
                 </RegularText>
               </Body>
             </ListItem>

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -402,7 +402,7 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
               <Body style={styles.label}>
                 <RegularText>
                   Jag samtycker till att personuppgifter om mig behandlas på det sätt som beskrivs i
-                  forskningspersonsinformationen ovan.
+                  informationen till studiedeltagare ovan.
                 </RegularText>
               </Body>
             </ListItem>


### PR DESCRIPTION
# Description

Sweden changes: update with Swedish links in the Drawer Menu. Small text updates for privacy and consent pages. And pointing Drawer Menu privacy policy to PrivacyPolicySV screen.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
