### PR TITLE
Localise default profile name when not set.

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -439,6 +439,7 @@
   "select-profile-text": "Or add more profiles",
   "select-profile-button": "New profile",
   "select-profile-last-report": "Last report:",
+  "default-profile-name": "Me",
 
   "validation-error-text": "Please fill in or correct the above information: %{info}",
   "validation-error-text-no-info": "Please fill in or correct the above information",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -348,7 +348,7 @@
   },
 
   "thank-you-title": "Stort tack för din hjälp och ditt värdefulla bidrag till forskningen.",
-  "blog-link": "https://covid.joinzoe.com/blog",
+  "blog-link": "https://covid19app.lu.se/",
   "thank-you-body": "Tack, du är nu en av de miljontals människor som hjälper forskare på Lunds universitet och King’s College London att bekämpa COVID-19.",
   "check-in-tomorrow": "Om du har möjlighet uppskattar vi verkligen om du rapporterar hur du mår igen i morgon.",
   "check-news-feed" : "Håll gärna utkik efter uppdateringar i vårt <b>nyhetsflöde</b>.",
@@ -416,6 +416,7 @@
   "select-profile-text": "Eller lägg till fler profiler",
   "select-profile-button": "Ny profil",
   "select-profile-last-report": "Sista rapport:",
+  "default-profile-name": "Jag",
 
   "next-question": "Nästa fråga",
   "completed": "Klar",

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -173,8 +173,13 @@ export default class UserService extends ApiClientBase {
       // and not null. (or any nullable field on the last page)
       (patient.has_heart_disease === true || patient.has_heart_disease === false);
 
+    let patientName = patient.name;
+    if (!patientName || (!patient.reported_by_another && patientName === 'Me')) {
+      patientName = i18n.t('default-profile-name');
+    }
+
     const profile: PatientProfile = {
-      name: patient.name || 'Me',
+      name: patientName,
       avatarName: (patient.avatar_name || 'profile1') as AvatarName,
       isPrimaryPatient: !patient.reported_by_another,
     };
@@ -214,6 +219,8 @@ export default class UserService extends ApiClientBase {
       if (!patient) {
         patient = await this.getPatient(patientId);
       }
+
+      console.log('[PATIENT]', patient);
 
       if (patient) {
         currentPatient = await this.updatePatientState(currentPatient, patient);

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -220,8 +220,6 @@ export default class UserService extends ApiClientBase {
         patient = await this.getPatient(patientId);
       }
 
-      console.log('[PATIENT]', patient);
-
       if (patient) {
         currentPatient = await this.updatePatientState(currentPatient, patient);
       }


### PR DESCRIPTION
# Description

Allow default profile name to be localised if not set (It's force-set to "Me" in the app and on the server, I think). This PR hacks around that to set it to a localised/translated "Me".

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
