### PR TITLE
Fix research link on the Repeat welcome screen.

### DIFF
--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -74,6 +74,8 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
   openWebsite = () => {
     if (isUSCountry()) {
       Linking.openURL('https://covid.joinzoe.com/us');
+    } else if (isSECountry()) {
+      Linking.openURL('https://covid19app.lu.se/');
     } else {
       Linking.openURL('https://covid.joinzoe.com/');
     }


### PR DESCRIPTION
# Description

Fix research link on WelcomeRepeat screen for Sweden to point to Swedish site.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
