### PR TITLE
Fix number separator for Sweden

### DIFF
--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -132,7 +132,7 @@
       "has-cancer": "Har du cancer?",
       "what-cancer-type": "Vilken typ av cancer har du?",
       "is-on-chemotherapy": "Behandlas din cancer med kemoterapi eller immunoterapi?",
-      "takes-immunosuppressant": "Tar du regelbundet immunsuppressiva läkemedel, t.ex. kortisontabletter, metotrexat eller biologiska läkemedel?",
+      "takes-immunosuppressant": "Tar du regelbundet mediciner som kan påverka ditt immunförsvar, t.ex. kortisontabletter, Metotrexate® eller biologiska läkemedel (som används vid t.ex. vissa typer av cancer eller reumatisk sjukdom)?",
       "takes-asprin": "Tar du regelbundet aspirin/acetylsalicylsyra (inkl. acetylsalicylsyra i lågdos t.ex. Trombyl®)?",
       "takes-nsaids": "Tar du regelbundet icke-steroida antiinflammatoriska läkemedel (NSAID), t.ex. Ipren®, Brufen®, Eeze®, Voltaren®, eller Naproxen®?”",
       "takes-any-blood-pressure-medication": "Tar du regelbundet någon blodtryckssänkande medicin?",

--- a/src/components/ContributionCounter.tsx
+++ b/src/components/ContributionCounter.tsx
@@ -4,13 +4,17 @@ import { StyleSheet } from 'react-native';
 import reactStringReplace from 'react-string-replace';
 
 import { colors } from '../../theme';
+import UserService from '../core/user/UserService';
 import i18n from '../locale/i18n';
 import { RegularBoldText, RegularText } from './Text';
 
 type ContributionCounterProps = { variant: number; count: number | null };
 export const ContributionCounter = (props: ContributionCounterProps) => {
   if (props.count) {
-    const countValue = I18n.toNumber(props.count, { precision: 0 });
+    const userService = new UserService();
+    const features = userService.getConfig();
+
+    const countValue = I18n.toNumber(props.count, { precision: 0, delimiter: features.thousandSeparator });
     return props.variant === 1 ? (
       <RegularText style={styles.contributingText}>
         {reactStringReplace(

--- a/src/components/ContributionCounter.tsx
+++ b/src/components/ContributionCounter.tsx
@@ -13,8 +13,9 @@ export const ContributionCounter = (props: ContributionCounterProps) => {
   if (props.count) {
     const userService = new UserService();
     const features = userService.getConfig();
+    const delimiter = features ? features.thousandSeparator : ',';
 
-    const countValue = I18n.toNumber(props.count, { precision: 0, delimiter: features.thousandSeparator });
+    const countValue = I18n.toNumber(props.count, { precision: 0, delimiter });
     return props.variant === 1 ? (
       <RegularText style={styles.contributingText}>
         {reactStringReplace(

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -15,6 +15,7 @@ export type ConfigType = {
   defaultHeightUnit: string;
   defaultWeightUnit: string;
   defaultTemperatureUnit: string;
+  thousandSeparator: string;
 };
 
 const configs = new Map<string, ConfigType>([

--- a/src/core/config/SE.json
+++ b/src/core/config/SE.json
@@ -6,5 +6,5 @@
 
     "showEthnicityQuestion": false,
     "showRaceQuestion": false,
-    "thousandSeparator": " ",
+    "thousandSeparator": " "
 }

--- a/src/core/config/SE.json
+++ b/src/core/config/SE.json
@@ -5,5 +5,6 @@
     "enableCohorts": true,
 
     "showEthnicityQuestion": false,
-    "showRaceQuestion": false
+    "showRaceQuestion": false,
+    "thousandSeparator": " ",
 }

--- a/src/core/config/default.json
+++ b/src/core/config/default.json
@@ -9,5 +9,6 @@
 
     "defaultHeightUnit": "cm",
     "defaultWeightUnit": "kg",
-    "defaultTemperatureUnit": "C"
+    "defaultTemperatureUnit": "C",
+    "thousandSeparator": ",",
 }

--- a/src/core/config/default.json
+++ b/src/core/config/default.json
@@ -10,5 +10,5 @@
     "defaultHeightUnit": "cm",
     "defaultWeightUnit": "kg",
     "defaultTemperatureUnit": "C",
-    "thousandSeparator": ",",
+    "thousandSeparator": ","
 }


### PR DESCRIPTION
# Description

- Fix number separator for Sweden
- Fixes translation for immunosurpressants.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

