### PR TITLE
Add screen to ask back dated profile questions

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -93,7 +93,6 @@
     "back": "Back"
   },
 
-
   "next-question": "Next question",
   "completed": "Done",
   "something-went-wrong": "Something went wrong, please try again later",
@@ -108,6 +107,9 @@
     "worked-school-clinic": "School clinic",
     "worked-other-facility": "Other health care facility"
   },
+
+  "back-date-profile-title": "Some additional questions about you",
+  "update-profile": "Update profile",
 
   "title-about-work": "About your work",
   "label-cohort": "Are you part of one of these population studies or organisations?",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -435,5 +435,8 @@
 
   "website-home": "https://covid.joinzoe.com/",
   "share-with-friends-message": "Hjälp till att bromsa spridningen av #COVID19 och skydda de som tillhör en riskgrupp genom att själv rapportera dina symtom varje dag, även om du känner dig frisk 🙏. Ladda ned appen",
-  "share-with-friends-url": "https://covid19app.lu.se/"
+  "share-with-friends-url": "https://covid19app.lu.se/",
+
+  "back-date-profile-title": "Några fler frågor om dig",
+  "update-profile": "Uppdatera profilen"
 }

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -48,6 +48,7 @@ import StartAssessmentScreen from './features/assessment/StartAssessment';
 import PreviousExposureScreen from './features/patient/PreviousExposure';
 import StartPatientScreen from './features/patient/StartPatient';
 import { RegisterScreen } from './features/register/RegisterScreen';
+import ProfileBackDateScreen from "./features/assessment/ProfileBackDateScreen";
 
 const Stack = createStackNavigator<ScreenParamList>();
 const Drawer = createDrawerNavigator();
@@ -100,38 +101,14 @@ export default class ZoeApp extends Component<object, State> {
         <Stack.Screen name="Welcome2" component={Welcome2Screen} options={{ headerShown: false }} />
         <Stack.Screen name="WelcomeRepeat" component={WelcomeRepeatScreen} options={{ headerShown: false }} />
         <Stack.Screen name="Consent" component={ConsentScreen} options={{ headerShown: true, title: 'Consent' }} />
-        <Stack.Screen
-          name="TermsOfUseUS"
-          component={TermsOfUseUSScreen}
-          options={{ headerShown: true, title: 'Terms of Use' }}
-        />
-        <Stack.Screen
-          name="PrivacyPolicyUK"
-          component={PrivacyPolicyUKScreen}
-          options={{ headerShown: true, title: 'Privacy notice' }}
-        />
-        <Stack.Screen
-          name="PrivacyPolicyUS"
-          component={PrivacyPolicyUSScreen}
-          options={{ headerShown: true, title: 'Privacy policy' }}
-        />
-        <Stack.Screen
-          name="PrivacyPolicySV"
-          component={PrivacyPolicySVScreen}
-          options={{ headerShown: true, title: 'Integritetsmeddelande' }}
-        />
-        <Stack.Screen
-          name="NursesConsentUS"
-          component={NursesConsentUSScreen}
-          options={{ headerShown: true, title: 'Research Consent' }}
-        />
+        <Stack.Screen name="TermsOfUseUS" component={TermsOfUseUSScreen} options={{ headerShown: true, title: 'Terms of Use' }}/>
+        <Stack.Screen name="PrivacyPolicyUK" component={PrivacyPolicyUKScreen} options={{ headerShown: true, title: 'Privacy notice' }}/>
+        <Stack.Screen name="PrivacyPolicyUS" component={PrivacyPolicyUSScreen} options={{ headerShown: true, title: 'Privacy policy' }}/>
+        <Stack.Screen name="PrivacyPolicySV" component={PrivacyPolicySVScreen} options={{ headerShown: true, title: 'Integritetsmeddelande' }}/>
+        <Stack.Screen name="NursesConsentUS" component={NursesConsentUSScreen} options={{ headerShown: true, title: 'Research Consent' }}/>
         <Stack.Screen name="BeforeWeStartUS" component={BeforeWeStartUS} options={{ headerShown: false }} />
         <Stack.Screen name="ResetPassword" component={ResetPasswordScreen} options={{ headerShown: false }} />
-        <Stack.Screen
-          name="ResetPasswordConfirm"
-          component={ResetPasswordConfirmScreen}
-          options={{ headerShown: false }}
-        />
+        <Stack.Screen name="ResetPasswordConfirm" component={ResetPasswordConfirmScreen} options={{ headerShown: false }}/>
         <Stack.Screen name="Register" component={RegisterScreen} options={{ headerShown: false }} />
         <Stack.Screen name="OptionalInfo" component={OptionalInfoScreen} options={{ headerShown: false }} />
         <Stack.Screen name="StartPatient" component={StartPatientScreen} options={{ headerShown: false }} />
@@ -141,11 +118,7 @@ export default class ZoeApp extends Component<object, State> {
         <Stack.Screen name="AboutYou" component={AboutYouScreen} options={{ headerShown: false }} />
         <Stack.Screen name="PreviousExposure" component={PreviousExposureScreen} options={{ headerShown: false }} />
         <Stack.Screen name="StartAssessment" component={StartAssessmentScreen} options={{ headerShown: false }} />
-        <Stack.Screen
-          name="HealthWorkerExposure"
-          component={HealthWorkerExposureScreen}
-          options={{ headerShown: false }}
-        />
+        <Stack.Screen name="HealthWorkerExposure" component={HealthWorkerExposureScreen} options={{ headerShown: false }}/>
         <Stack.Screen name="CovidTest" component={CovidTestScreen} options={{ headerShown: false }} />
         <Stack.Screen name="HowYouFeel" component={HowYouFeelScreen} options={{ headerShown: false }} />
         <Stack.Screen name="DescribeSymptoms" component={DescribeSymptomsScreen} options={{ headerShown: false }} />
@@ -161,6 +134,7 @@ export default class ZoeApp extends Component<object, State> {
         <Stack.Screen name="ReportForOther" component={ReportForOtherScreen} options={{ headerShown: false }} />
         <Stack.Screen name="SelectProfile" component={SelectProfileScreen} options={{ headerShown: false }} />
         <Stack.Screen name="AdultOrChild" component={AdultOrChildScreen} options={{ headerShown: false }} />
+        <Stack.Screen name="ProfileBackDate" component={ProfileBackDateScreen} options={{ headerShown: false }} />
       </Stack.Navigator>
     );
   }

--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -17,6 +17,7 @@ export type PatientStateType = {
   isSameHousehold: boolean;
   shouldAskLevelOfIsolation: boolean;
   shouldAskStudy: boolean;
+  hasRaceAnswer: boolean;
 };
 
 const initPatientState = {
@@ -33,6 +34,7 @@ const initPatientState = {
   isSameHousehold: false,
   shouldAskLevelOfIsolation: false,
   shouldAskStudy: false,
+  hasRaceAnswer: true,
 } as Partial<PatientStateType>;
 
 export const getInitialPatientState = (patientId: string): PatientStateType => {

--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -10,7 +10,7 @@ export type PatientStateType = {
   patientId: string;
   profile: PatientProfile;
   isHealthWorker: boolean;
-  hasCompletePatientDetails: boolean;
+  hasCompletedPatientDetails: boolean;
   hasBloodPressureAnswer: boolean;
   isFemale: boolean;
   isReportedByAnother: boolean;
@@ -27,7 +27,7 @@ const initPatientState = {
     isPrimaryPatient: true,
   },
   isHealthWorker: false,
-  hasCompletePatientDetails: true,
+  hasCompletedPatientDetails: true,
   hasBloodPressureAnswer: true,
   isFemale: false,
   isReportedByAnother: false,

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -160,18 +160,19 @@ export default class UserService extends ApiClientBase {
 
   public async updatePatientState(patientState: PatientStateType, patient: PatientInfosRequest) {
     // Calculate the flags based on patient info
+    const hasRaceAnswer = patient.race.length > 0;
     const isFemale = patient.gender == 0;
     const isHealthWorker =
       ['yes_does_treat', 'yes_does_interact'].includes(patient.healthcare_professional) ||
       patient.is_carer_for_community;
     const hasBloodPressureAnswer =
-      patient.takes_any_blood_pressure_medications === true || patient.takes_any_blood_pressure_medications === false;
+      patient.takes_any_blood_pressure_medications || !patient.takes_any_blood_pressure_medications;
     const hasCompletePatientDetails =
       // They've done at least one page of the patient flow. That's a start.
       !!patient.profile_attributes_updated_at &&
       // If they've completed the last page, heart disease will either be true or false
       // and not null. (or any nullable field on the last page)
-      (patient.has_heart_disease === true || patient.has_heart_disease === false);
+      (patient.has_heart_disease || !patient.has_heart_disease);
 
     let patientName = patient.name;
     if (!patientName || (!patient.reported_by_another && patientName === 'Me')) {
@@ -203,6 +204,7 @@ export default class UserService extends ApiClientBase {
       profile,
       isFemale,
       isHealthWorker,
+      hasRaceAnswer,
       hasBloodPressureAnswer,
       hasCompletePatientDetails,
       isReportedByAnother,

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -165,14 +165,13 @@ export default class UserService extends ApiClientBase {
     const isHealthWorker =
       ['yes_does_treat', 'yes_does_interact'].includes(patient.healthcare_professional) ||
       patient.is_carer_for_community;
-    const hasBloodPressureAnswer =
-      patient.takes_any_blood_pressure_medications || !patient.takes_any_blood_pressure_medications;
+    const hasBloodPressureAnswer = patient.takes_any_blood_pressure_medications != null
     const hasCompletePatientDetails =
       // They've done at least one page of the patient flow. That's a start.
       !!patient.profile_attributes_updated_at &&
       // If they've completed the last page, heart disease will either be true or false
       // and not null. (or any nullable field on the last page)
-      (patient.has_heart_disease || !patient.has_heart_disease);
+      (patient.has_heart_disease != null);
 
     let patientName = patient.name;
     if (!patientName || (!patient.reported_by_another && patientName === 'Me')) {

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -29,6 +29,7 @@ export type ScreenParamList = {
   Register: undefined;
   Login: { terms: string };
   CountrySelect: { patientId: string | null };
+  ProfileBackDate: { currentPatient: PatientStateType };
 
   // PII screens
   OptionalInfo: { patientId: string };

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -19,15 +19,11 @@ import { ScreenParamList } from '../ScreenParamList';
 const initialFormValues = {
   hasCovidTest: 'no',
   hasCovidPositive: 'no',
-
-  takesAnyBloodPressureMedications: '',
 };
 
 interface CovidTestData {
   hasCovidTest: string;
   hasCovidPositive: string;
-
-  takesAnyBloodPressureMedications: string;
 }
 
 type CovidProps = {
@@ -37,12 +33,10 @@ type CovidProps = {
 
 type State = {
   errorMessage: string;
-  needBloodPressureAnswer: boolean;
 };
 
 const initialState: State = {
   errorMessage: '',
-  needBloodPressureAnswer: false,
 };
 
 export default class CovidTestScreen extends Component<CovidProps, State> {
@@ -56,11 +50,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
     hasCovidPositive: Yup.string().required(),
     takesAnyBloodPressureMedications: Yup.string(),
   });
-
-  async componentDidMount() {
-    const currentPatient = this.props.route.params.currentPatient;
-    this.setState({ needBloodPressureAnswer: !currentPatient.hasBloodPressureAnswer });
-  }
 
   handleUpdateHealth(formData: CovidTestData) {
     const { currentPatient, assessmentId } = this.props.route.params;
@@ -77,19 +66,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
         ...assessment,
         tested_covid_positive: formData.hasCovidPositive,
       };
-    }
-
-    // Update patient data with blood pressure answer, if answered.
-    if (patientId && formData.takesAnyBloodPressureMedications) {
-      // Deliberately fire and forget.
-      userService
-        .updatePatient(patientId, {
-          takes_any_blood_pressure_medications: formData.takesAnyBloodPressureMedications === 'yes',
-        })
-        .then((response) => (currentPatient.hasBloodPressureAnswer = true))
-        .catch((err) => {
-          this.setState({ errorMessage: i18n.t('something-went-wrong') });
-        });
     }
 
     if (assessmentId == null) {
@@ -154,18 +130,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
                     onValueChange={props.handleChange('hasCovidPositive')}
                     label={i18n.t('covid-test.question-has-covid-positive')}
                     items={hasCovidPositiveItems}
-                  />
-                )}
-
-                {this.state.needBloodPressureAnswer && (
-                  <DropdownField
-                    selectedValue={props.values.takesAnyBloodPressureMedications}
-                    onValueChange={props.handleChange('takesAnyBloodPressureMedications')}
-                    label={i18n.t('covid-test.question-takes-any-blood-pressure-medications')}
-                    error={
-                      props.touched.takesAnyBloodPressureMedications && props.errors.takesAnyBloodPressureMedications
-                    }
-                    androidDefaultLabel={i18n.t('label-chose-an-option')}
                   />
                 )}
 

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -1,0 +1,235 @@
+import { RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { Formik, FormikProps } from 'formik';
+import { Form, Item, Label, Text } from 'native-base';
+import React, { Component } from 'react';
+import { Platform } from 'react-native';
+import * as Yup from 'yup';
+
+import DropdownField from '../../components/DropdownField';
+import ProgressStatus from '../../components/ProgressStatus';
+import Screen, { FieldWrapper, Header, ProgressBlock } from '../../components/Screen';
+import { BrandedButton, ErrorText, HeaderText } from '../../components/Text';
+import { ValidationErrors } from '../../components/ValidationError';
+import UserService, { isUSCountry } from '../../core/user/UserService';
+import { AssessmentInfosRequest, PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
+import i18n from '../../locale/i18n';
+import { ScreenParamList } from '../ScreenParamList';
+import { CheckboxItem, CheckboxList } from '../../components/Checkbox';
+import { GenericTextField } from '../../components/GenericTextField';
+import { RaceEthnicityQuestion } from '../patient/fields/RaceEthnicityQuestion';
+import { AboutYouData } from '../patient/AboutYouScreen';
+import { YourHealthData } from '../patient/YourHealthScreen';
+import {BloodPressureMedicationQuestion} from "../patient/fields/BloodPressureMedicationQuestion";
+
+const initialFormValues: BackData = {
+  yearOfBirth: '',
+  sex: '',
+  genderIdentity: '',
+  genderIdentityDescription: '',
+  postcode: '',
+  height: '',
+  feet: '',
+  inches: '',
+  heightUnit: 'ft',
+  weight: '',
+  stones: '',
+  pounds: '',
+  weightUnit: 'lbs',
+
+  everExposed: '',
+  houseboundProblems: 'no',
+  needsHelp: 'no',
+  helpAvailable: 'no',
+  mobilityAid: 'no',
+  race: [] as string[],
+  raceOther: '',
+  ethnicity: '',
+  isPregnant: 'no',
+  hasHeartDisease: 'no',
+  hasDiabetes: 'no',
+  hasLungDisease: 'no',
+  smokerStatus: 'never',
+  smokedYearsAgo: '',
+  hasKidneyDisease: 'no',
+
+  hasCancer: 'no',
+  cancerType: '',
+
+  doesChemiotherapy: 'no',
+  takesImmunosuppressants: 'no',
+  takesCorticosteroids: 'no',
+  takesAspirin: 'no',
+  takesBloodPressureMedications: 'no', // pril
+  takesAnyBloodPressureMedications: 'no',
+  takesBloodPressureMedicationsSartan: 'no',
+
+  limitedActivity: 'no',
+};
+
+interface BackData extends AboutYouData, YourHealthData {}
+
+type BackDateProps = {
+  navigation: StackNavigationProp<ScreenParamList, 'ProfileBackDate'>;
+  route: RouteProp<ScreenParamList, 'ProfileBackDate'>;
+};
+
+type State = {
+  errorMessage: string;
+  needBloodPressureAnswer: boolean;
+  needRaceAnswer: boolean;
+};
+
+const initialState: State = {
+  errorMessage: '',
+  needBloodPressureAnswer: false,
+  needRaceAnswer: false,
+};
+
+export default class ProfileBackDateScreen extends Component<BackDateProps, State> {
+  userService = new UserService();
+  features = this.userService.getConfig();
+
+  constructor(props: BackDateProps) {
+    super(props);
+    this.state = initialState;
+  }
+
+  registerSchema = Yup.object().shape({
+    takesAnyBloodPressureMedications: Yup.string().when([], {
+      is: () => this.state.needBloodPressureAnswer,
+      then: Yup.string().required()
+    }),
+    takesBloodPressureMedications: Yup.string().when([], {
+      is: () => this.state.needBloodPressureAnswer,
+      then: Yup.string().required()
+    }),
+    takesBloodPressureMedicationsSartan: Yup.string().when([], {
+      is: () => this.state.needBloodPressureAnswer,
+      then: Yup.string().required()
+    }),
+
+    race: Yup.array<string>().when([], {
+      is: () => this.state.needRaceAnswer,
+      then: Yup.array<string>().min(1, i18n.t('please-select-race')),
+    }),
+    raceOther: Yup.string().when('race', {
+      is: (val: string[]) => val.includes('other'),
+      then: Yup.string().required(),
+    }),
+    ethnicity: Yup.string().when([], {
+      is: () => isUSCountry(),
+      then: Yup.string().required(),
+    }),
+  });
+
+  async componentDidMount() {
+    const currentPatient = this.props.route.params.currentPatient;
+    this.setState({ needBloodPressureAnswer: !currentPatient.hasBloodPressureAnswer });
+    this.setState({ needRaceAnswer: !currentPatient.hasRaceAnswer });
+  }
+
+  handleProfileUpdate(formData: BackData) {
+    const { currentPatient } = this.props.route.params;
+    const patientId = currentPatient.patientId;
+
+    const userService = new UserService();
+
+    let infos: Partial<PatientInfosRequest> = {};
+
+    if (formData.takesAnyBloodPressureMedications) {
+      infos = {
+        ...infos,
+        takes_any_blood_pressure_medications: formData.takesAnyBloodPressureMedications === 'yes',
+      };
+    }
+
+    if (infos.takes_any_blood_pressure_medications) {
+      infos = {
+        ...infos,
+        takes_blood_pressure_medications: formData.takesBloodPressureMedications === 'yes', // pril
+        takes_blood_pressure_medications_sartan: formData.takesBloodPressureMedicationsSartan === 'yes',
+      };
+    }
+
+    if (formData.race) {
+      infos = {
+        ...infos,
+        race: formData.race,
+      };
+    }
+
+    if (formData.ethnicity) {
+      infos = {
+        ...infos,
+        ethnicity: formData.ethnicity,
+      };
+    }
+
+    if (formData.raceOther) {
+      infos = {
+        ...infos,
+        race_other: formData.raceOther,
+      };
+    }
+
+    userService
+      .updatePatient(patientId, infos)
+      .then((response) => {
+        if (formData.race) currentPatient.hasRaceAnswer = true;
+        if (formData.takesAnyBloodPressureMedications) currentPatient.hasBloodPressureAnswer = true;
+        this.props.navigation.replace('StartAssessment', { currentPatient });
+      })
+      .catch((err) => {
+        this.setState({ errorMessage: i18n.t('something-went-wrong') });
+      });
+  }
+
+  render() {
+    const currentPatient = this.props.route.params.currentPatient;
+
+    return (
+      <Screen profile={currentPatient.profile} navigation={this.props.navigation}>
+        <Header>
+          <HeaderText>{i18n.t('back-date-profile-title')}</HeaderText>
+        </Header>
+
+        <ProgressBlock>
+          <ProgressStatus step={1} maxSteps={6} />
+        </ProgressBlock>
+
+        <Formik
+          initialValues={initialFormValues}
+          validationSchema={this.registerSchema}
+          onSubmit={(values: BackData) => {
+            return this.handleProfileUpdate(values);
+          }}>
+          {(props) => {
+            return (
+              <Form>
+                {this.state.needBloodPressureAnswer && (
+                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<YourHealthData>}/>
+                )}
+
+                {this.state.needRaceAnswer && (
+                  <RaceEthnicityQuestion
+                    showRaceQuestion={this.features.showRaceQuestion}
+                    showEthnicityQuestion={this.features.showEthnicityQuestion}
+                    formikProps={props as FormikProps<AboutYouData>}
+                  />
+                )}
+
+                <ErrorText>{this.state.errorMessage}</ErrorText>
+                {!!Object.keys(props.errors).length && <ValidationErrors errors={props.errors as string[]} />}
+
+                <BrandedButton onPress={props.handleSubmit}>
+                  <Text>{i18n.t('update-profile')}</Text>
+                </BrandedButton>
+              </Form>
+            );
+          }}
+        </Formik>
+      </Screen>
+    );
+  }
+}

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -17,57 +17,22 @@ import i18n from '../../locale/i18n';
 import { ScreenParamList } from '../ScreenParamList';
 import { CheckboxItem, CheckboxList } from '../../components/Checkbox';
 import { GenericTextField } from '../../components/GenericTextField';
-import { RaceEthnicityQuestion } from '../patient/fields/RaceEthnicityQuestion';
+import {RaceEthnicityData, RaceEthnicityQuestion} from '../patient/fields/RaceEthnicityQuestion';
 import { AboutYouData } from '../patient/AboutYouScreen';
 import { YourHealthData } from '../patient/YourHealthScreen';
-import {BloodPressureMedicationQuestion} from "../patient/fields/BloodPressureMedicationQuestion";
+import {BloodPressureData, BloodPressureMedicationQuestion} from "../patient/fields/BloodPressureMedicationQuestion";
 
 const initialFormValues: BackData = {
-  yearOfBirth: '',
-  sex: '',
-  genderIdentity: '',
-  genderIdentityDescription: '',
-  postcode: '',
-  height: '',
-  feet: '',
-  inches: '',
-  heightUnit: 'ft',
-  weight: '',
-  stones: '',
-  pounds: '',
-  weightUnit: 'lbs',
-
-  everExposed: '',
-  houseboundProblems: 'no',
-  needsHelp: 'no',
-  helpAvailable: 'no',
-  mobilityAid: 'no',
   race: [] as string[],
   raceOther: '',
   ethnicity: '',
-  isPregnant: 'no',
-  hasHeartDisease: 'no',
-  hasDiabetes: 'no',
-  hasLungDisease: 'no',
-  smokerStatus: 'never',
-  smokedYearsAgo: '',
-  hasKidneyDisease: 'no',
 
-  hasCancer: 'no',
-  cancerType: '',
-
-  doesChemiotherapy: 'no',
-  takesImmunosuppressants: 'no',
-  takesCorticosteroids: 'no',
-  takesAspirin: 'no',
   takesBloodPressureMedications: 'no', // pril
   takesAnyBloodPressureMedications: 'no',
   takesBloodPressureMedicationsSartan: 'no',
-
-  limitedActivity: 'no',
 };
 
-interface BackData extends AboutYouData, YourHealthData {}
+interface BackData extends BloodPressureData, RaceEthnicityData {}
 
 type BackDateProps = {
   navigation: StackNavigationProp<ScreenParamList, 'ProfileBackDate'>;
@@ -208,14 +173,14 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
             return (
               <Form>
                 {this.state.needBloodPressureAnswer && (
-                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<YourHealthData>}/>
+                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<BloodPressureData>}/>
                 )}
 
                 {this.state.needRaceAnswer && (
                   <RaceEthnicityQuestion
                     showRaceQuestion={this.features.showRaceQuestion}
                     showEthnicityQuestion={this.features.showEthnicityQuestion}
-                    formikProps={props as FormikProps<AboutYouData>}
+                    formikProps={props as FormikProps<RaceEthnicityData>}
                   />
                 )}
 

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -1,36 +1,20 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik, FormikProps } from 'formik';
-import { Form, Item, Label, Text } from 'native-base';
+import { Form, Text } from 'native-base';
 import React, { Component } from 'react';
-import { Platform } from 'react-native';
 import * as Yup from 'yup';
 
-import DropdownField from '../../components/DropdownField';
 import ProgressStatus from '../../components/ProgressStatus';
-import Screen, { FieldWrapper, Header, ProgressBlock } from '../../components/Screen';
+import Screen, { Header, ProgressBlock } from '../../components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '../../components/Text';
 import { ValidationErrors } from '../../components/ValidationError';
 import UserService, { isUSCountry } from '../../core/user/UserService';
-import { AssessmentInfosRequest, PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
+import { PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import { ScreenParamList } from '../ScreenParamList';
-import { CheckboxItem, CheckboxList } from '../../components/Checkbox';
-import { GenericTextField } from '../../components/GenericTextField';
-import {RaceEthnicityData, RaceEthnicityQuestion} from '../patient/fields/RaceEthnicityQuestion';
-import { AboutYouData } from '../patient/AboutYouScreen';
-import { YourHealthData } from '../patient/YourHealthScreen';
-import {BloodPressureData, BloodPressureMedicationQuestion} from "../patient/fields/BloodPressureMedicationQuestion";
-
-const initialFormValues: BackData = {
-  race: [] as string[],
-  raceOther: '',
-  ethnicity: '',
-
-  takesBloodPressureMedications: 'no', // pril
-  takesAnyBloodPressureMedications: 'no',
-  takesBloodPressureMedicationsSartan: 'no',
-};
+import { RaceEthnicityData, RaceEthnicityQuestion } from '../patient/fields/RaceEthnicityQuestion';
+import { BloodPressureData, BloodPressureMedicationQuestion } from '../patient/fields/BloodPressureMedicationQuestion';
 
 interface BackData extends BloodPressureData, RaceEthnicityData {}
 
@@ -63,15 +47,15 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
   registerSchema = Yup.object().shape({
     takesAnyBloodPressureMedications: Yup.string().when([], {
       is: () => this.state.needBloodPressureAnswer,
-      then: Yup.string().required()
+      then: Yup.string().required(),
     }),
     takesBloodPressureMedications: Yup.string().when([], {
       is: () => this.state.needBloodPressureAnswer,
-      then: Yup.string().required()
+      then: Yup.string().required(),
     }),
     takesBloodPressureMedicationsSartan: Yup.string().when([], {
       is: () => this.state.needBloodPressureAnswer,
-      then: Yup.string().required()
+      then: Yup.string().required(),
     }),
 
     race: Yup.array<string>().when([], {
@@ -164,7 +148,10 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
         </ProgressBlock>
 
         <Formik
-          initialValues={initialFormValues}
+          initialValues={{
+            ...RaceEthnicityQuestion.initialFormValues(),
+            ...BloodPressureMedicationQuestion.initialFormValues(),
+          }}
           validationSchema={this.registerSchema}
           onSubmit={(values: BackData) => {
             return this.handleProfileUpdate(values);
@@ -173,7 +160,7 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
             return (
               <Form>
                 {this.state.needBloodPressureAnswer && (
-                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<BloodPressureData>}/>
+                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<BloodPressureData>} />
                 )}
 
                 {this.state.needRaceAnswer && (

--- a/src/features/assessment/StartAssessment.tsx
+++ b/src/features/assessment/StartAssessment.tsx
@@ -16,7 +16,7 @@ export default class StartAssessmentScreen extends Component<StartAssessmentProp
     const currentPatient = this.props.route.params.currentPatient;
     const assessmentId = this.props.route.params.assessmentId ?? null;
 
-    if (currentPatient.hasCompletePatientDetails) {
+    if (currentPatient.hasCompletedPatientDetails) {
       if (currentPatient.shouldAskLevelOfIsolation) {
         this.props.navigation.replace('LevelOfIsolation', { currentPatient, assessmentId });
       } else {

--- a/src/features/assessment/StartAssessment.tsx
+++ b/src/features/assessment/StartAssessment.tsx
@@ -17,7 +17,9 @@ export default class StartAssessmentScreen extends Component<StartAssessmentProp
     const assessmentId = this.props.route.params.assessmentId ?? null;
 
     if (currentPatient.hasCompletedPatientDetails) {
-      if (currentPatient.shouldAskLevelOfIsolation) {
+      if (currentPatient.hasRaceAnswer && currentPatient.hasBloodPressureAnswer) {
+        this.props.navigation.replace('ProfileBackDate', { currentPatient });
+      } else if (currentPatient.shouldAskLevelOfIsolation) {
         this.props.navigation.replace('LevelOfIsolation', { currentPatient, assessmentId });
       } else {
         // Everything in this block should be replicated in Level Of Isolation navigation for now

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -71,7 +71,12 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
   async startAssessment(patientId: string) {
     const userService = new UserService();
     const currentPatient = await userService.getCurrentPatient(patientId);
-    this.props.navigation.navigate('StartAssessment', { currentPatient });
+
+    if (currentPatient.hasRaceAnswer && currentPatient.hasBloodPressureAnswer) {
+      this.props.navigation.navigate('StartAssessment', { currentPatient });
+    } else {
+      this.props.navigation.navigate('ProfileBackDate', { currentPatient });
+    }
   }
 
   getNextAvatarName() {

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -71,12 +71,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
   async startAssessment(patientId: string) {
     const userService = new UserService();
     const currentPatient = await userService.getCurrentPatient(patientId);
-
-    if (currentPatient.hasRaceAnswer && currentPatient.hasBloodPressureAnswer) {
-      this.props.navigation.navigate('StartAssessment', { currentPatient });
-    } else {
-      this.props.navigation.navigate('ProfileBackDate', { currentPatient });
-    }
+    this.props.navigation.navigate('StartAssessment', { currentPatient });
   }
 
   getNextAvatarName() {

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -17,7 +17,7 @@ import UserService, { isUSCountry } from '../../core/user/UserService';
 import { PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import { ScreenParamList } from '../ScreenParamList';
-import {RaceEthnicityQuestion} from "./fields/RaceEthnicityQuestion";
+import {RaceEthnicityData, RaceEthnicityQuestion} from "./fields/RaceEthnicityQuestion";
 
 const initialFormValues = {
   yearOfBirth: '',
@@ -44,7 +44,7 @@ const initialFormValues = {
   ethnicity: '',
 };
 
-export interface AboutYouData {
+export interface AboutYouData extends RaceEthnicityData {
   yearOfBirth: string;
   sex: string;
   genderIdentity: string;
@@ -364,7 +364,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                   <RaceEthnicityQuestion
                     showRaceQuestion={this.state.showRaceQuestion}
                     showEthnicityQuestion={this.state.showEthnicityQuestion}
-                    formikProps={props}
+                    formikProps={props as FormikProps<RaceEthnicityData>}
                   />
 
                   <FieldWrapper>

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -6,8 +6,6 @@ import { Form, Icon, Item, Label, Picker, Text } from 'native-base';
 import React, { Component } from 'react';
 import { KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native';
 import * as Yup from 'yup';
-
-import { CheckboxItem, CheckboxList } from '../../components/Checkbox';
 import DropdownField from '../../components/DropdownField';
 import { GenericTextField } from '../../components/GenericTextField';
 import ProgressStatus from '../../components/ProgressStatus';
@@ -19,6 +17,7 @@ import UserService, { isUSCountry } from '../../core/user/UserService';
 import { PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import { ScreenParamList } from '../ScreenParamList';
+import {RaceEthnicityQuestion} from "./fields/RaceEthnicityQuestion";
 
 const initialFormValues = {
   yearOfBirth: '',
@@ -45,7 +44,7 @@ const initialFormValues = {
   ethnicity: '',
 };
 
-interface AboutYouData {
+export interface AboutYouData {
   yearOfBirth: string;
   sex: string;
   genderIdentity: string;
@@ -71,11 +70,6 @@ interface AboutYouData {
   raceOther: string;
   ethnicity: string;
 }
-
-type RaceCheckBoxData = {
-  label: string;
-  value: string;
-};
 
 type AboutYouProps = {
   navigation: StackNavigationProp<ScreenParamList, 'AboutYou'>;
@@ -291,27 +285,6 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
       { label: i18n.t('exposed-no'), value: 'no' },
     ];
 
-    const createRaceCheckboxes = (data: RaceCheckBoxData[], props: FormikProps<AboutYouData>) => {
-      return data.map((checkBoxData) => {
-        return (
-          <CheckboxItem
-            key={checkBoxData.value}
-            value={props.values.race.includes(checkBoxData.value)}
-            onChange={(checked: boolean) => {
-              let raceArray = props.values.race;
-              if (checked) {
-                raceArray.push(checkBoxData.value);
-              } else {
-                raceArray = raceArray.filter((val) => val != checkBoxData.value);
-              }
-              props.setFieldValue('race', raceArray);
-            }}>
-            {checkBoxData.label}
-          </CheckboxItem>
-        );
-      });
-    };
-
     const getInitialFormValues = () => {
       const userService = new UserService();
       const features = userService.getConfig();
@@ -388,58 +361,11 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                     />
                   )}
 
-                  {this.state.showRaceQuestion && (
-                    <FieldWrapper>
-                      <Item stackedLabel style={styles.textItemStyle}>
-                        <Label>{i18n.t('race-question')}</Label>
-                        <CheckboxList>{createRaceCheckboxes(UKRaceCheckboxes, props)}</CheckboxList>
-                      </Item>
-                    </FieldWrapper>
-                  )}
-
-                  {this.state.showEthnicityQuestion && (
-                    <FieldWrapper>
-                      <Item stackedLabel style={styles.textItemStyle}>
-                        <Label>{i18n.t('race-question')}</Label>
-                        <CheckboxList>{createRaceCheckboxes(USRaceCheckboxes, props)}</CheckboxList>
-                      </Item>
-                    </FieldWrapper>
-                  )}
-
-                  {props.values.race.includes('other') && (
-                    <GenericTextField formikProps={props} label={i18n.t('race-other-question')} name="raceOther" />
-                  )}
-
-                  {isUSCountry() && (
-                    <FieldWrapper>
-                      <Item stackedLabel style={styles.textItemStyle}>
-                        <Label>{i18n.t('ethnicity-question')}</Label>
-                        <CheckboxList>
-                          <CheckboxItem
-                            value={props.values.ethnicity == 'hispanic'}
-                            onChange={(value: boolean) => {
-                              props.setFieldValue('ethnicity', value ? 'hispanic' : '');
-                            }}>
-                            {i18n.t('hispanic')}
-                          </CheckboxItem>
-                          <CheckboxItem
-                            value={props.values.ethnicity == 'not_hispanic'}
-                            onChange={(value: boolean) => {
-                              props.setFieldValue('ethnicity', value ? 'not_hispanic' : '');
-                            }}>
-                            {i18n.t('not-hispanic')}
-                          </CheckboxItem>
-                          <CheckboxItem
-                            value={props.values.ethnicity == 'prefer_not_to_say'}
-                            onChange={(value: boolean) => {
-                              props.setFieldValue('ethnicity', value ? 'prefer_not_to_say' : '');
-                            }}>
-                            {i18n.t('prefer-not-to-say')}
-                          </CheckboxItem>
-                        </CheckboxList>
-                      </Item>
-                    </FieldWrapper>
-                  )}
+                  <RaceEthnicityQuestion
+                    showRaceQuestion={this.state.showRaceQuestion}
+                    showEthnicityQuestion={this.state.showEthnicityQuestion}
+                    formikProps={props}
+                  />
 
                   <FieldWrapper>
                     <Item stackedLabel style={styles.textItemStyle}>
@@ -731,28 +657,6 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
     );
   }
 }
-
-const UKRaceCheckboxes = [
-  { label: i18n.t('uk-asian'), value: 'uk_asian' },
-  { label: i18n.t('uk-black'), value: 'uk_black' },
-  { label: i18n.t('uk-mixed-white-black'), value: 'uk_mixed_white_black' },
-  { label: i18n.t('uk-mixed-other'), value: 'uk_mixed_other' },
-  { label: i18n.t('uk-white'), value: 'uk_white' },
-  { label: i18n.t('uk-chinese'), value: 'uk_chinese' },
-  { label: i18n.t('uk-middle-eastern'), value: 'uk_middle_eastern' },
-  { label: i18n.t('uk-other'), value: 'other' },
-  { label: i18n.t('prefer-not-to-say'), value: 'prefer_not_to_say' },
-];
-
-const USRaceCheckboxes = [
-  { label: i18n.t('us-indian_native'), value: 'us_indian_native' },
-  { label: i18n.t('us-asian'), value: 'us_asian' },
-  { label: i18n.t('us-black'), value: 'us_black' },
-  { label: i18n.t('us-hawaiian_pacific'), value: 'us_hawaiian_pacific' },
-  { label: i18n.t('us-white'), value: 'us_white' },
-  { label: i18n.t('us-other'), value: 'other' },
-  { label: i18n.t('prefer-not-to-say'), value: 'prefer_not_to_say' },
-];
 
 const styles = StyleSheet.create({
   fieldRow: {

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -39,9 +39,6 @@ const initialFormValues = {
   needsHelp: 'no',
   helpAvailable: 'no',
   mobilityAid: 'no',
-  race: [] as string[],
-  raceOther: '',
-  ethnicity: '',
 };
 
 export interface AboutYouData extends RaceEthnicityData {
@@ -66,9 +63,6 @@ export interface AboutYouData extends RaceEthnicityData {
   needsHelp: string;
   helpAvailable: string;
   mobilityAid: string;
-  race: string[];
-  raceOther: string;
-  ethnicity: string;
 }
 
 type AboutYouProps = {
@@ -289,11 +283,12 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
       const userService = new UserService();
       const features = userService.getConfig();
 
-      return cloneDeep({
+      return{
         ...initialFormValues,
         heightUnit: features.defaultHeightUnit,
         weightUnit: features.defaultWeightUnit,
-      });
+        ...RaceEthnicityQuestion.initialFormValues()
+      };
     };
 
     return (

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -115,7 +115,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
     userService
       .updatePatient(patientId, infos)
       .then((response) => {
-        currentPatient.hasCompletePatientDetails = true;
+        currentPatient.hasCompletedPatientDetails = true;
         currentPatient.hasBloodPressureAnswer = true;
 
         this.props.navigation.navigate('PreviousExposure', { currentPatient });

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Formik } from 'formik';
+import {Formik, FormikProps} from 'formik';
 import { Form } from 'native-base';
 import React, { Component } from 'react';
 import { KeyboardAvoidingView, Platform } from 'react-native';
@@ -17,8 +17,9 @@ import { PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import { stripAndRound } from '../../utils/helpers';
 import { ScreenParamList } from '../ScreenParamList';
+import {BloodPressureMedicationQuestion} from "./fields/BloodPressureMedicationQuestion";
 
-interface YourHealthData {
+export interface YourHealthData {
   isPregnant: string;
   hasHeartDisease: string;
   hasDiabetes: string;
@@ -327,27 +328,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
                     label={i18n.t('your-health.takes-nsaids')}
                   />
 
-                  <DropdownField
-                    selectedValue={props.values.takesAnyBloodPressureMedications}
-                    onValueChange={props.handleChange('takesAnyBloodPressureMedications')}
-                    label={i18n.t('your-health.takes-any-blood-pressure-medication')}
-                  />
-
-                  {props.values.takesAnyBloodPressureMedications === 'yes' && (
-                    <>
-                      <DropdownField
-                        selectedValue={props.values.takesBloodPressureMedications}
-                        onValueChange={props.handleChange('takesBloodPressureMedications')}
-                        label={i18n.t('your-health.takes-pril-blood-pressure-medication')}
-                      />
-
-                      <DropdownField
-                        selectedValue={props.values.takesBloodPressureMedicationsSartan}
-                        onValueChange={props.handleChange('takesBloodPressureMedicationsSartan')}
-                        label={i18n.t('your-health.takes-sartan-blood-pressure-medication')}
-                      />
-                    </>
-                  )}
+                  <BloodPressureMedicationQuestion formikProps={props}/>
 
                   <ErrorText>{this.state.errorMessage}</ErrorText>
                   {!!Object.keys(props.errors).length && <ValidationErrors errors={props.errors as string[]} />}

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -17,9 +17,9 @@ import { PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import { stripAndRound } from '../../utils/helpers';
 import { ScreenParamList } from '../ScreenParamList';
-import {BloodPressureMedicationQuestion} from "./fields/BloodPressureMedicationQuestion";
+import {BloodPressureData, BloodPressureMedicationQuestion} from "./fields/BloodPressureMedicationQuestion";
 
-export interface YourHealthData {
+export interface YourHealthData extends BloodPressureData {
   isPregnant: string;
   hasHeartDisease: string;
   hasDiabetes: string;
@@ -328,7 +328,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
                     label={i18n.t('your-health.takes-nsaids')}
                   />
 
-                  <BloodPressureMedicationQuestion formikProps={props}/>
+                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<BloodPressureData>}/>
 
                   <ErrorText>{this.state.errorMessage}</ErrorText>
                   {!!Object.keys(props.errors).length && <ValidationErrors errors={props.errors as string[]} />}

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import {Formik, FormikProps} from 'formik';
+import { Formik, FormikProps } from 'formik';
 import { Form } from 'native-base';
 import React, { Component } from 'react';
 import { KeyboardAvoidingView, Platform } from 'react-native';
@@ -17,9 +17,9 @@ import { PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import { stripAndRound } from '../../utils/helpers';
 import { ScreenParamList } from '../ScreenParamList';
-import {BloodPressureData, BloodPressureMedicationQuestion} from "./fields/BloodPressureMedicationQuestion";
+import { BloodPressureData, BloodPressureMedicationQuestion } from './fields/BloodPressureMedicationQuestion';
 
-export interface YourHealthData extends BloodPressureData {
+export interface YourHealthData extends BloodPressureData{
   isPregnant: string;
   hasHeartDisease: string;
   hasDiabetes: string;
@@ -35,9 +35,6 @@ export interface YourHealthData extends BloodPressureData {
   takesImmunosuppressants: string;
   takesAspirin: string;
   takesCorticosteroids: string;
-  takesBloodPressureMedications: string; // pril
-  takesAnyBloodPressureMedications: string;
-  takesBloodPressureMedicationsSartan: string;
 
   limitedActivity: string;
 }
@@ -58,10 +55,7 @@ const initialFormValues = {
   takesImmunosuppressants: 'no',
   takesCorticosteroids: 'no',
   takesAspirin: 'no',
-  takesBloodPressureMedications: 'no', // pril
-  takesAnyBloodPressureMedications: 'no',
-  takesBloodPressureMedicationsSartan: 'no',
-
+  
   limitedActivity: 'no',
 };
 
@@ -210,7 +204,10 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
         </ProgressBlock>
 
         <Formik
-          initialValues={initialFormValues}
+          initialValues={{
+            ...initialFormValues,
+            ...BloodPressureMedicationQuestion.initialFormValues(),
+          }}
           validationSchema={this.registerSchema}
           onSubmit={(values: YourHealthData) => {
             return this.handleUpdateHealth(values);
@@ -328,7 +325,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
                     label={i18n.t('your-health.takes-nsaids')}
                   />
 
-                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<BloodPressureData>}/>
+                  <BloodPressureMedicationQuestion formikProps={props as FormikProps<BloodPressureData>} />
 
                   <ErrorText>{this.state.errorMessage}</ErrorText>
                   {!!Object.keys(props.errors).length && <ValidationErrors errors={props.errors as string[]} />}

--- a/src/features/patient/fields/BloodPressureMedicationQuestion.tsx
+++ b/src/features/patient/fields/BloodPressureMedicationQuestion.tsx
@@ -3,12 +3,11 @@ import { View } from 'react-native';
 import i18n from '../../../locale/i18n';
 import { FormikProps } from 'formik';
 import DropdownField from '../../../components/DropdownField';
-import {YourHealthData} from "../YourHealthScreen";
 
 export interface BloodPressureData {
-    takesBloodPressureMedications: string; // pril
-    takesAnyBloodPressureMedications: string;
-    takesBloodPressureMedicationsSartan: string;
+  takesBloodPressureMedications: string; // pril
+  takesAnyBloodPressureMedications: string;
+  takesBloodPressureMedicationsSartan: string;
 }
 
 interface Props {
@@ -16,6 +15,15 @@ interface Props {
 }
 
 export class BloodPressureMedicationQuestion extends Component<Props, {}> {
+
+  static initialFormValues = () => {
+    return {
+      takesBloodPressureMedications: 'no', // pril
+      takesAnyBloodPressureMedications: 'no',
+      takesBloodPressureMedicationsSartan: 'no',
+    };
+  };
+
   render() {
     return (
       <View>
@@ -24,7 +32,8 @@ export class BloodPressureMedicationQuestion extends Component<Props, {}> {
           onValueChange={this.props.formikProps.handleChange('takesAnyBloodPressureMedications')}
           label={i18n.t('your-health.takes-any-blood-pressure-medication')}
           error={
-            this.props.formikProps.touched.takesAnyBloodPressureMedications && this.props.formikProps.errors.takesAnyBloodPressureMedications
+            this.props.formikProps.touched.takesAnyBloodPressureMedications &&
+            this.props.formikProps.errors.takesAnyBloodPressureMedications
           }
           androidDefaultLabel={i18n.t('label-chose-an-option')}
         />

--- a/src/features/patient/fields/BloodPressureMedicationQuestion.tsx
+++ b/src/features/patient/fields/BloodPressureMedicationQuestion.tsx
@@ -5,8 +5,14 @@ import { FormikProps } from 'formik';
 import DropdownField from '../../../components/DropdownField';
 import {YourHealthData} from "../YourHealthScreen";
 
+export interface BloodPressureData {
+    takesBloodPressureMedications: string; // pril
+    takesAnyBloodPressureMedications: string;
+    takesBloodPressureMedicationsSartan: string;
+}
+
 interface Props {
-  formikProps: FormikProps<YourHealthData>;
+  formikProps: FormikProps<BloodPressureData>;
 }
 
 export class BloodPressureMedicationQuestion extends Component<Props, {}> {

--- a/src/features/patient/fields/BloodPressureMedicationQuestion.tsx
+++ b/src/features/patient/fields/BloodPressureMedicationQuestion.tsx
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import i18n from '../../../locale/i18n';
+import { FormikProps } from 'formik';
+import DropdownField from '../../../components/DropdownField';
+import {YourHealthData} from "../YourHealthScreen";
+
+interface Props {
+  formikProps: FormikProps<YourHealthData>;
+}
+
+export class BloodPressureMedicationQuestion extends Component<Props, {}> {
+  render() {
+    return (
+      <View>
+        <DropdownField
+          selectedValue={this.props.formikProps.values.takesAnyBloodPressureMedications}
+          onValueChange={this.props.formikProps.handleChange('takesAnyBloodPressureMedications')}
+          label={i18n.t('your-health.takes-any-blood-pressure-medication')}
+          error={
+            this.props.formikProps.touched.takesAnyBloodPressureMedications && this.props.formikProps.errors.takesAnyBloodPressureMedications
+          }
+          androidDefaultLabel={i18n.t('label-chose-an-option')}
+        />
+
+        {this.props.formikProps.values.takesAnyBloodPressureMedications === 'yes' && (
+          <>
+            <DropdownField
+              selectedValue={this.props.formikProps.values.takesBloodPressureMedications}
+              onValueChange={this.props.formikProps.handleChange('takesBloodPressureMedications')}
+              label={i18n.t('your-health.takes-pril-blood-pressure-medication')}
+            />
+
+            <DropdownField
+              selectedValue={this.props.formikProps.values.takesBloodPressureMedicationsSartan}
+              onValueChange={this.props.formikProps.handleChange('takesBloodPressureMedicationsSartan')}
+              label={i18n.t('your-health.takes-sartan-blood-pressure-medication')}
+            />
+          </>
+        )}
+      </View>
+    );
+  }
+}

--- a/src/features/patient/fields/RaceEthnicityQuestion.tsx
+++ b/src/features/patient/fields/RaceEthnicityQuestion.tsx
@@ -1,4 +1,4 @@
-import {Item, Label } from 'native-base';
+import { Item, Label } from 'native-base';
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 import i18n from '../../../locale/i18n';
@@ -7,7 +7,6 @@ import { GenericTextField } from '../../../components/GenericTextField';
 import { isUSCountry } from '../../../core/user/UserService';
 import { FormikProps } from 'formik';
 import { FieldWrapper } from '../../../components/Screen';
-import { AboutYouData } from '../AboutYouScreen';
 
 export interface RaceEthnicityData {
   race: string[];
@@ -70,6 +69,15 @@ const createRaceCheckboxes = (data: RaceCheckBoxData[], props: FormikProps<RaceE
 };
 
 export class RaceEthnicityQuestion extends Component<RaceEthnicityQuestionProps, {}> {
+
+  static initialFormValues = () => {
+    return {
+      race: [] as string[],
+      raceOther: '',
+      ethnicity: '',
+    };
+  };
+
   render() {
     return (
       <View>

--- a/src/features/patient/fields/RaceEthnicityQuestion.tsx
+++ b/src/features/patient/fields/RaceEthnicityQuestion.tsx
@@ -1,0 +1,135 @@
+import {Item, Label } from 'native-base';
+import React, { Component } from 'react';
+import { StyleSheet, View } from 'react-native';
+import i18n from '../../../locale/i18n';
+import { CheckboxItem, CheckboxList } from '../../../components/Checkbox';
+import { GenericTextField } from '../../../components/GenericTextField';
+import { isUSCountry } from '../../../core/user/UserService';
+import { FormikProps } from 'formik';
+import { FieldWrapper } from '../../../components/Screen';
+import { AboutYouData } from '../AboutYouScreen';
+
+interface RaceEthnicityQuestionProps {
+  showRaceQuestion: Boolean;
+  showEthnicityQuestion: Boolean;
+  formikProps: FormikProps<AboutYouData>;
+}
+
+type RaceCheckBoxData = {
+  label: string;
+  value: string;
+};
+
+const UKRaceCheckboxes = [
+  { label: i18n.t('uk-asian'), value: 'uk_asian' },
+  { label: i18n.t('uk-black'), value: 'uk_black' },
+  { label: i18n.t('uk-mixed-white-black'), value: 'uk_mixed_white_black' },
+  { label: i18n.t('uk-mixed-other'), value: 'uk_mixed_other' },
+  { label: i18n.t('uk-white'), value: 'uk_white' },
+  { label: i18n.t('uk-chinese'), value: 'uk_chinese' },
+  { label: i18n.t('uk-middle-eastern'), value: 'uk_middle_eastern' },
+  { label: i18n.t('uk-other'), value: 'other' },
+  { label: i18n.t('prefer-not-to-say'), value: 'prefer_not_to_say' },
+];
+
+const USRaceCheckboxes = [
+  { label: i18n.t('us-indian_native'), value: 'us_indian_native' },
+  { label: i18n.t('us-asian'), value: 'us_asian' },
+  { label: i18n.t('us-black'), value: 'us_black' },
+  { label: i18n.t('us-hawaiian_pacific'), value: 'us_hawaiian_pacific' },
+  { label: i18n.t('us-white'), value: 'us_white' },
+  { label: i18n.t('us-other'), value: 'other' },
+  { label: i18n.t('prefer-not-to-say'), value: 'prefer_not_to_say' },
+];
+
+const createRaceCheckboxes = (data: RaceCheckBoxData[], props: FormikProps<AboutYouData>) => {
+  return data.map((checkBoxData) => {
+    return (
+      <CheckboxItem
+        key={checkBoxData.value}
+        value={props.values.race.includes(checkBoxData.value)}
+        onChange={(checked: boolean) => {
+          let raceArray = props.values.race;
+          if (checked) {
+            raceArray.push(checkBoxData.value);
+          } else {
+            raceArray = raceArray.filter((val) => val != checkBoxData.value);
+          }
+          props.setFieldValue('race', raceArray);
+        }}>
+        {checkBoxData.label}
+      </CheckboxItem>
+    );
+  });
+};
+
+export class RaceEthnicityQuestion extends Component<RaceEthnicityQuestionProps, {}> {
+  render() {
+    return (
+      <View>
+        {this.props.showRaceQuestion && (
+          <FieldWrapper>
+            <Item stackedLabel style={styles.textItemStyle}>
+              <Label>{i18n.t('race-question')}</Label>
+              <CheckboxList>{createRaceCheckboxes(UKRaceCheckboxes, this.props.formikProps)}</CheckboxList>
+            </Item>
+          </FieldWrapper>
+        )}
+
+        {this.props.showEthnicityQuestion && (
+          <FieldWrapper>
+            <Item stackedLabel style={styles.textItemStyle}>
+              <Label>{i18n.t('race-question')}</Label>
+              <CheckboxList>{createRaceCheckboxes(USRaceCheckboxes, this.props.formikProps)}</CheckboxList>
+            </Item>
+          </FieldWrapper>
+        )}
+
+        {this.props.formikProps.values.race.includes('other') && (
+          <GenericTextField
+            formikProps={this.props.formikProps}
+            label={i18n.t('race-other-question')}
+            name="raceOther"
+          />
+        )}
+
+        {isUSCountry() && (
+          <FieldWrapper>
+            <Item stackedLabel style={styles.textItemStyle}>
+              <Label>{i18n.t('ethnicity-question')}</Label>
+              <CheckboxList>
+                <CheckboxItem
+                  value={this.props.formikProps.values.ethnicity == 'hispanic'}
+                  onChange={(value: boolean) => {
+                    this.props.formikProps.setFieldValue('ethnicity', value ? 'hispanic' : '');
+                  }}>
+                  {i18n.t('hispanic')}
+                </CheckboxItem>
+                <CheckboxItem
+                  value={this.props.formikProps.values.ethnicity == 'not_hispanic'}
+                  onChange={(value: boolean) => {
+                    this.props.formikProps.setFieldValue('ethnicity', value ? 'not_hispanic' : '');
+                  }}>
+                  {i18n.t('not-hispanic')}
+                </CheckboxItem>
+                <CheckboxItem
+                  value={this.props.formikProps.values.ethnicity == 'prefer_not_to_say'}
+                  onChange={(value: boolean) => {
+                    this.props.formikProps.setFieldValue('ethnicity', value ? 'prefer_not_to_say' : '');
+                  }}>
+                  {i18n.t('prefer-not-to-say')}
+                </CheckboxItem>
+              </CheckboxList>
+            </Item>
+          </FieldWrapper>
+        )}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  textItemStyle: {
+    borderColor: 'transparent',
+  },
+});

--- a/src/features/patient/fields/RaceEthnicityQuestion.tsx
+++ b/src/features/patient/fields/RaceEthnicityQuestion.tsx
@@ -9,10 +9,16 @@ import { FormikProps } from 'formik';
 import { FieldWrapper } from '../../../components/Screen';
 import { AboutYouData } from '../AboutYouScreen';
 
+export interface RaceEthnicityData {
+  race: string[];
+  raceOther: string;
+  ethnicity: string;
+}
+
 interface RaceEthnicityQuestionProps {
   showRaceQuestion: Boolean;
   showEthnicityQuestion: Boolean;
-  formikProps: FormikProps<AboutYouData>;
+  formikProps: FormikProps<RaceEthnicityData>;
 }
 
 type RaceCheckBoxData = {
@@ -42,7 +48,7 @@ const USRaceCheckboxes = [
   { label: i18n.t('prefer-not-to-say'), value: 'prefer_not_to_say' },
 ];
 
-const createRaceCheckboxes = (data: RaceCheckBoxData[], props: FormikProps<AboutYouData>) => {
+const createRaceCheckboxes = (data: RaceCheckBoxData[], props: FormikProps<RaceEthnicityData>) => {
   return data.map((checkBoxData) => {
     return (
       <CheckboxItem


### PR DESCRIPTION
# Description

Adds a screen before assessment that will ask the user any profile questions that may have been added to the app after they have already signed up.

Ive moved the blood pressure medication here and added the race/ethnicity question. This involves moving those questions out into their own components and using them in their original screens as well as the new one.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Out of scope and potential follow-up

It seems formik validation for the race question may have gotten broken before this, but it looks like its not working atm. I couldn't see the issue but will look again.
