### PR TITLE
Fix se share link

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,11 +26,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.joinzoe.covid-zoe",
-      "buildNumber": "0.0.28"
+      "buildNumber": "0.0.29"
     },
     "android": {
       "package": "com.joinzoe.covid_zoe",
-      "versionCode": 28,
+      "versionCode": 29,
       "permissions": [],
       "googleServicesFile": "./google-services.json",
       "config": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -427,7 +427,7 @@
   "validation-error-text": "Fyll i eller korrigera informationen ovan: %{info}",
   "validation-error-text-no-info": "Fyll i eller korrigera informationen ovan",
 
-  "website-home": "https://covid.joinzoe.com/",
+  "website-home": "https://covid19app.lu.se/",
   "share-with-friends-message": "Hjälp till att bromsa spridningen av #COVID19 och skydda de som tillhör en riskgrupp genom att själv rapportera dina symtom varje dag, även om du känner dig frisk 🙏. Ladda ned appen",
-  "share-with-friends-url": "https://covid.joinzoe.com/"
+  "share-with-friends-url": "https://covid19app.lu.se/"
 }


### PR DESCRIPTION
# Description

Fix share message link in Sweden to point to Swedish covid website

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
