### PR TITLE
Notch build versions for 2nd build of 0.12

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,11 +26,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.joinzoe.covid-zoe",
-      "buildNumber": "0.0.28"
+      "buildNumber": "0.0.29"
     },
     "android": {
       "package": "com.joinzoe.covid_zoe",
-      "versionCode": 28,
+      "versionCode": 29,
       "permissions": [],
       "googleServicesFile": "./google-services.json",
       "config": {


### PR DESCRIPTION
# Description

Had to do a second build of the app yesterday, so iOS build picked the correct push notification key from expo. This is the app.json used for the second build.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [X] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
