### PR TITLE
[Splash] Show an error dialog when startup info fails to fetch

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
       "ios",
       "android"
     ],
-    "version": "0.12",
+    "version": "0.13",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -26,11 +26,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.joinzoe.covid-zoe",
-      "buildNumber": "0.0.27"
+      "buildNumber": "0.0.28"
     },
     "android": {
       "package": "com.joinzoe.covid_zoe",
-      "versionCode": 27,
+      "versionCode": 28,
       "permissions": [],
       "googleServicesFile": "./google-services.json",
       "config": {

--- a/app.json
+++ b/app.json
@@ -26,11 +26,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.joinzoe.covid-zoe",
-      "buildNumber": "0.0.28"
+      "buildNumber": "0.0.29"
     },
     "android": {
       "package": "com.joinzoe.covid_zoe",
-      "versionCode": 28,
+      "versionCode": 29,
       "permissions": [],
       "googleServicesFile": "./google-services.json",
       "config": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -50,6 +50,13 @@
     "button": "Continue"
   },
 
+  "splash-error": {
+    "title": "Error",
+    "message": "There was a problem while fetching startup information",
+    "primary-action-title": "Try again",
+    "secondary-action-title": "Cancel"
+  },
+
   "welcome": {
     "title": "COVID Symptom Tracker",
     "sign-in": "Sign in",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -429,5 +429,5 @@
 
   "website-home": "https://covid.joinzoe.com/",
   "share-with-friends-message": "Hjälp till att bromsa spridningen av #COVID19 och skydda de som tillhör en riskgrupp genom att själv rapportera dina symtom varje dag, även om du känner dig frisk 🙏. Ladda ned appen",
-  "share-with-friends-url": "https://covid.joinzoe.com/"
+  "share-with-friends-url": "https://covid19app.lu.se/"
 }

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -20,6 +20,13 @@
     "i-agree": "Jag godkänner",
     "back": "Tillbaka"
   },
+
+  "splash-error": {
+    "title": "Fel",
+    "message": "Det uppstod ett fel vid hämtningen av startinformation",
+    "primary-action-title": "Försök igen",
+    "secondary-action-title": "Avbryt"
+  },
   
   "title-about-work": "Om ditt arbete",
   "are-you-healthcare-staff": "Arbetar du inom hälso- och sjukvården (sjukhus, primärvård, kommunal omsorg, privat vård eller omsorg)?",

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -6,6 +6,7 @@ import { colors } from '../../theme';
 import { AsyncStorageService } from '../core/AsyncStorageService';
 import { ApiClientBase } from '../core/user/ApiClientBase';
 import UserService, { isUSCountry } from '../core/user/UserService';
+import i18n from '../../locale/i18n';
 import Navigator from './Navigation';
 import { ScreenParamList } from './ScreenParamList';
 
@@ -37,14 +38,14 @@ export class SplashScreen extends Component<Props, object> {
       this.userService.initCountry(country as string);
     } catch (err) {
       Alert.alert(
-        'Error',
-        'There was a problem while fetching startup information: ' + err.message,
+        i18n.t('splash-error.title'),
+        i18n.t('splash-error.message') + ': ' + err.message,
         [
           {
-            text: 'Cancel',
+            text: i18n.t('splash-error.secondary-action-title'),
             style: 'cancel',
           },
-          { text: 'Try Again', onPress: () => this.bootstrapAsync() },
+          { text: i18n.t('splash-error.primary-action-title'), onPress: () => this.bootstrapAsync() },
         ],
         { cancelable: false }
       );

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -37,16 +37,14 @@ export class SplashScreen extends Component<Props, object> {
       this.userService.initCountry(country as string);
     } catch (err) {
       Alert.alert(
-        "Error",
-        "There was a problem while fetching startup information: " + err.message,
+        'Error',
+        'There was a problem while fetching startup information: ' + err.message,
         [
           {
-            text: "Cancel",
-            style: "cancel"
+            text: 'Cancel',
+            style: 'cancel',
           },
-          { text: "Try Again", 
-            onPress: () => this.bootstrapAsync()
-          }
+          { text: 'Try Again', onPress: () => this.bootstrapAsync() },
         ],
         { cancelable: false }
       );

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -1,6 +1,6 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { Component } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Alert } from 'react-native';
 
 import { colors } from '../../theme';
 import { AsyncStorageService } from '../core/AsyncStorageService';
@@ -36,8 +36,20 @@ export class SplashScreen extends Component<Props, object> {
       country = await this.userService.getUserCountry();
       this.userService.initCountry(country as string);
     } catch (err) {
-      // TODO: how to deal with the user_startup info endpoint failing?
-      // TODO: Trigger Offline handling here? At least show an error
+      Alert.alert(
+        "Error",
+        "There was a problem while fetching startup information: " + err.message,
+        [
+          {
+            text: "Cancel",
+            style: "cancel"
+          },
+          { text: "Try Again", 
+            onPress: () => this.bootstrapAsync()
+          }
+        ],
+        { cancelable: false }
+      );
     }
 
     const { userToken, userId } = await AsyncStorageService.GetStoredData();


### PR DESCRIPTION
# Description

Add an error dialog when we fail to fetch startup info. This should also fix #31 (although it seems we don't show a blank screen anymore). Let me know if you want me to change the wording of the message!

Question: Calling `bootstrapAsync` again shows an error message on the simulator (it seems to be related to changes to the navigator this function makes), but this won't be shown on a prod build. Nevertheless, I was thinking whether we should wait before making changes to navigator, etc?

This is my first time with React Native so apologies in advance for any mistakes!

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device
