### PR TITLE
Strip Down Covid Test Screen

### DIFF
--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -17,10 +17,7 @@ export type PatientStateType = {
   isSameHousehold: boolean;
   shouldAskLevelOfIsolation: boolean;
   shouldAskStudy: boolean;
-
   hasRaceAnswer: boolean;
-  isWaitingForCovidTestResult: boolean;
-  everHadCovidTest: boolean;
 };
 
 const initPatientState = {

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -201,10 +201,6 @@ export default class UserService extends ApiClientBase {
     const consent = await this.getConsentSigned();
     const shouldAskStudy = (isUSCountry() && consent && consent.document === 'US Nurses') || isGBCountry();
 
-    // CovidTestScreen flag
-    const isWaitingForCovidTestResult = patient.is_waiting_for_covid_test_result || false;
-    const everHadCovidTest = patient.ever_had_covid_test || false;
-
     return {
       ...patientState,
       profile,
@@ -217,8 +213,6 @@ export default class UserService extends ApiClientBase {
       isSameHousehold,
       shouldAskLevelOfIsolation,
       shouldAskStudy,
-      isWaitingForCovidTestResult,
-      everHadCovidTest,
     };
   }
 

--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -182,10 +182,6 @@ export type PatientInfosRequest = {
   race_other: string;
   ethnicity: string;
   last_asked_level_of_isolation: Date;
-
-  // Covid test
-  ever_had_covid_test: boolean;
-  is_waiting_for_covid_test_result: boolean;
 };
 
 export type AssessmentInfosRequest = {
@@ -195,12 +191,6 @@ export type AssessmentInfosRequest = {
   //Covid test
   had_covid_test: boolean;
   tested_covid_positive: string;
-
-  covid_test_result: string;
-  covid_test_result_status: string;
-
-  ever_had_covid_test: boolean;
-  had_new_covid_test: boolean;
 
   health_status: string; //'healthy' for healthy as normal, 'not_healthy' for not feeling quite right
   fever: boolean; //defaults to False

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -94,18 +94,19 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
     const patientId = currentPatient.patientId;
 
     const userService = new UserService();
-    const everHadOrNewTest = formData.hasCovidTest === 'yes';
+    const hadCovidTest = formData.hasCovidTest === 'yes';
+    const receivedTestResults = formData.hasCovidPositive === 'yes' || formData.hasCovidPositive === 'no';
     const dateToPost = moment(this.state.date).format('YYYY-MM-DD');
 
     const assessment = {
       patient: patientId,
       had_covid_test: formData.hasCovidTest === 'yes',
-      ...(everHadOrNewTest && { tested_covid_positive: formData.hasCovidPositive }),
-      ...(everHadOrNewTest &&
-        formData.hasCovidPositive !== 'waiting' &&
+      ...(hadCovidTest && { tested_covid_positive: formData.hasCovidPositive }),
+      ...(hadCovidTest &&
+        receivedTestResults &&
         formData.knowsDateOfTest === 'yes' && { date_test_occurred: dateToPost }),
-      ...(everHadOrNewTest &&
-        formData.hasCovidPositive !== 'waiting' &&
+      ...(hadCovidTest &&
+        receivedTestResults &&
         formData.knowsDateOfTest === 'no' && { date_test_occurred_guess: formData.dateTestOccurredGuess }),
     } as Partial<AssessmentInfosRequest>;
 
@@ -139,6 +140,10 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
 
     const registerSchema = Yup.object().shape({
       hasCovidTest: Yup.string(),
+      hasCovidPositive: Yup.string().when('hasCovidTest', {
+        is: 'yes',
+        then: Yup.string().required(),
+      }),
       knowsDateOfTest: Yup.string().when(['hasCovidTest', 'hasCovidPositive'], {
         is: (hasNewTest, hasCovidPositive) => {
           if (isWaitingForCovidTestResult) return false;

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -56,21 +56,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
     this.state = initialState;
   }
 
-  handleUpdatePatientEverHadCovid(patientId: string, formData: CovidTestData) {
-    const userService = new UserService();
-    // Update patient data with has ever had covid test, if answered.
-    if (patientId && formData.hasCovidTest === 'yes') {
-      // Deliberately fire and forget.
-      userService
-        .updatePatient(patientId, {
-          ever_had_covid_test: true,
-        })
-        .catch((err) => {
-          this.setState({ errorMessage: i18n.t('something-went-wrong') });
-        });
-    }
-  }
-
   setDate = (selectedDate: Date) => {
     const stateDate = moment(selectedDate);
     const offset = stateDate.utcOffset();
@@ -103,7 +88,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
       userService
         .addAssessment(assessment)
         .then((response) => {
-          this.handleUpdatePatientEverHadCovid(patientId, formData);
           this.props.navigation.setParams({ assessmentId: response.data.id });
           this.props.navigation.navigate('HowYouFeel', { currentPatient, assessmentId: response.data.id });
         })
@@ -114,7 +98,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
       userService
         .updateAssessment(assessmentId, assessment)
         .then((response) => {
-          this.handleUpdatePatientEverHadCovid(patientId, formData);
           this.props.navigation.navigate('HowYouFeel', { currentPatient, assessmentId });
         })
         .catch((err) => {

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -22,21 +22,16 @@ import { IOption } from '../patient/YourWorkScreen/helpers';
 const initialFormValues = {
   covidTestResult: '',
   hasCovidPositive: '',
-  everHadCovidTest: 'no', //Patient
-
   hasCovidTest: 'no',
   dateTestOccurredGuess: '',
-
   knowsDateOfTest: '', // only for ux logic
 };
 
 interface CovidTestData {
   covidTestResult: string;
   hasCovidPositive: string;
-  everHadCovidTest: string;
   hasCovidTest: string;
   dateTestOccurredGuess: string;
-
   knowsDateOfTest: string; // only for ux logic
 }
 
@@ -64,7 +59,7 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
   handleUpdatePatientEverHadCovid(patientId: string, formData: CovidTestData) {
     const userService = new UserService();
     // Update patient data with has ever had covid test, if answered.
-    if (patientId && (formData.hasCovidTest === 'yes' || formData.everHadCovidTest === 'yes')) {
+    if (patientId && formData.hasCovidTest === 'yes') {
       // Deliberately fire and forget.
       userService
         .updatePatient(patientId, {

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -26,9 +26,6 @@ const initialFormValues = {
 
   hasCovidTest: 'no',
   dateTestOccurredGuess: '',
-  covidTestMechanism: '',
-  covidTestMechanismSpecify: '',
-  covidTestResultStatus: '',
 
   knowsDateOfTest: '', // only for ux logic
 };
@@ -36,12 +33,9 @@ const initialFormValues = {
 interface CovidTestData {
   covidTestResult: string;
   hasCovidPositive: string;
-  covidTestResultStatus: string;
   everHadCovidTest: string;
   hasCovidTest: string;
   dateTestOccurredGuess: string;
-  covidTestMechanism: string;
-  covidTestMechanismSpecify: string;
 
   knowsDateOfTest: string; // only for ux logic
 }
@@ -136,7 +130,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
 
   render() {
     const currentPatient = this.props.route.params.currentPatient;
-    const { isWaitingForCovidTestResult } = currentPatient;
 
     const registerSchema = Yup.object().shape({
       hasCovidTest: Yup.string(),
@@ -146,7 +139,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
       }),
       knowsDateOfTest: Yup.string().when(['hasCovidTest', 'hasCovidPositive'], {
         is: (hasNewTest, hasCovidPositive) => {
-          if (isWaitingForCovidTestResult) return false;
           return hasNewTest === 'yes' && (hasCovidPositive === 'yes' || hasCovidPositive === 'no');
         },
         then: Yup.string().required(),
@@ -170,25 +162,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
       { label: i18n.t('covid-test.picker-waiting'), value: 'waiting' },
     ];
 
-    const covidTestResultItems = [
-      androidOption,
-      { label: i18n.t('picker-no'), value: 'negative' },
-      { label: i18n.t('picker-yes'), value: 'positive' },
-      { label: i18n.t('covid-test.picker-test-failed'), value: 'test_failed' },
-    ].filter(Boolean) as IOption[];
-
-    const covidTestResultStatusItems = [
-      androidOption,
-      { label: i18n.t('picker-yes'), value: 'received' },
-      { label: i18n.t('picker-no'), value: 'waiting' },
-    ].filter(Boolean) as IOption[];
-
-    if (isWaitingForCovidTestResult)
-      covidTestResultStatusItems.push({
-        label: i18n.t('covid-test.picker-never-had-test'),
-        value: 'never_had_test',
-      });
-
     const dateTestOccurredGuessItems = [
       androidOption,
       { label: i18n.t('covid-test.picker-less-than-7-days-ago'), value: 'less_than_7_days_ago' },
@@ -196,15 +169,6 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
       { label: i18n.t('covid-test.picker-over-2-week-ago'), value: 'over_2_week_ago' },
       { label: i18n.t('covid-test.picker-over-3-week-ago'), value: 'over_3_week_ago' },
       { label: i18n.t('covid-test.picker-over-1-month-ago'), value: 'over_1_month_ago' },
-    ].filter(Boolean) as IOption[];
-
-    const covidTestMechanismItems = [
-      androidOption,
-      { label: i18n.t('covid-test.picker-nose-swab'), value: 'nose_swab' },
-      { label: i18n.t('covid-test.picker-throat-swab'), value: 'throat_swab' },
-      { label: i18n.t('covid-test.picker-saliva-sample'), value: 'spit_tube' },
-      { label: i18n.t('covid-test.picker-blood-sample'), value: 'blood_sample' },
-      { label: i18n.t('covid-test.picker-other'), value: 'other' },
     ].filter(Boolean) as IOption[];
 
     return (

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -43,11 +43,15 @@ type CovidProps = {
 type State = {
   errorMessage: string;
   date: Date;
+  today: Date;
 };
+
+const now = moment().add(moment().utcOffset(), 'minutes').toDate();
 
 const initialState: State = {
   errorMessage: '',
-  date: moment().add(moment().utcOffset(), 'minutes').toDate(),
+  date: now,
+  today: now
 };
 
 export default class CovidTestScreen extends Component<CovidProps, State> {
@@ -201,8 +205,8 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
                             <DatePicker
                               defaultDate={this.state.date}
                               minimumDate={new Date(2019, 11, 1)}
-                              maximumDate={this.state.date}
-                              locale="fr-FR"
+                              maximumDate={this.state.today}
+                              locale={i18n.locale}
                               modalTransparent={false}
                               animationType="fade"
                               onDateChange={this.setDate}

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -51,7 +51,7 @@ const now = moment().add(moment().utcOffset(), 'minutes').toDate();
 const initialState: State = {
   errorMessage: '',
   date: now,
-  today: now
+  today: now,
 };
 
 export default class CovidTestScreen extends Component<CovidProps, State> {

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -135,10 +135,11 @@ export default class CovidTestScreen extends Component<CovidProps, State> {
     };
 
     const hasCovidPositiveItems = [
+      androidOption,
       { label: i18n.t('picker-no'), value: 'no' },
       { label: i18n.t('picker-yes'), value: 'yes' },
       { label: i18n.t('covid-test.picker-waiting'), value: 'waiting' },
-    ];
+    ].filter(Boolean) as IOption[];
 
     const dateTestOccurredGuessItems = [
       androidOption,

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -79,6 +79,12 @@ type State = {
   showEthnicityQuestion: boolean;
 };
 
+const checkFormFilled = (props: FormikProps<AboutYouData>) => {
+  if (Object.keys(props.errors).length) return false;
+  if (Object.keys(props.values).length === 0) return false;
+  return true;
+};
+
 const initialState: State = {
   errorMessage: '',
   enableSubmit: true,
@@ -281,7 +287,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
       { label: i18n.t('exposed-no'), value: 'no' },
     ];
 
-    const getInitialFormValues = () => {
+    const getInitialFormValues = (): AboutYouData => {
       const userService = new UserService();
       const features = userService.getConfig();
 
@@ -642,7 +648,10 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                   <ErrorText>{this.state.errorMessage}</ErrorText>
                   {!!Object.keys(props.errors).length && <ValidationErrors errors={props.errors as string[]} />}
 
-                  <BrandedButton onPress={props.handleSubmit} enable={this.state.enableSubmit}>
+                  <BrandedButton
+                    onPress={props.handleSubmit}
+                    enable={checkFormFilled(props)}
+                    hideLoading={!props.isSubmitting}>
                     <Text>{i18n.t('next-question')}</Text>
                   </BrandedButton>
                 </Form>


### PR DESCRIPTION
# Description

This implements a tactical work around that preserves that presents just the key question (i.e the date of the test) that product & researchers need first. The rest of https://github.com/zoe/covid-app/pull/152/files will be adapted into a different flow as requirements have shifted. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

### Test 1:
```
{
    "patient": "be428fa3-043a-41ac-9ca9-f8cb44da1493",
    "had_covid_test": false,
    "version": "1.3.2"
}
```
![Screenshot 2020-04-30 at 21 42 22](https://user-images.githubusercontent.com/7824212/80757881-c9484500-8b2c-11ea-92b2-10eb02f7a90a.png)

### Test 2
```
{
    "patient": "be428fa3-043a-41ac-9ca9-f8cb44da1493",
    "had_covid_test": true,
    "tested_covid_positive": "waiting",
    "version": "1.3.2"
}
```
![Screenshot 2020-04-30 at 21 42 17](https://user-images.githubusercontent.com/7824212/80757913-d49b7080-8b2c-11ea-9f76-1237e2976c11.png)


### Test 3
```json
{
    "patient": "be428fa3-043a-41ac-9ca9-f8cb44da1493",
    "had_covid_test": true,
    "tested_covid_positive": "no",
    "date_test_occurred_guess": "less_than_7_days_ago",
    "version": "1.3.2"
}
```
![Screenshot 2020-04-30 at 21 41 58](https://user-images.githubusercontent.com/7824212/80757858-c0f00a00-8b2c-11ea-95a4-3b514dac0b59.png)
 



### Test 4
```
{
    "patient": "be428fa3-043a-41ac-9ca9-f8cb44da1493",
    "had_covid_test": true,
    "tested_covid_positive": "yes",
    "date_test_occurred": "2020-04-30",
    "version": "1.3.2"
}
```
![Screenshot 2020-04-30 at 21 42 06](https://user-images.githubusercontent.com/7824212/80757943-dfee9c00-8b2c-11ea-9c57-484061dcf138.png)
