### PR TITLE
Stop navigation to back date profile for disabled question on se locale

### DIFF
--- a/src/features/assessment/StartAssessment.tsx
+++ b/src/features/assessment/StartAssessment.tsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 
 import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
+import UserService from '../../core/user/UserService';
 
 type StartAssessmentProps = {
   navigation: StackNavigationProp<ScreenParamList, 'StartAssessment'>;
@@ -16,8 +17,13 @@ export default class StartAssessmentScreen extends Component<StartAssessmentProp
     const currentPatient = this.props.route.params.currentPatient;
     const assessmentId = this.props.route.params.assessmentId ?? null;
 
+    const userService = new UserService();
+    const features = userService.getConfig();
+
     if (currentPatient.hasCompletedPatientDetails) {
-      if (!currentPatient.hasRaceAnswer || !currentPatient.hasBloodPressureAnswer) {
+      if (features.showRaceQuestion && !currentPatient.hasRaceAnswer) {
+        this.props.navigation.replace('ProfileBackDate', { currentPatient });
+      } else if (!currentPatient.hasBloodPressureAnswer) {
         this.props.navigation.replace('ProfileBackDate', { currentPatient });
       } else if (currentPatient.shouldAskLevelOfIsolation) {
         this.props.navigation.replace('LevelOfIsolation', { currentPatient, assessmentId });

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -121,8 +121,9 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
       userService
         .updatePatient(patientId, infos)
         .then((response) => {
-          (currentPatient.isFemale = formData.sex !== 'male'),
-            this.props.navigation.navigate('YourHealth', { currentPatient });
+          currentPatient.hasRaceAnswer = formData.race.length > 0;
+          currentPatient.isFemale = formData.sex !== 'male';
+          this.props.navigation.navigate('YourHealth', { currentPatient });
         })
         .catch((err) => {
           this.setState({ errorMessage: i18n.t('something-went-wrong') });


### PR DESCRIPTION
# Description

Navigation to back date screen was still happening on SE locale for disabled questions.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device