### PR TITLE
replace existing isolation questions

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -336,19 +336,12 @@
 
   "level-of-isolation": {
     "question-level-of-isolation": "How much have you been isolating over the last week?",
-    "question-little-interaction": "In the last week, how often have you been outside, with little interaction with people outside your household (e.g. exercise)?",
-    "question-lots-of-people": "In the last week, how often have you visited somewhere with lots of people (e.g. groceries, public transport, work)?",
-    "question-healthcare-provider": "In the last week, how often have you visited a healthcare provider (e.g. hospital, clinic, dentist, pharmacy)?",
-    "picker-never": "Never",
-    "picker-once": "Once",
-    "picker-twice": "Twice",
-    "picker-three": "3 times",
-    "picker-four": "4 times",
-    "picker-five": "5 times",
-    "picker-six": "6 times",
-    "picker-seven": "7 times",
-    "picker-more-than-seven": "More than 7 times during last week"
-
+    "question-little-interaction": "In the last week, how many times have you been outside, with little interaction with people outside your household (e.g. exercise)?",
+    "question-lots-of-people": "In the last week, how many times have you visited somewhere with lots of people (e.g. groceries, public transport, work)?",
+    "question-healthcare-provider": "In the last week, how many times have you visited a healthcare provider (e.g. hospital, clinic, dentist, pharmacy)?",
+    "placeholder-frequency": "Number of times this occured",
+    "required-answer": "Please indicate the number of times this occured",
+    "correct-answer": "Please correct your answer"
   },
 
   "where-are-you": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -336,10 +336,19 @@
 
   "level-of-isolation": {
     "question-level-of-isolation": "How much have you been isolating over the last week?",
-    "picker-not-left-the-house": "I have not left the house",
-    "picker-rarely-left-the-house": "I rarely leave the house and when I do, I have little interaction with others (e.g. for exercise)",
-    "picker-rarely-left-the-house-but-visited-lots": "I rarely leave the house but had to visit somewhere with lots of people (e.g. hospital/clinic, groceries)",
-    "picker-often-left-the-house": "I have to leave the house often and am in contact with other people (e.g. still working outside the house or using public transport)"
+    "question-little-interaction": "In the last week, how often have you been outside, with little interaction with people outside your household (e.g. exercise)?",
+    "question-lots-of-people": "In the last week, how often have you visited somewhere with lots of people (e.g. groceries, public transport, work)?",
+    "question-healthcare-provider": "In the last week, how often have you visited a healthcare provider (e.g. hospital, clinic, dentist, pharmacy)?",
+    "picker-never": "Never",
+    "picker-once": "Once",
+    "picker-twice": "Twice",
+    "picker-three": "3 times",
+    "picker-four": "4 times",
+    "picker-five": "5 times",
+    "picker-six": "6 times",
+    "picker-seven": "7 times",
+    "picker-more-than-seven": "More than 7 times during last week"
+
   },
 
   "where-are-you": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -346,8 +346,8 @@
     "question-little-interaction": "In the last week, how many times have you been outside, with little interaction with people outside your household (e.g. exercise)?",
     "question-lots-of-people": "In the last week, how many times have you visited somewhere with lots of people (e.g. groceries, public transport, work)?",
     "question-healthcare-provider": "In the last week, how many times have you visited a healthcare provider (e.g. hospital, clinic, dentist, pharmacy)?",
-    "placeholder-frequency": "Number of times this occured",
-    "required-answer": "Please indicate the number of times this occured",
+    "placeholder-frequency": "Number of times this occurred",
+    "required-answer": "Please indicate the number of times this occurred",
     "correct-answer": "Please correct your answer"
   },
 

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -208,10 +208,12 @@
 
   "level-of-isolation": {
       "question-level-of-isolation": "Till vilken grad har du isolerat dig den senaste veckan?",
-      "picker-not-left-the-house": "Jag har inte lämnat min bostad",
-      "picker-rarely-left-the-house": "Jag lämnar sällan bostaden, och när jag gör det har jag mycket lite kontakt med andra (t.ex. går bara ut för att motionera utomhus)",
-      "picker-rarely-left-the-house-but-visited-lots": "Jag lämnar sällan bostaden, men var tvungen att besöka en plats med många personer (t.ex. sjukhus/mottagning, mataffär)",
-      "picker-often-left-the-house": "Jag måste lämna bostaden ofta och har då kontakt med andra människor (t.ex. arbetar fortfarande utanför bostaden eller använder kollektivtrafiken)"
+      "question-little-interaction": "Hur många gånger den senaste veckan har du varit utomhus, och då haft begränsat med umgänge med personer utanför ditt hushåll (t.ex. för att motionera)?",
+      "question-lots-of-people": "Hur många gånger den senaste veckan har du besökt en plats som besöks av många människor (t.ex. mataffär, kollektivtrafik, arbetsplats)?",
+      "question-healthcare-provider": "Hur många gånger den senaste veckan har du besökt en vårdgivare (t.ex. sjukhus, vårdcentral, tandläkare, apotek)?",
+      "placeholder-frequency": "Antal gånger detta inträffade",
+      "required-answer": "Ange hur många gånger detta inträffade",
+      "correct-answer": "Var snäll och granska ditt svar"
   },
 
   "covid-test": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -208,11 +208,11 @@
 
   "level-of-isolation": {
       "question-level-of-isolation": "Till vilken grad har du isolerat dig den senaste veckan?",
-      "question-little-interaction": "Hur många gånger den senaste veckan har du varit utomhus, och då haft begränsat med umgänge med personer utanför ditt hushåll (t.ex. för att motionera)?",
+      "question-little-interaction": "Hur många gånger den senaste veckan har du varit utomhus med begränsad kontakt med personer utanför ditt hushåll (t.ex. för att motionera)?",
       "question-lots-of-people": "Hur många gånger den senaste veckan har du besökt en plats som besöks av många människor (t.ex. mataffär, kollektivtrafik, arbetsplats)?",
       "question-healthcare-provider": "Hur många gånger den senaste veckan har du besökt en vårdgivare (t.ex. sjukhus, vårdcentral, tandläkare, apotek)?",
-      "placeholder-frequency": "Antal gånger detta inträffade",
-      "required-answer": "Ange hur många gånger detta inträffade",
+      "placeholder-frequency": "Antal tillfällen",
+      "required-answer": "Ange antal tillfällen",
       "correct-answer": "Var snäll och granska ditt svar"
   },
 

--- a/src/components/BrandedButton/__tests__/BrandedButton.test.native.tsx
+++ b/src/components/BrandedButton/__tests__/BrandedButton.test.native.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
+
 import { BrandedButton } from '..';
 
 describe('BrandedButton tests', () => {

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+
 import { colors, fontStyles } from '../../theme';
 
 export * from './BrandedButton';

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -24,7 +24,7 @@ const initialFormValues = {
   hasCovidPositive: '',
   hasCovidTest: 'no',
   dateTestOccurredGuess: '',
-  knowsDateOfTest: '', // only for ux logic
+  knowsDateOfTest: 'yes', // only for ux logic
 };
 
 interface CovidTestData {

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -64,9 +64,9 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
 
     return {
       patient: patientId,
-      isolation_little_interaction: parseInt(formData.isolationLittleInteraction),
-      isolation_lots_of_people: parseInt(formData.isolationLotsOfPeople),
-      isolation_healthcare_provider: parseInt(formData.isolationHealthcareProvider),
+      isolation_little_interaction: parseInt(formData.isolationLittleInteraction, 10),
+      isolation_lots_of_people: parseInt(formData.isolationLotsOfPeople, 10),
+      isolation_healthcare_provider: parseInt(formData.isolationHealthcareProvider, 10),
     } as Partial<AssessmentInfosRequest>;
   }
 

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -11,11 +11,11 @@ import DropdownField from '../../components/DropdownField';
 import ProgressStatus from '../../components/ProgressStatus';
 import Screen, { Header, ProgressBlock, FieldWrapper } from '../../components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '../../components/Text';
+import { ValidatedTextInput } from '../../components/ValidatedTextInput';
+import { ValidationError, ValidationErrors } from '../../components/ValidationError';
 import { PatientStateType } from '../../core/patient/PatientState';
 import UserService from '../../core/user/UserService';
 import { AssessmentInfosRequest, PatientInfosRequest } from '../../core/user/dto/UserAPIContracts';
-import { ValidatedTextInput } from '../../components/ValidatedTextInput';
-import { ValidationError, ValidationErrors } from '../../components/ValidationError';
 import i18n from '../../locale/i18n';
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -71,9 +71,21 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
   }
 
   registerSchema = Yup.object().shape({
-    isolationLittleInteraction: Yup.number().required(i18n.t('level-of-isolation.required-answer')).typeError(i18n.t('level-of-isolation.correct-answer')).integer(i18n.t('level-of-isolation.correct-answer')).min(0, i18n.t('level-of-isolation.correct-answer')),
-    isolationLotsOfPeople: Yup.number().required(i18n.t('level-of-isolation.required-answer')).typeError(i18n.t('level-of-isolation.correct-answer')).integer(i18n.t('level-of-isolation.correct-answer')).min(0, i18n.t('level-of-isolation.correct-answer')),
-    isolationHealthcareProvider: Yup.number().required(i18n.t('level-of-isolation.required-answer')).typeError(i18n.t('level-of-isolation.correct-answer')).integer(i18n.t('level-of-isolation.correct-answer')).min(0, i18n.t('level-of-isolation.correct-answer')),
+    isolationLittleInteraction: Yup.number()
+      .required(i18n.t('level-of-isolation.required-answer'))
+      .typeError(i18n.t('level-of-isolation.correct-answer'))
+      .integer(i18n.t('level-of-isolation.correct-answer'))
+      .min(0, i18n.t('level-of-isolation.correct-answer')),
+    isolationLotsOfPeople: Yup.number()
+      .required(i18n.t('level-of-isolation.required-answer'))
+      .typeError(i18n.t('level-of-isolation.correct-answer'))
+      .integer(i18n.t('level-of-isolation.correct-answer'))
+      .min(0, i18n.t('level-of-isolation.correct-answer')),
+    isolationHealthcareProvider: Yup.number()
+      .required(i18n.t('level-of-isolation.required-answer'))
+      .typeError(i18n.t('level-of-isolation.correct-answer'))
+      .integer(i18n.t('level-of-isolation.correct-answer'))
+      .min(0, i18n.t('level-of-isolation.correct-answer')),
   });
 
   private updatePatientsLastAskedDate(currentPatient: PatientStateType) {

--- a/src/features/assessment/StartAssessment.tsx
+++ b/src/features/assessment/StartAssessment.tsx
@@ -2,9 +2,9 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { Component } from 'react';
 
+import UserService from '../../core/user/UserService';
 import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
-import UserService from '../../core/user/UserService';
 
 type StartAssessmentProps = {
   navigation: StackNavigationProp<ScreenParamList, 'StartAssessment'>;


### PR DESCRIPTION
# Description

Change isolation question to capture both level of isolation, and frequency of interactions
Also prevent errors from showing up until user hits submit. 
Translations also included

## On what platform have you tested the change?

- [ ] iOS - Emulator
Unable to test on Android device an emulator so please double check.

## Screenshots

![image](https://user-images.githubusercontent.com/52913482/80929551-c2c40280-8da4-11ea-86df-eac3b5657ee2.png)
![image](https://user-images.githubusercontent.com/52913482/80929557-d2dbe200-8da4-11ea-888d-78817a0cd2de.png)
![image](https://user-images.githubusercontent.com/52913482/80929563-dbccb380-8da4-11ea-99e2-c209f749fc12.png)


## Out of scope and potential follow-up

Use this fix for errors displaying before submit on other pages.
