### PR TITLE
Android Dropdown - create placeholder when selected value not listed

### DIFF
--- a/src/components/DropdownField.tsx
+++ b/src/components/DropdownField.tsx
@@ -31,8 +31,12 @@ const DropdownPicker = (props: DropdownPickerProps) => {
     { label: i18n.t('picker-yes'), value: 'yes' },
   ];
 
-  if (androidDefaultLabel && isAndroid) {
-    items.unshift({ label: androidDefaultLabel, value: '' });
+  if (isAndroid) {
+    if (androidDefaultLabel) {
+      items.unshift({ label: androidDefaultLabel, value: '' });
+    } else if (!items.find((item) => item.value === selectedValue)) {
+      items.unshift({ label: i18n.t('choose-one-of-these-options'), value: selectedValue });
+    }
   }
 
   return (

--- a/src/features/assessment/CovidTestScreen.tsx
+++ b/src/features/assessment/CovidTestScreen.tsx
@@ -24,7 +24,7 @@ const initialFormValues = {
   hasCovidPositive: '',
   hasCovidTest: 'no',
   dateTestOccurredGuess: '',
-  knowsDateOfTest: 'yes', // only for ux logic
+  knowsDateOfTest: '', // only for ux logic
 };
 
 interface CovidTestData {


### PR DESCRIPTION
Dropdown/pickers are inconsistent between iOS and Android. If the selectedValue of the dropdown doesn't match any entries in the dropdown, iOS leaves the displayed item blank / shows a placeholder, but Android defaults to showing the first available item in the dropdown.

This raises an issue that bites us multiple times -- to the user there's a selected item showing, but to the app the selected value isn't that of the item showing. That mismatch leads to confusion where the user is told he needs to pick a value, but he can clearly see one already picked, and leading him to believe the defaulted item isn't selectable, and he must chose another. Or feel like he is stuck on the page and cannot continue.

We had this issue on adding the any blood medication question on the Covid screen. And again on Friday with the "do you know the date of your test".

This PR is to always have Android fall back to a sensible default working state, to align with iOS where possible: when a dropdown is rendered and the selectedValue doesn't match the available list of options, on Android we insert a "placeholder" item of "Please choose..." which then, like iOS, forces the user to select another item from the dropdown.


## On what platform have you tested the change?

- [X] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="883" alt="iOS and Android side-by-side, Android showing a please choose message" src="https://user-images.githubusercontent.com/61784325/80947106-59b1ae80-8de7-11ea-93bf-c3794904b11d.png">

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
