### PR TITLE
Chore/setup fastlane stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
           command: npx expo-cli build:android -t app-bundle --release-channel $RELEASE_CHANNEL --non-interactive --no-publish
           no_output_timeout: 2h
       - run: curl -o fastlane/app.aab "$(npx expo-cli url:apk --non-interactive)"
+      - run: echo "$PLAY_STORE_JSON" | base64 --decode > fastlane/playstore.json
       - run: bundle exec fastlane android $FASTLANE_LANE app_name:$APPCENTER_APP_NAME_ANDROID app_token:$APPCENTER_API_TOKEN
       - store_artifacts:
           path: ~/covid-react/fastlane/app.apk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,9 @@ commands:
           command: npx expo-cli build:ios --release-channel $RELEASE_CHANNEL --non-interactive --no-publish
           no_output_timeout: 2h
       - run: curl -o fastlane/app.ipa "$(npx expo-cli url:ipa --non-interactive)"
+      - run: bundle exec fastlane-credentials add --username $ITUNES_CONNECT_USER --password $ITUNES_CONNECT_PASSWORD
       - run: bundle exec fastlane ios $FASTLANE_LANE app_name:$APPCENTER_APP_NAME_IOS app_token:$APPCENTER_API_TOKEN
+      - run: bundle exec fastlane-credentials remove --username $ITUNES_CONNECT_USER
       - store_artifacts:
           path: ~/covid-react/fastlane/app.ipa
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,8 +37,16 @@ platform :android do
     )
   end
 
-  desc "TODO: Android Stage Channel (AppCenter/Play Store Beta)"
+  desc "Android Stage Channel (Play Store Beta)"
   lane :stage do
+    upload_to_play_store(
+      track: "beta",
+      aab: Dir.pwd + "/app.aab",
+      json_key: Dir.pwd + "/playstore.json",
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
   end
 
   desc "TODO: Android Production Channel (Play Store)"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,8 +14,12 @@ platform :ios do
     )
   end
 
-  desc "TODO: iOS Stage Channel (AppCenter/TestFlight)"
+  desc "iOS Stage Channel (TestFlight)"
   lane :stage do
+    upload_to_testflight(
+      username: ENV["ITUNES_CONNECT_USER"],
+      ipa: Dir.pwd + "/app.ipa",
+    )
   end
 
   desc "TODO: iOS Production Channel (App Store)"


### PR DESCRIPTION
# Description

This PR intends to set the foundations of Beta distribution using TestFlight for iOS and PlayStore Beta for Android.

There's some setup to do on CircleCI before testing this:

### Android
Fastlane uses [Supply](https://docs.fastlane.tools/actions/supply/) to automate deployment to PlayStore. 

You'll need to [collect your Google credentials](https://docs.fastlane.tools/getting-started/android/setup/#collect-your-google-credentials) in order to get publishing access. 
Then you'll have to base64 encode the credentials JSON file and create a new environment variable named `PLAY_STORE_JSON`.

The script will automatically decode this file and use it for authenticating when deploying to PlayStore Beta.

### iOS
Fastlane uses [Pilot](https://docs.fastlane.tools/actions/pilot/) to automate deployment to TestFlight.

You'll need to create two environment variables:
`ITUNES_CONNECT_USER` = your iTunes Connect username
`ITUNES_CONNECT_PASSWORD` = your iTunes Connect password

The script will use the secure `fastlane-credentials` feature to store the user information before publishing, and removing it afterwards for extra security. 

## On what platform have you tested the change?

N/A

## Screenshots

N/A

## Out of scope and potential follow-up

After proper Staging setup, we can move forward to automating production distribution.
Also, we can have a look on automating release notes, etc.
