### PR TITLE
Move login screen to Formik

### DIFF
--- a/mock-server/mockServer.ts
+++ b/mock-server/mockServer.ts
@@ -9,17 +9,23 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
 app.post('/auth/login', (req, res) => {
-  return res.status(200).send({
-    key: 'abc',
-    user: {
-      username: 'testuser@example.com',
-      authorizations: [],
-      patients: ['00000000-0000-0000-0000-000000000000'],
-      pii: '00000000-0000-0000-0000-000000000000',
-      push_tokens: [],
-      country_code: 'GB',
-    },
-  });
+  setTimeout(() => {
+    if (req.body.username === 'invalid@test.com') {
+      return res.status(403).send('Unauthorised');
+    } else {
+      return res.status(200).send({
+        key: 'abc',
+        user: {
+          username: 'testuser@example.com',
+          authorizations: [],
+          patients: ['00000000-0000-0000-0000-000000000000'],
+          pii: '00000000-0000-0000-0000-000000000000',
+          push_tokens: [],
+          country_code: 'GB',
+        },
+      });
+    }
+  }, 1000);
 });
 
 app.post('/auth/password/reset', (req, res) => {

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -43,6 +43,7 @@ const RegisterStartLink: React.FC<PropsType> = ({ navigation }) => {
     </ClickableText>
   );
 };
+
 const initialValues: LoginSubmitProps = {
   username: '',
   password: '',
@@ -52,6 +53,7 @@ export const LoginScreen: React.FC<PropsType> = (props) => {
   const getWelcomeRepeatScreenName = () => {
     return isUSCountry() ? 'WelcomeRepeatUS' : 'WelcomeRepeat';
   };
+
   const registerSchema = Yup.object().shape({
     username: Yup.string()
       .required(i18n.t('create-account.email-required'))
@@ -89,7 +91,12 @@ export const LoginScreen: React.FC<PropsType> = (props) => {
   let passwordInput: any | null = null;
 
   return (
-    <Formik onSubmit={handleLogin} initialValues={initialValues} validationSchema={registerSchema} validateOnBlur>
+    <Formik
+      onSubmit={handleLogin}
+      initialValues={initialValues}
+      validationSchema={registerSchema}
+      validateOnMount
+      validateOnBlur>
       {({ handleSubmit, handleChange, values, ...formikProps }) => {
         return (
           <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
@@ -112,7 +119,9 @@ export const LoginScreen: React.FC<PropsType> = (props) => {
                       blurOnSubmit={false}
                     />
                   </Item>
-                  {formikProps.errors.username && <FieldError>{formikProps.errors.username}</FieldError>}
+                  {formikProps.errors.username && formikProps.touched.username && (
+                    <FieldError>{formikProps.errors.username}</FieldError>
+                  )}
                 </View>
                 <View style={styles.formItem}>
                   <Item style={styles.labelPos} floatingLabel>
@@ -131,7 +140,7 @@ export const LoginScreen: React.FC<PropsType> = (props) => {
               <View>
                 <BrandedButton
                   onPress={() => handleSubmit()}
-                  enable={!formikProps.isSubmitting && !!values.username && !!values.password && formikProps.isValid}
+                  enable={!formikProps.isSubmitting && formikProps.isValid}
                   hideLoading={!formikProps.isSubmitting}>
                   <Text>{i18n.t('login.button')}</Text>
                 </BrandedButton>


### PR DESCRIPTION
# Description

Use @jamesbrooks94 PR https://github.com/zoe/covid-tracker-react-native/pull/148 which fixes #90 

I've updated some of the logic around validation to display errors only after the field is touched. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Screenshot 2020-05-04 at 21 33 11](https://user-images.githubusercontent.com/7824212/81010880-e3e12d80-8e4e-11ea-9429-69b7b1ed606c.png)

## Checklist
- [x] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
