### PR TITLE
Fix Validation on LevelOfIsolationScreen

### DIFF
--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -227,6 +227,10 @@ export type AssessmentInfosRequest = {
   never_used_shortage: string;
   // Allowed values should be defined app side.
   // Can be null
+
+  isolation_little_interaction: number;
+  isolation_lots_of_people: number;
+  isolation_healthcare_provider: number;
 };
 
 export type AssessmentResponse = {

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -42,8 +42,8 @@ type State = {
 };
 
 const checkFormFilled = (props: FormikProps<LevelOfIsolationData>) => {
-  if (Object.keys(props.errors).length) return false;
-  if (Object.keys(props.values).length === 0) return false;
+  if (Object.keys(props.errors).length && props.submitCount > 0) return false;
+  if (Object.keys(props.values).length === 0 && props.submitCount > 0) return false;
   return true;
 };
 
@@ -148,8 +148,6 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
         <Formik
           initialValues={initialFormValues}
           validationSchema={this.registerSchema}
-          validateOnChange={false}
-          validateOnBlur={false}
           onSubmit={(values: LevelOfIsolationData) => {
             return this.handleUpdate(values);
           }}>
@@ -165,12 +163,16 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
                         value={props.values.isolationLittleInteraction}
                         onChangeText={props.handleChange('isolationLittleInteraction')}
                         onBlur={props.handleBlur('isolationLittleInteraction')}
-                        error={props.touched.isolationLittleInteraction && props.errors.isolationLittleInteraction}
+                        error={
+                          props.touched.isolationLittleInteraction &&
+                          props.errors.isolationLittleInteraction &&
+                          props.submitCount > 0
+                        }
                         returnKeyType="next"
                         keyboardType="numeric"
                       />
                     </Item>
-                    {!!props.errors.isolationLittleInteraction && (
+                    {!!props.errors.isolationLittleInteraction && props.submitCount > 0 && (
                       <ValidationError error={props.errors.isolationLittleInteraction} />
                     )}
                   </FieldWrapper>
@@ -183,12 +185,16 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
                         value={props.values.isolationLotsOfPeople}
                         onChangeText={props.handleChange('isolationLotsOfPeople')}
                         onBlur={props.handleBlur('isolationLotsOfPeople')}
-                        error={props.touched.isolationLotsOfPeople && props.errors.isolationLotsOfPeople}
+                        error={
+                          props.touched.isolationLotsOfPeople &&
+                          props.errors.isolationLotsOfPeople &&
+                          props.submitCount > 0
+                        }
                         returnKeyType="next"
                         keyboardType="numeric"
                       />
                     </Item>
-                    {!!props.errors.isolationLotsOfPeople && (
+                    {!!props.errors.isolationLotsOfPeople && props.submitCount > 0 && (
                       <ValidationError error={props.errors.isolationLotsOfPeople} />
                     )}
                   </FieldWrapper>
@@ -201,18 +207,24 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
                         value={props.values.isolationHealthcareProvider}
                         onChangeText={props.handleChange('isolationHealthcareProvider')}
                         onBlur={props.handleBlur('isolationHealthcareProvider')}
-                        error={props.touched.isolationHealthcareProvider && props.errors.isolationHealthcareProvider}
+                        error={
+                          props.touched.isolationHealthcareProvider &&
+                          props.errors.isolationHealthcareProvider &&
+                          props.submitCount > 0
+                        }
                         returnKeyType="next"
                         keyboardType="numeric"
                       />
                     </Item>
-                    {!!props.errors.isolationHealthcareProvider && (
+                    {!!props.errors.isolationHealthcareProvider && props.submitCount > 0 && (
                       <ValidationError error={props.errors.isolationHealthcareProvider} />
                     )}
                   </FieldWrapper>
 
                   <ErrorText>{this.state.errorMessage}</ErrorText>
-                  {!!Object.keys(props.errors).length && <ValidationErrors errors={props.errors as string[]} />}
+                  {!!Object.keys(props.errors).length && props.submitCount > 0 && (
+                    <ValidationErrors errors={props.errors as string[]} />
+                  )}
 
                   <BrandedButton
                     onPress={props.handleSubmit}


### PR DESCRIPTION
# Description

Previously if you submitted once with incorrect, you would then be unable to re-submit, even with correct answers and the BrandedButton's enable prop would be set to `false` but `validationOnChange` and `validationOnBlur` were also set to `false` so would never re-check the input validation.

This PR re-sets `validationOnChange` and `validationOnBlur` to `true`, but only allows validation errors to appear once the CTA Button has been clicked at least once, via Formik's built-in submitCount prop. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="300" alt="Screenshot 2020-05-04 at 21 42 51" src="https://user-images.githubusercontent.com/52913482/81012287-33285d80-8e51-11ea-9787-b89c614b6e70.png"> <img width="300" alt="Screenshot 2020-05-04 at 21 49 50" src="https://user-images.githubusercontent.com/52913482/81012293-358ab780-8e51-11ea-80a9-7e437a0e4354.png">
<img width="300" alt="Screenshot 2020-05-04 at 21 49 32" src="https://user-images.githubusercontent.com/52913482/81012297-36234e00-8e51-11ea-9a6d-18cdc0d250e7.png"> <img width="300" alt="Screenshot 2020-05-04 at 21 43 32" src="https://user-images.githubusercontent.com/52913482/81012298-36bbe480-8e51-11ea-903d-72f35223d8e1.png">

## Checklist
- [ ] I have updated mockServer
I did not need to as mockServer doesn't contain assessment fields.

## Out of scope and potential follow-up

If we're happy with this approach, apply it to existing pages with validation.