### PR TITLE
Condition race and ethnicity validation on needRaceAnswer.

### DIFF
--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -73,11 +73,11 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
       then: Yup.array<string>().min(1, i18n.t('please-select-race')),
     }),
     raceOther: Yup.string().when('race', {
-      is: (val: string[]) => val.includes('other'),
+      is: (val: string[]) => this.state.needRaceAnswer && val.includes('other'),
       then: Yup.string().required(),
     }),
     ethnicity: Yup.string().when([], {
-      is: () => isUSCountry(),
+      is: () => this.state.needRaceAnswer && isUSCountry(),
       then: Yup.string().required(),
     }),
 


### PR DESCRIPTION
# Description

On Backfill screen for US where race/ethnicity has already been populated, the Backfill profile screen blocks on an ethnicity validation. So added a conditional check that the needsRaceAnswer is set along with the rest of the validation.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
