### PR TITLE
Better error message on isolation screen

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -381,7 +381,8 @@
     "question-healthcare-provider": "In the last week, how many times have you visited a healthcare provider (e.g. hospital, clinic, dentist, pharmacy)?",
     "placeholder-frequency": "Number of times this occurred",
     "required-answer": "Please indicate the number of times this occurred",
-    "correct-answer": "Please correct your answer"
+    "correct-answer": "Please correct your answer",
+    "whole-number": "Please enter a whole number"
   },
 
   "where-are-you": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -211,7 +211,8 @@
     "question-healthcare-provider": "Hur många gånger den senaste veckan har du besökt en vårdgivare (t.ex. sjukhus, vårdcentral, tandläkare, apotek)?",
     "placeholder-frequency": "Antal tillfällen",
     "required-answer": "Ange antal tillfällen",
-    "correct-answer": "Var snäll och granska ditt svar"
+    "correct-answer": "Var snäll och granska ditt svar",
+    "whole-number": "Ange ett helt nummer"
   },
 
   "covid-test": {

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -73,18 +73,18 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
   registerSchema = Yup.object().shape({
     isolationLittleInteraction: Yup.number()
       .required(i18n.t('level-of-isolation.required-answer'))
-      .typeError(i18n.t('level-of-isolation.correct-answer'))
-      .integer(i18n.t('level-of-isolation.correct-answer'))
+      .typeError(i18n.t('level-of-isolation.whole-number'))
+      .integer(i18n.t('level-of-isolation.whole-number'))
       .min(0, i18n.t('level-of-isolation.correct-answer')),
     isolationLotsOfPeople: Yup.number()
       .required(i18n.t('level-of-isolation.required-answer'))
-      .typeError(i18n.t('level-of-isolation.correct-answer'))
-      .integer(i18n.t('level-of-isolation.correct-answer'))
+      .typeError(i18n.t('level-of-isolation.whole-number'))
+      .integer(i18n.t('level-of-isolation.whole-number'))
       .min(0, i18n.t('level-of-isolation.correct-answer')),
     isolationHealthcareProvider: Yup.number()
       .required(i18n.t('level-of-isolation.required-answer'))
-      .typeError(i18n.t('level-of-isolation.correct-answer'))
-      .integer(i18n.t('level-of-isolation.correct-answer'))
+      .typeError(i18n.t('level-of-isolation.whole-number'))
+      .integer(i18n.t('level-of-isolation.whole-number'))
       .min(0, i18n.t('level-of-isolation.correct-answer')),
   });
 


### PR DESCRIPTION
# Description

At the moment the error message is unclear if you enter a non-integer answer, vs a negative answer (for whatever reason). Screen shots show with and without main error cases. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/52913482/81218664-76f89f80-8fd6-11ea-8cc6-e44ea0571e71.png) ![image](https://user-images.githubusercontent.com/52913482/81218682-7f50da80-8fd6-11ea-88ce-7e6d42be7fee.png)
