### PR TITLE
remove androidOption from dropdowns

### DIFF
--- a/src/features/assessment/CovidTestDetailScreen.tsx
+++ b/src/features/assessment/CovidTestDetailScreen.tsx
@@ -181,27 +181,20 @@ export default class CovidTestDetailScreen extends Component<CovidProps, State> 
       knowsDateOfTest: Yup.string().required(),
     });
 
-    const androidOption = isAndroid && {
-      label: i18n.t('choose-one-of-these-options'),
-      value: '',
-    };
-
     const mechanismItems = [
-      androidOption,
       { label: i18n.t('covid-test.picker-nose-swab'), value: 'nose_swab' },
       { label: i18n.t('covid-test.picker-throat-swab'), value: 'throat_swab' },
       { label: i18n.t('covid-test.picker-saliva-sample'), value: 'spit_tube' },
       { label: i18n.t('covid-test.picker-blood-sample'), value: 'blood_sample' },
       { label: i18n.t('covid-test.picker-other'), value: 'other' },
-    ].filter(Boolean) as IOption[];
+    ];
 
     const resultItems = [
-      androidOption,
       { label: i18n.t('picker-no'), value: 'negative' },
       { label: i18n.t('picker-yes'), value: 'positive' },
       { label: i18n.t('covid-test.picker-test-failed'), value: 'failed' },
       { label: i18n.t('covid-test.picker-waiting'), value: 'waiting' },
-    ].filter(Boolean) as IOption[];
+    ];
 
     return (
       <Screen profile={currentPatient.profile} navigation={this.props.navigation}>

--- a/src/features/assessment/DescribeSymptomsScreen.tsx
+++ b/src/features/assessment/DescribeSymptomsScreen.tsx
@@ -217,11 +217,6 @@ export default class DescribeSymptomsScreen extends Component<SymptomProps, Stat
   }
 
   render() {
-    const androidOption = isAndroid && {
-      label: i18n.t('choose-one-of-these-options'),
-      value: '',
-    };
-
     const currentPatient = this.props.route.params.currentPatient;
     const temperatureItems = [
       { label: i18n.t('describe-symptoms.picker-celsius'), value: 'C' },
@@ -239,17 +234,15 @@ export default class DescribeSymptomsScreen extends Component<SymptomProps, Stat
       { label: i18n.t('describe-symptoms.picker-shortness-of-breath-severe'), value: 'severe' },
     ];
     const headacheFrequencyItems = [
-      androidOption,
       { label: i18n.t('describe-symptoms.picker-headache-frequency-allday'), value: 'all_of_the_day' },
       { label: i18n.t('describe-symptoms.picker-headache-frequency-mostday'), value: 'most_of_day' },
       { label: i18n.t('describe-symptoms.picker-headache-frequency-someday'), value: 'some_of_day' },
-    ].filter(Boolean) as IOption[];
+    ];
     const diarrhoeaFrequencyItems = [
-      androidOption,
       { label: '1-2', value: 'one_to_two' },
       { label: '3-4', value: 'three_to_four' },
       { label: '5+', value: 'five_or_more' },
-    ].filter(Boolean) as IOption[];
+    ];
 
     return (
       <Screen profile={currentPatient.profile} navigation={this.props.navigation}>

--- a/src/features/patient/YourWorkScreen/index.tsx
+++ b/src/features/patient/YourWorkScreen/index.tsx
@@ -128,13 +128,7 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
   render() {
     const currentPatient = this.props.route.params.currentPatient;
 
-    const androidOption = isAndroid && {
-      label: i18n.t('choose-one-of-these-options'),
-      value: '',
-    };
-
     const healthcareStaffOptions = [
-      androidOption,
       {
         label: i18n.t('picker-no'),
         value: HealthCareStaffOptions.NO,
@@ -147,10 +141,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
         label: i18n.t('yes-not-interacting-patients'),
         value: HealthCareStaffOptions.DOES_NOT_INTERACT,
       },
-    ].filter(Boolean) as IOption[];
+    ];
 
     const equipmentUsageOptions = [
-      androidOption,
       {
         label: i18n.t('health-worker-exposure-picker-ppe-always'),
         value: EquipmentUsageOptions.ALWAYS,
@@ -163,10 +156,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
         label: i18n.t('health-worker-exposure-picker-ppe-never'),
         value: EquipmentUsageOptions.NEVER,
       },
-    ].filter(Boolean) as IOption[];
+    ];
 
     const availabilityAlwaysOptions = [
-      androidOption,
       {
         label: i18n.t('health-worker-exposure-picker-ppe-always-all-needed'),
         value: AvailabilityAlwaysOptions.ALL_NEEDED,
@@ -175,10 +167,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
         label: i18n.t('health-worker-exposure-picker-ppe-always-reused'),
         value: AvailabilityAlwaysOptions.REUSED,
       },
-    ].filter(Boolean) as IOption[];
+    ];
 
     const availabilitySometimesOptions = [
-      androidOption,
       {
         label: i18n.t('health-worker-exposure-picker-ppe-sometimes-all-needed'),
         value: AvailabilitySometimesOptions.ALL_NEEDED,
@@ -191,10 +182,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
         label: i18n.t('health-worker-exposure-picker-ppe-sometimes-reused'),
         value: AvailabilitySometimesOptions.REUSED,
       },
-    ].filter(Boolean) as IOption[];
+    ];
 
     const availabilityNeverOptions = [
-      androidOption,
       {
         label: i18n.t('health-worker-exposure-picker-ppe-never-not-needed'),
         value: AvailabilityNeverOptions.NOT_NEEDED,
@@ -203,10 +193,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
         label: i18n.t('health-worker-exposure-picker-ppe-never-not-available'),
         value: AvailabilityNeverOptions.NOT_AVAILABLE,
       },
-    ].filter(Boolean) as IOption[];
+    ];
 
     const patientInteractionOptions = [
-      androidOption,
       {
         label: i18n.t('exposed-yes-documented'),
         value: PatientInteractions.YES_DOCUMENTED,
@@ -220,7 +209,7 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
         value: PatientInteractions.YES_DOCUMENTED_SUSPECTED,
       },
       { label: i18n.t('exposed-no'), value: PatientInteractions.NO },
-    ].filter(Boolean) as IOption[];
+    ];
 
     return (
       <Screen profile={currentPatient.profile} navigation={this.props.navigation}>


### PR DESCRIPTION
# Description

I've previously fixed the dropdowns so that in Android it automatically gets populated with a "please select" option if the selected value doesn't match an available option item value.
This makes `androidOption` method redundant, so I've removed it from all fields.

## On what platform have you tested the change?

- [X] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="416" alt="Screenshot 2020-05-07 at 14 01 38" src="https://user-images.githubusercontent.com/61784325/81297539-4d3d8800-906b-11ea-9646-7a0d20e3ac85.png">



## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
