### PR TITLE
Remove us optional data screen for normal consent

### DIFF
--- a/src/features/Navigation.ts
+++ b/src/features/Navigation.ts
@@ -136,7 +136,12 @@ const ScreenFlow: any = {
     const { patientId } = routeParams;
     const config = navigator.getConfig();
 
-    if (config.enablePersonalInformation) {
+    let askPersonalInfo = config.enablePersonalInformation;
+    if (isUSCountry() && UserService.consentSigned.document != 'US Nurses') {
+      askPersonalInfo = false;
+    }
+
+    if (askPersonalInfo) {
       await navigator.replaceScreen('OptionalInfo', { patientId });
     } else if (patientId) {
       const currentPatient = await navigator.getCurrentPatient(patientId);

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -66,6 +66,7 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
   handleUSAgreeClicked = async () => {
     if (this.state.processingChecked && this.state.termsOfUseChecked) {
       await this.userService.setConsentSigned('US', consentVersionUS, privacyPolicyVersionUS);
+      UserService.countryConfig.enablePersonalInformation = false;
       this.props.navigation.navigate('Register');
     }
   };

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -66,7 +66,6 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
   handleUSAgreeClicked = async () => {
     if (this.state.processingChecked && this.state.termsOfUseChecked) {
       await this.userService.setConsentSigned('US', consentVersionUS, privacyPolicyVersionUS);
-      UserService.countryConfig.enablePersonalInformation = false;
       this.props.navigation.navigate('Register');
     }
   };


### PR DESCRIPTION
# Description

We want to remove the optional data screen for normal US consent users. This is somewhat of a work around as I am modify the county config on the go, but I think its the simplest way, happy for other suggestions.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device