### PR TITLE
Fix condition Navigation to use the correct countryConfig flag. 

### DIFF
--- a/src/features/Navigation.ts
+++ b/src/features/Navigation.ts
@@ -64,7 +64,7 @@ class Navigator {
 
   async gotoStartReport(patientId: string) {
     const config = this.getConfig();
-    if (config.enablePersonalInformation) {
+    if (config.enableMultiplePatients) {
       navigator.gotoScreen('SelectProfile', { patientId });
     } else {
       const currentPatient = await this.getCurrentPatient(patientId);


### PR DESCRIPTION
# Description

Fix condition Navigation to use the correct countryConfig flag. 

This has no impact> Sweden currently has enablePersonalInformation = False and enableMultiplePatient = False. US and UK have both values set to True. 

However this may not alway be the case.....

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
