### PR TITLE
Add donate module to Thank You Page

### DIFF
--- a/appConfig.ts
+++ b/appConfig.ts
@@ -2,5 +2,5 @@
 import { API_URL } from 'react-native-dotenv';
 
 export default {
-  apiBase: API_URL,
+  apiBase: 'http://062707f9.ngrok.io',
 };

--- a/appConfig.ts
+++ b/appConfig.ts
@@ -2,5 +2,5 @@
 import { API_URL } from 'react-native-dotenv';
 
 export default {
-  apiBase: 'http://062707f9.ngrok.io',
+  apiBase: API_URL,
 };

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -439,8 +439,6 @@
 
   "select-country": "Select country of residence",
   "website-home": "https://covid.joinzoe.com/",
-  "share-with-friends-message": "Help slow the spread of #COVID19 and identify at risk cases sooner by self-reporting your symptoms daily, even if you feel well  🙏. Download the app",
-  "share-with-friends-url": "https://covid.joinzoe.com/",
 
   "title-health-worker-exposure": "Healthcare Worker Exposure to COVID",
   "required-treated-patients-with-covid": "Please indicate whether you've treated any patients with COVID-19 in the last day",
@@ -450,11 +448,16 @@
   "required-ppe-availability-never": "Please indicate the availability of PPE equipment to you",
 
   "thank-you": {
-    "please-share-app": "Please share this app",
-    "share-text": "The more people report their symptoms, the more we can help those at risk.",
-    "btn-share": "Share this app",
     "check-for-updates": "Please check our %{link} for updates.",
     "news-feed": "news feed"
+  },
+
+  "share-this-app": {
+    "message": "Help slow the spread of #COVID19 and identify at risk cases sooner by self-reporting your symptoms daily, even if you feel well 🙏. Download the app",
+    "url": "https://covid.joinzoe.com/",
+    "primary-text": "Please share this app",
+    "secondary-text": "The more people report their symptoms, the more we can help those at risk.",
+    "button-text": "Share this app"
   },
 
   "thank-you-title": "Thank you for your help and vital contribution to the study of COVID-19.",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -460,6 +460,15 @@
     "button-text": "Share this app"
   },
 
+  "donate": {
+    "banner": "URGENT APPEAL",
+    "url": "https://uk.virginmoneygiving.com/charity-web/charity/displayCharityCampaignPage.action?charityCampaignUrl=COVIDSymptomStudy",
+    "primary-text": "Keep the COVID Symptom Study alive",
+    "secondary-text": "Without funding, critical COVID research support the NHS cannot continue. Will you help?",
+    "button-text": "Donate now"
+  },
+
+
   "thank-you-title": "Thank you for your help and vital contribution to the study of COVID-19.",
   "blog-link": "https://covid.joinzoe.com/blog",
   "thank-you-body": "Thank you for joining millions of people supporting scientists at King’s College London to help our health services.",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -421,11 +421,16 @@
   "sweden": "Sverige",
 
   "thank-you": {
-    "please-share-app": "Hjälp till att sprida appen",
-    "share-text": "Ju fler som rapporterar sina symtom, desto bättre kan vi skydda de som riskerar att bli allvarligt sjuka",
-    "btn-share": "Dela appen",
     "check-for-updates": "Håll gärna utkik efter uppdateringar i vårt %{link}.",
     "news-feed": "nyhetsflöde"
+  },
+
+  "share-this-app": {
+    "message": "Hjälp till att bromsa spridningen av #COVID19 och skydda de som tillhör en riskgrupp genom att själv rapportera dina symtom varje dag, även om du känner dig frisk 🙏. Ladda ned appen",
+    "url": "https://covid19app.lu.se/",
+    "primary-text": "Hjälp till att sprida appen",
+    "secondary-text": "Ju fler som rapporterar sina symtom, desto bättre kan vi skydda de som riskerar att bli allvarligt sjuka",
+    "button-text": "Dela appen"
   },
 
   "thank-you-title": "Stort tack för din hjälp och ditt värdefulla bidrag till forskningen.",
@@ -509,8 +514,6 @@
   "validation-error-text-no-info": "Fyll i eller korrigera informationen ovan",
 
   "website-home": "https://covid.joinzoe.com/",
-  "share-with-friends-message": "Hjälp till att bromsa spridningen av #COVID19 och skydda de som tillhör en riskgrupp genom att själv rapportera dina symtom varje dag, även om du känner dig frisk 🙏. Ladda ned appen",
-  "share-with-friends-url": "https://covid19app.lu.se/",
 
   "back-date-profile-title": "Några fler frågor om dig",
   "update-profile": "Uppdatera profilen",

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,8 +1,8 @@
+import { Badge } from 'native-base';
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
 
 import { colors } from '../../theme';
-import { Badge } from 'native-base';
 
 type BadgeProps = {
   children: React.ReactNode;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { colors } from '../../theme';
+import { Badge } from 'native-base';
+
+type BadgeProps = {
+  children: React.ReactNode;
+};
+
+export const CoralBadge: React.FC<BadgeProps> = (props) => (
+  <Badge style={styles.badge}>
+    <Text style={styles.badgeText}>{props.children}</Text>
+  </Badge>
+);
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: 'center',
+    backgroundColor: colors.coral,
+    borderRadius: 5,
+    height: 30,
+    marginBottom: 10,
+  },
+  badgeText: {
+    color: colors.white,
+    paddingHorizontal: 10,
+  },
+});

--- a/src/components/Donate.tsx
+++ b/src/components/Donate.tsx
@@ -2,17 +2,19 @@ import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { colors } from '../../theme';
-import { BrandedButton, HeaderText, RegularBoldText, RegularText, SecondaryText } from '../components/Text';
+import { BrandedButton, HeaderText, RegularBoldText, SecondaryText } from '../components/Text';
 import i18n from '../locale/i18n';
+import { CoralBadge } from './Badge';
+import { Linking } from 'expo';
 
 export default class Donate extends Component {
   render() {
     return (
       <View style={styles.container}>
-        {/*<RegularBoldText style={styles.share}>{i18n.t('donate.banner')}</RegularBoldText>*/}
-        <HeaderText style={styles.primary}>{i18n.t('donate.primary-text')}</HeaderText>
+        <CoralBadge>{i18n.t('donate.banner')}</CoralBadge>
+        <RegularBoldText style={styles.primary}>{i18n.t('donate.primary-text')}</RegularBoldText>
         <SecondaryText style={styles.secondary}>{i18n.t('donate.secondary-text')}</SecondaryText>
-        <BrandedButton onPress={() => {}} style={styles.button}>
+        <BrandedButton onPress={() => Linking.openURL(i18n.t('donate.url'))} style={styles.button}>
           {i18n.t('donate.button-text')}
         </BrandedButton>
       </View>
@@ -30,12 +32,14 @@ const styles = StyleSheet.create({
   },
   primary: {
     textAlign: 'center',
-    marginBottom: 20,
+    fontSize: 20,
+    marginTop: 10,
+    marginBottom: 10,
   },
   secondary: {
     textAlign: 'center',
   },
   button: {
-    marginTop: 30,
+    marginTop: 20,
   },
 });

--- a/src/components/Donate.tsx
+++ b/src/components/Donate.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { colors } from '../../theme';
-import { BrandedButton, HeaderText, RegularBoldText, SecondaryText } from '../components/Text';
+import { BrandedButton, RegularBoldText, SecondaryText } from '../components/Text';
 import i18n from '../locale/i18n';
 import { CoralBadge } from './Badge';
 import { Linking } from 'expo';

--- a/src/components/Donate.tsx
+++ b/src/components/Donate.tsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { colors } from '../../theme';
+import { BrandedButton, HeaderText, RegularBoldText, RegularText, SecondaryText } from '../components/Text';
+import i18n from '../locale/i18n';
+
+export default class Donate extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        {/*<RegularBoldText style={styles.share}>{i18n.t('donate.banner')}</RegularBoldText>*/}
+        <HeaderText style={styles.primary}>{i18n.t('donate.primary-text')}</HeaderText>
+        <SecondaryText style={styles.secondary}>{i18n.t('donate.secondary-text')}</SecondaryText>
+        <BrandedButton onPress={() => {}} style={styles.button}>
+          {i18n.t('donate.button-text')}
+        </BrandedButton>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 30,
+    backgroundColor: colors.white,
+    borderRadius: 10,
+    marginHorizontal: 20,
+    alignContent: 'center',
+  },
+  primary: {
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  secondary: {
+    textAlign: 'center',
+  },
+  button: {
+    marginTop: 30,
+  },
+});

--- a/src/components/ShareThisApp.tsx
+++ b/src/components/ShareThisApp.tsx
@@ -29,12 +29,12 @@ export default class ShareThisApp extends Component<Props> {
 
   render() {
     return (
-      <View style={styles.shareContainer}>
+      <View style={styles.container}>
         <View style={styles.socialIconContainer}>
           <Image source={social} style={styles.socialIcon} />
         </View>
-        <RegularBoldText style={styles.share}>{i18n.t('share-this-app.primary-text')}</RegularBoldText>
-        <RegularText style={styles.shareSubtitle}>{i18n.t('share-this-app.secondary-text')}</RegularText>
+        <RegularBoldText style={styles.primaryText}>{i18n.t('share-this-app.primary-text')}</RegularBoldText>
+        <RegularText style={styles.secondaryText}>{i18n.t('share-this-app.secondary-text')}</RegularText>
         {this.props.ctaStyle === 'button' ? (
           <BrandedButton onPress={this.shareApp} style={styles.shareButton}>
             {i18n.t('share-this-app.button-text')}
@@ -50,16 +50,16 @@ export default class ShareThisApp extends Component<Props> {
 }
 
 const styles = StyleSheet.create({
-  shareContainer: {
+  container: {
     backgroundColor: colors.white,
     borderRadius: 10,
     marginHorizontal: 20,
   },
-  share: {
+  primaryText: {
     fontSize: 20,
     textAlign: 'center',
   },
-  shareSubtitle: {
+  secondaryText: {
     paddingVertical: 10,
     paddingHorizontal: 40,
     textAlign: 'center',

--- a/src/components/ShareThisApp.tsx
+++ b/src/components/ShareThisApp.tsx
@@ -3,11 +3,17 @@ import { Image, Share, StyleSheet, View } from 'react-native';
 
 import { social } from '../../assets';
 import { colors } from '../../theme';
-import { BrandedButton, RegularBoldText, RegularText } from '../components/Text';
+import { BrandedButton, ClickableText, RegularBoldText, RegularText } from '../components/Text';
 import i18n from '../locale/i18n';
 import { isAndroid } from './Screen';
 
-export default class ShareThisApp extends Component {
+type CtaStyles = 'button' | 'link';
+
+type Props = {
+  ctaStyle: CtaStyles;
+};
+
+export default class ShareThisApp extends Component<Props> {
   shareMessage = i18n.t('share-this-app.message');
   shareUrl = i18n.t('share-this-app.url');
 
@@ -29,9 +35,15 @@ export default class ShareThisApp extends Component {
         </View>
         <RegularBoldText style={styles.share}>{i18n.t('share-this-app.primary-text')}</RegularBoldText>
         <RegularText style={styles.shareSubtitle}>{i18n.t('share-this-app.secondary-text')}</RegularText>
-        <BrandedButton onPress={this.shareApp} style={styles.shareButton}>
-          {i18n.t('share-this-app.button-text')}
-        </BrandedButton>
+        {this.props.ctaStyle === 'button' ? (
+          <BrandedButton onPress={this.shareApp} style={styles.shareButton}>
+            {i18n.t('share-this-app.button-text')}
+          </BrandedButton>
+        ) : (
+          <ClickableText onPress={this.shareApp} style={styles.shareLink}>
+            {i18n.t('share-this-app.button-text')}
+          </ClickableText>
+        )}
       </View>
     );
   }
@@ -56,6 +68,12 @@ const styles = StyleSheet.create({
   shareButton: {
     marginVertical: 20,
     marginHorizontal: 30,
+  },
+  shareLink: {
+    marginTop: 5,
+    marginBottom: 20,
+    marginHorizontal: 30,
+    textAlign: 'center',
   },
   socialIconContainer: {
     borderRadius: 10,

--- a/src/components/ShareThisApp.tsx
+++ b/src/components/ShareThisApp.tsx
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import { Image, Share, StyleSheet, View } from 'react-native';
+
+import { social } from '../../assets';
+import { colors } from '../../theme';
+import { BrandedButton, RegularBoldText, RegularText } from '../components/Text';
+import i18n from '../locale/i18n';
+import { isAndroid } from './Screen';
+
+export default class ShareThisApp extends Component {
+  shareMessage = i18n.t('share-this-app.message');
+  shareUrl = i18n.t('share-this-app.url');
+
+  shareApp = async () => {
+    const message = this.shareMessage + (isAndroid ? ' ' + this.shareUrl : ''); // On Android add link to end of message
+    try {
+      await Share.share({
+        message,
+        url: this.shareUrl, // IOS has separate field for URL
+      });
+    } catch (error) {}
+  };
+
+  render() {
+    return (
+      <View style={styles.shareContainer}>
+        <View style={styles.socialIconContainer}>
+          <Image source={social} style={styles.socialIcon} />
+        </View>
+        <RegularBoldText style={styles.share}>{i18n.t('share-this-app.primary-text')}</RegularBoldText>
+        <RegularText style={styles.shareSubtitle}>{i18n.t('share-this-app.secondary-text')}</RegularText>
+        <BrandedButton onPress={this.shareApp} style={styles.shareButton}>
+          {i18n.t('share-this-app.button-text')}
+        </BrandedButton>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  shareContainer: {
+    backgroundColor: colors.white,
+    borderRadius: 10,
+    marginHorizontal: 20,
+  },
+  share: {
+    fontSize: 20,
+    textAlign: 'center',
+  },
+  shareSubtitle: {
+    paddingVertical: 10,
+    paddingHorizontal: 40,
+    textAlign: 'center',
+    color: colors.secondary,
+  },
+  shareButton: {
+    marginVertical: 20,
+    marginHorizontal: 30,
+  },
+  socialIconContainer: {
+    borderRadius: 10,
+    margin: 30,
+    alignSelf: 'center',
+  },
+  socialIcon: {
+    height: 60,
+    marginLeft: 5,
+    marginTop: 5,
+    resizeMode: 'contain',
+  },
+});

--- a/src/components/VisitWebsite.tsx
+++ b/src/components/VisitWebsite.tsx
@@ -1,0 +1,35 @@
+import { Linking } from 'expo';
+import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
+import reactStringReplace from 'react-string-replace';
+
+import { colors } from '../../theme';
+import i18n from '../locale/i18n';
+import { ClickableText, RegularText } from './Text';
+
+export default class VisitWebsite extends Component {
+  render() {
+    return (
+      <ClickableText onPress={() => Linking.openURL(i18n.t('blog-link'))} style={styles.container}>
+        {reactStringReplace(i18n.t('thank-you.check-for-updates', { link: '{{LINK}}' }), '{{LINK}}', (match, i) => (
+          <RegularText key={i} style={styles.linkText}>
+            {i18n.t('thank-you.news-feed')}
+          </RegularText>
+        ))}
+      </ClickableText>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 30,
+    paddingHorizontal: 40,
+    textAlign: 'center',
+    color: colors.primary,
+  },
+  linkText: {
+    color: colors.purple,
+    textDecorationLine: 'underline',
+  },
+});

--- a/src/features/ThankYouScreen.tsx
+++ b/src/features/ThankYouScreen.tsx
@@ -11,7 +11,6 @@ import { CovidRating, shouldAskForRating } from '../components/CovidRating';
 import ProgressStatus from '../components/ProgressStatus';
 import { Header, isAndroid, ProgressBlock } from '../components/Screen';
 import { BrandedButton, ClickableText, HeaderText, RegularBoldText, RegularText } from '../components/Text';
-import UserService from '../core/user/UserService';
 import i18n from '../locale/i18n';
 import { ScreenParamList } from './ScreenParamList';
 
@@ -31,7 +30,7 @@ export default class ThankYouScreen extends Component<RenderProps, { askForRatin
   shareApp = async () => {
     const message = this.shareMessage + (isAndroid ? ' ' + this.shareUrl : ''); // On Android add link to end of message
     try {
-      const result = await Share.share({
+      await Share.share({
         message,
         url: this.shareUrl, // IOS has separate field for URL
       });
@@ -105,13 +104,11 @@ const styles = StyleSheet.create({
     marginVertical: 32,
     marginHorizontal: 18,
   },
-
   scrollView: {
     flexGrow: 1,
     backgroundColor: colors.backgroundSecondary,
     justifyContent: 'space-between',
   },
-
   rootContainer: {
     padding: 10,
   },
@@ -124,7 +121,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     textAlign: 'center',
   },
-
   newsFeed: {
     paddingVertical: 20,
     paddingHorizontal: 40,
@@ -143,7 +139,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: colors.secondary,
   },
-
   shareButton: {
     marginVertical: 20,
     marginHorizontal: 30,

--- a/src/features/ThankYouScreen.tsx
+++ b/src/features/ThankYouScreen.tsx
@@ -2,17 +2,18 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { Component } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
+
 import { colors } from '../../theme';
 import { CovidRating, shouldAskForRating } from '../components/CovidRating';
+import Donate from '../components/Donate';
 import ProgressStatus from '../components/ProgressStatus';
 import { Header, ProgressBlock } from '../components/Screen';
+import ShareThisApp from '../components/ShareThisApp';
 import { ClickableText, HeaderText, RegularText } from '../components/Text';
+import VisitWebsite from '../components/VisitWebsite';
+import { isGBCountry } from '../core/user/UserService';
 import i18n from '../locale/i18n';
 import { ScreenParamList } from './ScreenParamList';
-import ShareThisApp from '../components/ShareThisApp';
-import Donate from '../components/Donate';
-import { isGBCountry } from '../core/user/UserService';
-import VisitWebsite from '../components/VisitWebsite';
 
 type RenderProps = {
   navigation: StackNavigationProp<ScreenParamList, 'ThankYou'>;
@@ -54,11 +55,11 @@ export default class ThankYouScreen extends Component<RenderProps, { askForRatin
                 <>
                   <Donate />
                   <VisitWebsite />
-                  <ShareThisApp />
+                  <ShareThisApp ctaStyle="link" />
                 </>
               ) : (
                 <>
-                  <ShareThisApp />
+                  <ShareThisApp ctaStyle="button" />
                   <VisitWebsite />
                 </>
               )}

--- a/src/features/ThankYouScreen.tsx
+++ b/src/features/ThankYouScreen.tsx
@@ -1,19 +1,18 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Linking } from 'expo';
 import React, { Component } from 'react';
-import { Image, SafeAreaView, ScrollView, Share, StyleSheet, View } from 'react-native';
-import reactStringReplace from 'react-string-replace';
-
-import { social } from '../../assets';
+import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import { colors } from '../../theme';
 import { CovidRating, shouldAskForRating } from '../components/CovidRating';
 import ProgressStatus from '../components/ProgressStatus';
-import { Header, isAndroid, ProgressBlock } from '../components/Screen';
-import { BrandedButton, ClickableText, HeaderText, RegularBoldText, RegularText } from '../components/Text';
+import { Header, ProgressBlock } from '../components/Screen';
+import { ClickableText, HeaderText, RegularText } from '../components/Text';
 import i18n from '../locale/i18n';
 import { ScreenParamList } from './ScreenParamList';
 import ShareThisApp from '../components/ShareThisApp';
+import Donate from '../components/Donate';
+import { isGBCountry } from '../core/user/UserService';
+import VisitWebsite from '../components/VisitWebsite';
 
 type RenderProps = {
   navigation: StackNavigationProp<ScreenParamList, 'ThankYou'>;
@@ -51,19 +50,19 @@ export default class ThankYouScreen extends Component<RenderProps, { askForRatin
                 <RegularText>{i18n.t('thank-you-body')}</RegularText>
               </View>
 
-              <ShareThisApp />
+              {isGBCountry() ? (
+                <>
+                  <Donate />
+                  <VisitWebsite />
+                  <ShareThisApp />
+                </>
+              ) : (
+                <>
+                  <ShareThisApp />
+                  <VisitWebsite />
+                </>
+              )}
 
-              <ClickableText onPress={() => Linking.openURL(i18n.t('blog-link'))} style={styles.newsFeed}>
-                {reactStringReplace(
-                  i18n.t('thank-you.check-for-updates', { link: '{{LINK}}' }),
-                  '{{LINK}}',
-                  (match, i) => (
-                    <RegularText key={i} style={styles.newsFeedClickable}>
-                      {i18n.t('thank-you.news-feed')}
-                    </RegularText>
-                  )
-                )}
-              </ClickableText>
               <RegularText style={styles.shareSubtitle}>{i18n.t('check-in-tomorrow')}</RegularText>
 
               <ClickableText onPress={this.props.navigation.popToTop} style={styles.done}>

--- a/src/features/ThankYouScreen.tsx
+++ b/src/features/ThankYouScreen.tsx
@@ -13,6 +13,7 @@ import { Header, isAndroid, ProgressBlock } from '../components/Screen';
 import { BrandedButton, ClickableText, HeaderText, RegularBoldText, RegularText } from '../components/Text';
 import i18n from '../locale/i18n';
 import { ScreenParamList } from './ScreenParamList';
+import ShareThisApp from '../components/ShareThisApp';
 
 type RenderProps = {
   navigation: StackNavigationProp<ScreenParamList, 'ThankYou'>;
@@ -22,19 +23,6 @@ type RenderProps = {
 export default class ThankYouScreen extends Component<RenderProps, { askForRating: boolean }> {
   state = {
     askForRating: false,
-  };
-
-  shareMessage = i18n.t('share-with-friends-message');
-  shareUrl = i18n.t('share-with-friends-url');
-
-  shareApp = async () => {
-    const message = this.shareMessage + (isAndroid ? ' ' + this.shareUrl : ''); // On Android add link to end of message
-    try {
-      await Share.share({
-        message,
-        url: this.shareUrl, // IOS has separate field for URL
-      });
-    } catch (error) {}
   };
 
   async componentDidMount() {
@@ -63,16 +51,7 @@ export default class ThankYouScreen extends Component<RenderProps, { askForRatin
                 <RegularText>{i18n.t('thank-you-body')}</RegularText>
               </View>
 
-              <View style={styles.shareContainer}>
-                <View style={styles.socialIconContainer}>
-                  <Image source={social} style={styles.socialIcon} />
-                </View>
-                <RegularBoldText style={styles.share}>{i18n.t('thank-you.please-share-app')}</RegularBoldText>
-                <RegularText style={styles.shareSubtitle}>{i18n.t('thank-you.share-text')}</RegularText>
-                <BrandedButton onPress={this.shareApp} style={styles.shareButton}>
-                  {i18n.t('thank-you.btn-share')}
-                </BrandedButton>
-              </View>
+              <ShareThisApp />
 
               <ClickableText onPress={() => Linking.openURL(i18n.t('blog-link'))} style={styles.newsFeed}>
                 {reactStringReplace(
@@ -112,15 +91,6 @@ const styles = StyleSheet.create({
   rootContainer: {
     padding: 10,
   },
-  shareContainer: {
-    backgroundColor: colors.white,
-    borderRadius: 10,
-    marginHorizontal: 20,
-  },
-  share: {
-    fontSize: 20,
-    textAlign: 'center',
-  },
   newsFeed: {
     paddingVertical: 20,
     paddingHorizontal: 40,
@@ -138,15 +108,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 40,
     textAlign: 'center',
     color: colors.secondary,
-  },
-  shareButton: {
-    marginVertical: 20,
-    marginHorizontal: 30,
-  },
-  socialIconContainer: {
-    borderRadius: 10,
-    margin: 30,
-    alignSelf: 'center',
   },
   socialIcon: {
     height: 60,


### PR DESCRIPTION
# Description

This PR add's a new Donate Module, for the UK App, on to the ThankYouScreen. This screen is currently shared between Sweden and UK. 

This PR also begins to refactor the ThankYou Screen into smaller components:
 - ShareThisApp
 - Donate
 - CoralBadge
 - VisitWebsite 

The ShareThisApp component has two variants: One where the CTA is a button and one where it is a link. The CTA on ShareThisApp is set to "link: when the Donate module is present (i.e. The UK App) so there aren't two CTA buttons on the same screen. 


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots
![Screenshot 2020-05-12 at 22 22 16](https://user-images.githubusercontent.com/7824212/81747841-b294dd00-94a0-11ea-82bd-de10fab53b31.png)
![Screenshot 2020-05-12 at 22 22 20](https://user-images.githubusercontent.com/7824212/81747848-b4f73700-94a0-11ea-80e0-884a3a5c8476.png)

## Sweden

![Screenshot 2020-05-12 at 22 37 08](https://user-images.githubusercontent.com/7824212/81748105-2fc05200-94a1-11ea-927c-439801b737e3.png)
![Screenshot 2020-05-12 at 22 37 14](https://user-images.githubusercontent.com/7824212/81748113-318a1580-94a1-11ea-81d3-5e94f7b5a262.png)


## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

Swedish translations are deliberately left out for the Donate Module. 
A separate ticket will unify the different thank you experiences. 