### PR TITLE
Actually wait for approval before running the OTA expo publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,4 +187,4 @@ workflows:
           filters: *legacy_ota_filter
           context: react-covid-tracker-prod
           requires:
-            - build_and_test
+            - wait_for_approval


### PR DESCRIPTION
# Description

Fix CircleCI to actually wait for approval before running the OTA expo publish

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
