### PR TITLE
Improve error handling

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -574,6 +574,7 @@
   "above-list-correct": "The above list is correct",
 
   "errors" : {
+    "button-retry": "Retry",
     "status-loading": "Loading...",
     "status-retrying": "Retrying...",
     "user-is-offline": "You are currently offline. Please check your connection.",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -571,5 +571,10 @@
   "pending": "Pending",
   "please-add-test-below": "If you’ve ever had a COVID-19 test, please add below. You can edit these at any time in the future.",
   "never-had-test": "I have never had a COVID test",
-  "above-list-correct": "The above list is correct"
+  "above-list-correct": "The above list is correct",
+
+  "errors" : {
+    "user-is-offline": "You are currently offline. Please check your connection.",
+    "server-is-busy": "Server is overloaded. Please wait"
+  }
 }

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -575,6 +575,8 @@
 
   "errors" : {
     "user-is-offline": "You are currently offline. Please check your connection.",
-    "server-is-busy": "Server is overloaded. Please wait"
+    "resource-not-found": "The server couldn't find your details",
+    "server-is-busy": "Server is busy. Please wait, then try again",
+    "server-error": "Server couldn't respond at this time. Please wait, then try again."
   }
 }

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -574,6 +574,8 @@
   "above-list-correct": "The above list is correct",
 
   "errors" : {
+    "status-loading": "Loading...",
+    "status-retrying": "Retrying...",
     "user-is-offline": "You are currently offline. Please check your connection.",
     "resource-not-found": "The server couldn't find your details",
     "server-is-busy": "Server is busy. Please wait, then try again",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -575,6 +575,7 @@
 
   "errors" : {
     "button-retry": "Retry",
+    "button-okay": "Ok",
     "status-loading": "Loading...",
     "status-retrying": "Retrying...",
     "user-is-offline": "You are currently offline. Please check your connection.",

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -53,18 +53,19 @@ import TermsOfUseUSScreen from './features/register/us/TermsOfUseUSScreen';
 import OfflineService from './core/offline/OfflineService';
 import { OfflineNotice } from './components/OfflineNotice';
 import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
+import { offlineService } from './Services';
 
 const Stack = createStackNavigator<ScreenParamList>();
 const Drawer = createDrawerNavigator();
 
 class State {
-  fontLoaded: boolean;
+  isLoaded: boolean;
   isOnline: boolean;
   isApiOnline: boolean;
 }
 
 const initialState = {
-  fontLoaded: false,
+  isLoaded: false,
   isOnline: true,
   isApiOnline: true,
 };
@@ -81,18 +82,17 @@ export default class CovidApp extends Component<object, State> {
       Roboto_medium: require('native-base/Fonts/Roboto_medium.ttf'),
     });
 
-    const offlineService = new OfflineService();
     await offlineService.checkStatus();
     console.log(`[OFFLINE] isOnline: ${offlineService.isOnline}, isApiOnline: ${offlineService.isApiOnline}`);
     this.setState({ isOnline: offlineService.isOnline, isApiOnline: offlineService.isApiOnline });
     // offlineService
     //   .on('status.online', (value: boolean) => this.setState({isOnline: value}))
     //   .on('status.apiOnline', (value: boolean) => this.setState({isOnline: value}));
-    this.setState({ fontLoaded: true });
+    this.setState({ isLoaded: true });
   }
 
   render() {
-    if (!this.state.fontLoaded) return <View />;
+    if (!this.state.isLoaded) return <View style={{ flex: 1, backgroundColor: colors.predict }} />;
 
     return (
       <SafeAreaProvider>

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -50,10 +50,8 @@ import BeforeWeStartUS from './features/register/us/BeforeWeStartUS';
 import { NursesConsentUSScreen } from './features/register/us/NursesConsentUS';
 import { PrivacyPolicyUSScreen } from './features/register/us/PrivacyPolicyUSScreen';
 import TermsOfUseUSScreen from './features/register/us/TermsOfUseUSScreen';
-import OfflineService from './core/offline/OfflineService';
 import { OfflineNotice } from './components/OfflineNotice';
 import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
-import { offlineService } from './Services';
 
 const Stack = createStackNavigator<ScreenParamList>();
 const Drawer = createDrawerNavigator();
@@ -81,13 +79,6 @@ export default class CovidApp extends Component<object, State> {
       Roboto: require('native-base/Fonts/Roboto.ttf'),
       Roboto_medium: require('native-base/Fonts/Roboto_medium.ttf'),
     });
-
-    await offlineService.checkStatus();
-    console.log(`[OFFLINE] isOnline: ${offlineService.isOnline}, isApiOnline: ${offlineService.isApiOnline}`);
-    this.setState({ isOnline: offlineService.isOnline, isApiOnline: offlineService.isApiOnline });
-    // offlineService
-    //   .on('status.online', (value: boolean) => this.setState({isOnline: value}))
-    //   .on('status.apiOnline', (value: boolean) => this.setState({isOnline: value}));
     this.setState({ isLoaded: true });
   }
 

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -50,7 +50,6 @@ import BeforeWeStartUS from './features/register/us/BeforeWeStartUS';
 import { NursesConsentUSScreen } from './features/register/us/NursesConsentUS';
 import { PrivacyPolicyUSScreen } from './features/register/us/PrivacyPolicyUSScreen';
 import TermsOfUseUSScreen from './features/register/us/TermsOfUseUSScreen';
-import { OfflineNotice } from './components/OfflineNotice';
 import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
 
 const Stack = createStackNavigator<ScreenParamList>();
@@ -88,9 +87,6 @@ export default class CovidApp extends Component<object, State> {
     return (
       <SafeAreaProvider>
         <Root>
-          <SafeAreaView>
-            <OfflineNotice isOnline={this.state.isOnline} isApiOnline={this.state.isApiOnline} />
-          </SafeAreaView>
           <Header style={{ display: 'none' }}>
             <StatusBar backgroundColor={colors.white} barStyle="dark-content" />
           </Header>

--- a/src/Services.tsx
+++ b/src/Services.tsx
@@ -1,0 +1,5 @@
+import UserService from './core/user/UserService';
+import OfflineService from './core/offline/OfflineService';
+
+export const userService = new UserService();
+export const offlineService = new OfflineService();

--- a/src/components/ErrorMessageBar.tsx
+++ b/src/components/ErrorMessageBar.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { RegularBoldText } from './Text';
+import { colors } from '../../theme';
+
+type ErrorMessageBarProps = {
+  children: React.ReactNode;
+};
+
+export const ErrorMessageBar = ({ children }: ErrorMessageBarProps) => {
+  return (
+    <View style={styles.errorBar}>
+      <RegularBoldText style={styles.errorText}>{children}</RegularBoldText>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  errorBar: {
+    backgroundColor: colors.coral,
+    color: colors.white,
+    padding: 10,
+  },
+  errorText: {
+    backgroundColor: colors.coral,
+    color: colors.white,
+    textAlign: 'center',
+  },
+});

--- a/src/components/FlexView.tsx
+++ b/src/components/FlexView.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+type FlexViewProps = {
+  children?: React.ReactNode;
+};
+
+export const FlexView = ({ children }: FlexViewProps) => {
+  return <View style={styles.flexView}>{children}</View>;
+};
+
+const styles = StyleSheet.create({
+  flexView: {
+    flex: 1,
+  },
+});

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -9,7 +9,7 @@ type LoadingProps = {
   error: AppException | null;
   status: string;
   style: StyleSheet | object;
-  onRetry?: any;
+  onRetry?: () => void;
 };
 
 export const Loading = ({ error, status, onRetry }: LoadingProps) => {
@@ -29,9 +29,9 @@ export const Loading = ({ error, status, onRetry }: LoadingProps) => {
         <View>
           {!!message && <ErrorText>{message}</ErrorText>}
           {!message && status && <RegularText>{status}</RegularText>}
-          {shouldRetry && (
+          {shouldRetry && !!onRetry && (
             <View style={styles.ctaBlock}>
-              <BrandedButton onPress={onRetry}>Retry</BrandedButton>
+              <BrandedButton onPress={onRetry}>{i18n.t("errors.button-retry")}</BrandedButton>
             </View>
           )}
         </View>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, StyleSheet, ActivityIndicator } from 'react-native';
+import { AppException } from '../core/ApiServiceErrors';
+import { colors } from '../../theme';
+import { ErrorText, BrandedButton, RegularText } from './Text';
+import i18n from '../locale/i18n';
+
+type LoadingProps = {
+  error: AppException | null;
+  status: string;
+  style: StyleSheet | object;
+  onRetry?: any;
+};
+
+export const Loading = ({ error, status, onRetry }: LoadingProps) => {
+  let messageKey: string | null = null;
+  let message: string | null = null;
+  let shouldRetry = false;
+
+  if (error) {
+    messageKey = error.friendlyI18n;
+    message = messageKey && i18n.t(messageKey);
+    shouldRetry = !!error.isRetryable && !!onRetry;
+  }
+
+  return (
+    <View style={styles.loadingView}>
+      {!!error ? (
+        <View>
+          {!!message && <ErrorText>{message}</ErrorText>}
+          {!message && status && <RegularText>{status}</RegularText>}
+          {shouldRetry && (
+            <View style={styles.ctaBlock}>
+              <BrandedButton onPress={onRetry}>Retry</BrandedButton>
+            </View>
+          )}
+        </View>
+      ) : (
+        <>
+          <ActivityIndicator size="large" color={colors.predict} />
+          <RegularText>{status}</RegularText>
+        </>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  loadingView: {
+    flexDirection: 'column',
+    flex: 1,
+    alignItems: 'center',
+    marginVertical: 10,
+  },
+  ctaBlock: {
+    margin: 10,
+  },
+});

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -90,8 +90,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: 22,
-    borderWidth: 1,
-    borderColor: 'red',
   },
   modalView: {
     margin: 20,

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, ActivityIndicator, Modal } from 'react-native';
 import { AppException } from '../core/ApiServiceErrors';
 import { colors } from '../../theme';
 import { ErrorText, BrandedButton, RegularText } from './Text';
@@ -7,45 +7,108 @@ import i18n from '../locale/i18n';
 
 type LoadingProps = {
   error: AppException | null;
-  status: string;
-  style: StyleSheet | object;
+  status?: string;
+  style?: StyleSheet | object;
   onRetry?: () => void;
+  onPress?: () => void;
 };
 
-export const Loading = ({ error, status, onRetry }: LoadingProps) => {
+const ErrorMessaging = ({ error, status, onRetry, onPress }: LoadingProps) => {
   let messageKey: string | null = null;
   let message: string | null = null;
   let shouldRetry = false;
+  let shouldCancel = true;
 
   if (error) {
     messageKey = error.friendlyI18n;
     message = messageKey && i18n.t(messageKey);
     shouldRetry = !!error.isRetryable && !!onRetry;
+    shouldCancel = !shouldRetry && !!error;
   }
 
+  const showRetry = shouldRetry && !!onRetry;
+  return (
+    <View>
+      {!!message && <ErrorText style={{ color: colors.coral }}>{message}</ErrorText>}
+      {!message && status && <RegularText>{status}</RegularText>}
+      {shouldRetry && !!onRetry && (
+        <View style={styles.ctaBlock}>
+          <BrandedButton onPress={onRetry}>{i18n.t('errors.button-retry')}</BrandedButton>
+        </View>
+      )}
+      {shouldCancel && !!error && !!onPress && (
+        <View style={styles.ctaBlock}>
+          <BrandedButton onPress={onPress}>{i18n.t('errors.button-okay')}</BrandedButton>
+        </View>
+      )}
+    </View>
+  );
+};
+
+export const Loading = (props: LoadingProps) => {
   return (
     <View style={styles.loadingView}>
-      {!!error ? (
-        <View>
-          {!!message && <ErrorText>{message}</ErrorText>}
-          {!message && status && <RegularText>{status}</RegularText>}
-          {shouldRetry && !!onRetry && (
-            <View style={styles.ctaBlock}>
-              <BrandedButton onPress={onRetry}>{i18n.t("errors.button-retry")}</BrandedButton>
-            </View>
-          )}
-        </View>
+      {!!props.error ? (
+        <ErrorMessaging {...props} />
       ) : (
         <>
           <ActivityIndicator size="large" color={colors.predict} />
-          <RegularText>{status}</RegularText>
+          <RegularText>{props.status}</RegularText>
         </>
       )}
     </View>
   );
 };
 
+export const LoadingModal = (props: LoadingProps) => {
+  let messageKey: string | null = null;
+  let message: string | null = null;
+  let shouldRetry = false;
+
+  if (props.error) {
+    messageKey = props.error.friendlyI18n;
+    message = messageKey && i18n.t(messageKey);
+    shouldRetry = !!props.error.isRetryable && !!props.onRetry;
+  }
+
+  return (
+    <Modal visible transparent>
+      <View style={styles.centeredView}>
+        <View style={styles.modalView}>
+          <ActivityIndicator size="large" color={colors.predict} />
+          <ErrorMessaging {...props} />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
 const styles = StyleSheet.create({
+  centeredView: {
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+    borderWidth: 1,
+    borderColor: 'red',
+  },
+  modalView: {
+    margin: 20,
+    width: '90%',
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
   loadingView: {
     flexDirection: 'column',
     flex: 1,

--- a/src/components/OfflineNotice.tsx
+++ b/src/components/OfflineNotice.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ErrorMessageBar } from './ErrorMessageBar';
+import i18n from '../locale/i18n';
+
+type NoticeProps = {
+  isOnline: boolean;
+  isApiOnline: boolean;
+};
+
+export const OfflineNotice = ({ isOnline, isApiOnline }: NoticeProps) => {
+  const message: string | null = !isOnline
+    ? i18n.t('errors.user-is-offline')
+    : !isApiOnline
+    ? i18n.t('errors.server-is-busy')
+    : null;
+
+  return message ? <ErrorMessageBar>{message}</ErrorMessageBar> : null;
+};

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -3,21 +3,12 @@ import { View, Image, StyleSheet } from 'react-native';
 import { RegularBoldText, BrandedButton } from './Text';
 import { covidIcon } from '../../assets';
 import { colors } from '../../theme';
+import { FlexView } from './FlexView';
 
 type SplashProps = {
   status: string;
   onRetry?: any;
 };
-
-type FlexViewProps = {
-  children?: React.ReactNode;
-}
-
-const FlexView = ({children}: FlexViewProps) => {
-  return (
-    <View style={styles.flexView}>{children}</View>
-  )
-}
 
 const Splash = ({ status, onRetry = null }: SplashProps) => {
   return (
@@ -41,9 +32,6 @@ const Splash = ({ status, onRetry = null }: SplashProps) => {
 };
 
 const styles = StyleSheet.create({
-  flexView: {
-    flex: 1,
-  },
   mainBlock: {
     alignItems: 'center',
   },

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { View, Image, StyleSheet } from 'react-native';
-import { RegularBoldText } from './Text';
+import { RegularBoldText, BrandedButton } from './Text';
 import { covidIcon } from '../../assets';
 import { colors } from '../../theme';
 
 type SplashProps = {
   status: string;
+  onRetry?: any;
 };
 
-const Splash = ({ status }: SplashProps) => {
+const Splash = ({ status, onRetry = null }: SplashProps) => {
   return (
     <View style={styles.flexView}>
       <View style={styles.flexView} />
@@ -18,7 +19,13 @@ const Splash = ({ status }: SplashProps) => {
           <RegularBoldText style={styles.statusText}>{status}</RegularBoldText>
         </View>
       </View>
-      <View style={styles.flexView} />
+      <View style={styles.flexView}>
+        {onRetry && (
+          <View style={styles.ctaBlock}>
+            <BrandedButton onPress={onRetry}>Retry</BrandedButton>
+          </View>
+        )}
+      </View>
     </View>
   );
 };
@@ -32,6 +39,10 @@ const styles = StyleSheet.create({
   },
   textBox: {
     marginVertical: 10,
+  },
+  ctaBlock: {
+    width: '80%',
+    alignSelf: 'center',
   },
   statusText: {
     color: colors.tertiary,

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -24,7 +24,7 @@ const Splash = (props: SplashProps) => {
       <FlexView>
         {!!props.onRetry && (
           <View style={styles.ctaBlock}>
-            <BrandedButton onPress={props.onRetry}>{i18n.t("errors.button-retry")}</BrandedButton>
+            <BrandedButton onPress={props.onRetry}>{i18n.t('errors.button-retry')}</BrandedButton>
           </View>
         )}
       </FlexView>

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+import { RegularBoldText } from './Text';
+import { covidIcon } from '../../assets';
+import { colors } from '../../theme';
+
+type SplashProps = {
+  status: string;
+};
+
+const Splash = ({ status }: SplashProps) => {
+  return (
+    <View style={styles.flexView}>
+      <View style={styles.flexView} />
+      <View style={styles.mainBlock}>
+        <Image source={covidIcon} />
+        <View style={styles.textBox}>
+          <RegularBoldText style={styles.statusText}>{status}</RegularBoldText>
+        </View>
+      </View>
+      <View style={styles.flexView} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  flexView: {
+    flex: 1,
+  },
+  mainBlock: {
+    alignItems: 'center',
+  },
+  textBox: {
+    marginVertical: 10,
+  },
+  statusText: {
+    color: colors.tertiary,
+  },
+});
+
+export default Splash;

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -8,7 +8,7 @@ import i18n from '../locale/i18n';
 
 type SplashProps = {
   status: string;
-  onRetry: () => void;
+  onRetry?: () => void;
 };
 
 const Splash = (props: SplashProps) => {

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -9,24 +9,34 @@ type SplashProps = {
   onRetry?: any;
 };
 
+type FlexViewProps = {
+  children?: React.ReactNode;
+}
+
+const FlexView = ({children}: FlexViewProps) => {
+  return (
+    <View style={styles.flexView}>{children}</View>
+  )
+}
+
 const Splash = ({ status, onRetry = null }: SplashProps) => {
   return (
-    <View style={styles.flexView}>
-      <View style={styles.flexView} />
+    <FlexView>
+      <FlexView />
       <View style={styles.mainBlock}>
         <Image source={covidIcon} />
         <View style={styles.textBox}>
           <RegularBoldText style={styles.statusText}>{status}</RegularBoldText>
         </View>
       </View>
-      <View style={styles.flexView}>
+      <FlexView>
         {onRetry && (
           <View style={styles.ctaBlock}>
             <BrandedButton onPress={onRetry}>Retry</BrandedButton>
           </View>
         )}
-      </View>
-    </View>
+      </FlexView>
+    </FlexView>
   );
 };
 

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -4,26 +4,27 @@ import { RegularBoldText, BrandedButton } from './Text';
 import { covidIcon } from '../../assets';
 import { colors } from '../../theme';
 import { FlexView } from './FlexView';
+import i18n from '../locale/i18n';
 
 type SplashProps = {
   status: string;
-  onRetry?: any;
+  onRetry: () => void;
 };
 
-const Splash = ({ status, onRetry = null }: SplashProps) => {
+const Splash = (props: SplashProps) => {
   return (
     <FlexView>
       <FlexView />
       <View style={styles.mainBlock}>
         <Image source={covidIcon} />
         <View style={styles.textBox}>
-          <RegularBoldText style={styles.statusText}>{status}</RegularBoldText>
+          <RegularBoldText style={styles.statusText}>{props.status}</RegularBoldText>
         </View>
       </View>
       <FlexView>
-        {onRetry && (
+        {!!props.onRetry && (
           <View style={styles.ctaBlock}>
-            <BrandedButton onPress={onRetry}>Retry</BrandedButton>
+            <BrandedButton onPress={props.onRetry}>{i18n.t("errors.button-retry")}</BrandedButton>
           </View>
         )}
       </FlexView>

--- a/src/core/ApiServiceErrors.ts
+++ b/src/core/ApiServiceErrors.ts
@@ -13,6 +13,20 @@ type ReceivedError = {
   response?: AxiosResponse;
 };
 
+export type ApiErrorState = {
+  isApiError: boolean;
+  error: AppException | null;
+  status: string;
+  onRetry?: () => void;
+}
+
+export const initialErrorState = {
+  isApiError: false,
+  error: null,
+  status: '',
+}
+
+
 export class AppException extends Error {
   friendlyI18n: string | null;
   isRetryable = false;

--- a/src/core/ApiServiceErrors.ts
+++ b/src/core/ApiServiceErrors.ts
@@ -1,0 +1,49 @@
+import { AxiosResponse } from 'axios';
+
+const NETWORK_ERROR = 'Network Error';
+
+const STATUS_NOT_FOUND = 404;
+const STATUS_SERVER_BUSY = 429;
+
+type ReceivedError = {
+  message: string;
+  isAxiosError?: boolean;
+  response?: AxiosResponse;
+};
+
+class OfflineException extends Error {}
+export class ApiException extends Error {
+  isApiException = true;
+  isRetryable = false;
+  response: AxiosResponse;
+
+  constructor(message: string, response: any) {
+    super(message);
+    this.message = message;
+    this.response = response;
+  }
+}
+class RetryableApiException extends ApiException {
+  isRetryable = true;
+}
+class ServerBusyException extends RetryableApiException {}
+
+export const handleServiceError = (error: ReceivedError) => {
+  if (error.isAxiosError && error.response) {
+    switch (error.response.status) {
+      case STATUS_SERVER_BUSY:
+      case STATUS_NOT_FOUND:
+        throw new ServerBusyException(error.message, error.response);
+      case STATUS_NOT_FOUND:
+        throw new ApiException(error.message, error.response);
+      default:
+        console.log('[ERROR] Unhandled:', error.response.status, ':', error.message);
+        throw error;
+    }
+  } else if (error.message === NETWORK_ERROR) {
+    throw new OfflineException(error.message);
+  }
+
+  // Rethrow error if we get here
+  throw error;
+};

--- a/src/core/ApiServiceErrors.ts
+++ b/src/core/ApiServiceErrors.ts
@@ -18,14 +18,13 @@ export type ApiErrorState = {
   error: AppException | null;
   status: string;
   onRetry?: () => void;
-}
+};
 
 export const initialErrorState = {
   isApiError: false,
   error: null,
   status: '',
-}
-
+};
 
 export class AppException extends Error {
   friendlyI18n: string | null;

--- a/src/core/ApiServiceErrors.ts
+++ b/src/core/ApiServiceErrors.ts
@@ -13,18 +13,19 @@ type ReceivedError = {
   response?: AxiosResponse;
 };
 
-class AppException extends Error {
+export class AppException extends Error {
   friendlyI18n: string | null;
+  isRetryable = false;
   status: number;
 }
 
 class OfflineException extends AppException {
   isRetryable = true;
+  friendlyI18n = 'errors.user-is-offline';
 }
 
 export class ApiException extends AppException {
   isApiException = true;
-  isRetryable = false;
   response: AxiosResponse;
 
   constructor(message: string, status: number, i18nString: string | null = null) {

--- a/src/core/offline/OfflineService.ts
+++ b/src/core/offline/OfflineService.ts
@@ -36,18 +36,24 @@ export default class OfflineService implements IOfflineService {
   lastUpdated: string;
   lastChecked: string;
 
-  private updateOnlineStatus = (newStatus: boolean, updateTime: string) => {
+  updateOnlineStatus = (newStatus: boolean, updateTime: string | null = null) => {
     if (this.isOnline !== newStatus) {
+      // console.log('[STATUS] isOnline:', this.isApiOnline, '->', newStatus);
       this.isOnline = newStatus;
-      this.lastUpdated = updateTime;
+      if (updateTime) {
+        this.lastUpdated = updateTime;
+      }
       // TODO: triggerEvent(EVENT_STATUS_ONLINE, newStatus)
     }
   };
 
-  private updateApiOnlineStatus = (newStatus: boolean, updateTime: string) => {
+  updateApiOnlineStatus = (newStatus: boolean, updateTime: string | null = null) => {
     if (this.isApiOnline !== newStatus) {
+      // console.log('[STATUS] isAPIOnline:', this.isApiOnline, '->', newStatus);
       this.isApiOnline = newStatus;
-      this.lastUpdated = updateTime;
+      if (updateTime) {
+        this.lastUpdated = updateTime;
+      }
       // TODO: triggerEvent(EVENT_STATUS_API_ONLINE, newStatus);
     }
   };

--- a/src/core/offline/OfflineService.ts
+++ b/src/core/offline/OfflineService.ts
@@ -1,0 +1,79 @@
+import appConfig from '../../../appConfig';
+import axios from 'axios';
+import moment from 'moment';
+
+// const ONLINE_URL = 'https://www.google.com/robots.txt';
+const ONLINE_URL = 'https://joinzoe.com/icons/icon-48x48.png';
+const API_URL = appConfig.apiBase + 'users/covid_count/';
+
+const NETWORK_ERROR = 'Network Error';
+const TIMEOUT_IN_SECONDS = 5 * 1000;
+const REQUEST_OPTS = {
+  validateStatus: (status: number) => status < 400,
+  timeout: TIMEOUT_IN_SECONDS,
+};
+
+const checkOnlineStatus = () => axios.get(ONLINE_URL, REQUEST_OPTS);
+const checkApiStatus = () => axios.get(API_URL, REQUEST_OPTS);
+
+type Events = 'status.online' | 'status.apiOnline';
+const listeners = {
+  'status.online': [] as Function[],
+  'status.apiOnline': [] as Function[],
+};
+
+export interface IOfflineService {
+  isOnline: boolean;
+  isApiOnline: boolean;
+  lastUpdated: string;
+  lastChecked: string;
+  checkStatus(): void;
+}
+
+export default class OfflineService implements IOfflineService {
+  isOnline: boolean = false;
+  isApiOnline: boolean = false;
+  lastUpdated: string;
+  lastChecked: string;
+
+  private updateOnlineStatus = (newStatus: boolean, updateTime: string) => {
+    if (this.isOnline !== newStatus) {
+      this.isOnline = newStatus;
+      this.lastUpdated = updateTime;
+      // TODO: triggerEvent(EVENT_STATUS_ONLINE, newStatus)
+    }
+  };
+
+  private updateApiOnlineStatus = (newStatus: boolean, updateTime: string) => {
+    if (this.isApiOnline !== newStatus) {
+      this.isApiOnline = newStatus;
+      this.lastUpdated = updateTime;
+      // TODO: triggerEvent(EVENT_STATUS_API_ONLINE, newStatus);
+    }
+  };
+
+  async checkStatus() {
+    const checkTime = moment().format();
+    try {
+      await checkOnlineStatus();
+      this.updateOnlineStatus(true, checkTime);
+    } catch (error) {
+      if (error.message === NETWORK_ERROR) {
+        this.updateOnlineStatus(false, checkTime);
+      }
+    }
+
+    try {
+      await checkApiStatus();
+      this.updateOnlineStatus(true, checkTime);
+      this.updateApiOnlineStatus(true, checkTime);
+    } catch (error) {
+      if (error.message === NETWORK_ERROR) {
+        this.updateOnlineStatus(false, checkTime);
+      }
+      this.updateApiOnlineStatus(false, checkTime);
+    }
+
+    this.lastChecked = checkTime;
+  }
+}

--- a/src/core/offline/OfflineService.ts
+++ b/src/core/offline/OfflineService.ts
@@ -22,12 +22,15 @@ const listeners = {
   'status.apiOnline': [] as Function[],
 };
 
+const RETRY_DELAY = 5000; // in microseconds
+
 export interface IOfflineService {
   isOnline: boolean;
   isApiOnline: boolean;
   lastUpdated: string;
   lastChecked: string;
   checkStatus(): void;
+  getRetryDelay(): number;
 }
 
 export default class OfflineService implements IOfflineService {
@@ -81,5 +84,10 @@ export default class OfflineService implements IOfflineService {
     }
 
     this.lastChecked = checkTime;
+  }
+
+  getRetryDelay() {
+    // Can implement an exponential backing-off here later.
+    return RETRY_DELAY;
   }
 }

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -91,7 +91,7 @@ export interface IDontKnowService {
 
 export default class UserService extends ApiClientBase
   implements
-    IUserService,   // TODO: ideally a UserService should only implement this, everything else is a separate service
+    IUserService, // TODO: ideally a UserService should only implement this, everything else is a separate service
     IProfileService,
     IConsentService,
     IPatientService,

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -210,7 +210,13 @@ export default class UserService extends ApiClientBase
   }
 
   public async listPatients() {
-    return this.client.get(`/patient_list/`);
+    try {
+      const response = await this.client.get(`/patient_list/`);
+      return response;
+    } catch (error) {
+      handleServiceError(error);
+    }
+    return null;
   }
 
   public async createPatient(infos: Partial<PatientInfosRequest>) {
@@ -482,7 +488,7 @@ export default class UserService extends ApiClientBase
   public async hasMultipleProfiles() {
     try {
       const response = await this.listPatients();
-      return response.data.length > 1;
+      return !!response && response.data.length > 1;
     } catch (e) {
       return false;
     }

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -337,11 +337,11 @@ export default class UserService extends ApiClientBase {
   async setUserCountry(countryCode: string) {
     UserService.userCountry = countryCode;
     UserService.setLocaleFromCountry(countryCode);
-    this.initCountry(countryCode);
+    this.initCountryConfig(countryCode);
     await AsyncStorageService.setUserCountry(countryCode);
   }
 
-  initCountry(countryCode: string) {
+  initCountryConfig(countryCode: string) {
     UserService.countryConfig = getCountryConfig(countryCode);
   }
 

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -24,6 +24,7 @@ import {
   UserResponse,
 } from './dto/UserAPIContracts';
 import { camelizeKeys } from './utils';
+import { handleServiceError } from '../ApiServiceErrors';
 
 const ASSESSMENT_VERSION = '1.4.0'; // TODO: Wire this to something automatic.
 const PATIENT_VERSION = '1.4.1'; // TODO: Wire this to something automatic.
@@ -409,9 +410,13 @@ export default class UserService extends ApiClientBase
   }
 
   async getStartupInfo() {
-    const response = await this.client.get<StartupInfo>('/users/startup_info/');
-    UserService.ipCountry = response.data.ip_country;
-    await AsyncStorageService.setUserCount(response.data.users_count.toString());
+    try {
+      const response = await this.client.get<StartupInfo>('/users/startup_info/');
+      UserService.ipCountry = response.data.ip_country;
+      await AsyncStorageService.setUserCount(response.data.users_count.toString());
+    } catch (error) {
+      handleServiceError(error);
+    }
   }
 
   async setUserCountry(countryCode: string) {

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -36,7 +36,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   }
 
   function logout() {
-    userService.deleteLocalUserData();
+    userService.logout();
     props.navigation.reset({
       index: 0,
       routes: [{ name: 'Welcome' }],

--- a/src/features/Navigation.ts
+++ b/src/features/Navigation.ts
@@ -108,7 +108,7 @@ class Navigator {
 
   async gotoNextScreen(screenName: ScreenName, params: RouteParamsType) {
     if (ScreenFlow[screenName]) {
-      ScreenFlow[screenName](params);
+      await ScreenFlow[screenName](params);
     } else {
       // We don't have nextScreen logic for this page. Explain loudly.
       console.error('[ROUTE] no next route found for:', screenName);
@@ -154,9 +154,6 @@ const ScreenFlow: any = {
 
   // Start of reporting flow
   WelcomeRepeat: async (routeParams: PatientIdParamType) => {
-    await navigator.gotoStartReport(routeParams.patientId);
-  },
-  WelcomeRepeatUS: async (routeParams: PatientIdParamType) => {
     await navigator.gotoStartReport(routeParams.patientId);
   },
 

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -105,8 +105,7 @@ export class SplashScreen extends Component<Props, object> {
   };
 
   private forceLogout = async () => {
-    ApiClientBase.unsetToken();
-    await AsyncStorageService.clearData();
+    await this.userService.logout();
   };
 
   private initAuthenticatedUser = async (user: AuthenticatedUser) => {

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -17,66 +17,109 @@ type Props = {
 
 type NavigationType = StackNavigationProp<ScreenParamList, keyof ScreenParamList>;
 
+type AuthenticatedUser = {
+  userToken: string;
+  userId: string;
+};
+
 export class SplashScreen extends Component<Props, object> {
   private userService = new UserService();
 
   constructor(props: Props) {
     super(props);
-    this.bootstrapAsync();
+    this.initNavigator();
+    this.gotoWelcomeScreen();
   }
 
-  private bootstrapAsync = async () => {
+  private initNavigator = () => {
     const { navigation } = this.props;
-    let country: string | null = null;
-
     // Stash a reference to navigator so we can have a class handle next page.
     Navigator.setNavigation(navigation as NavigationType);
+  };
 
-    try {
-      await this.userService.getStartupInfo();
-      country = await this.userService.getUserCountry();
-      this.userService.initCountry(country as string);
-    } catch (err) {
-      Alert.alert(
-        i18n.t('splash-error.title'),
-        i18n.t('splash-error.message') + ': ' + err.message,
-        [
-          {
-            text: i18n.t('splash-error.secondary-action-title'),
-            style: 'cancel',
-          },
-          { text: i18n.t('splash-error.primary-action-title'), onPress: () => this.bootstrapAsync() },
-        ],
-        { cancelable: false }
-      );
-    }
-
-    const { userToken, userId } = await AsyncStorageService.GetStoredData();
-
-    if (userToken && userId) {
-      ApiClientBase.setToken(userToken, userId);
-
-      // If logged in with no country default to GB as this will handle all GB users before selector was included.
-      if (country == null) {
-        await this.userService.setUserCountry('GB');
-      }
-
-      try {
-        const profile = await this.userService.getProfile();
-        const patientId = profile.patients[0];
-        Navigator.replaceScreen('WelcomeRepeat', { patientId });
-      } catch (error) {
-        // Logged in with an account doesn't exist. Force logout.
-        ApiClientBase.unsetToken();
-        await AsyncStorageService.clearData();
-        Navigator.replaceScreen('Welcome');
-      }
+  private gotoWelcomeScreen = async () => {
+    const patientId: string | null = await this.bootstrapAsync();
+    if (patientId) {
+      Navigator.replaceScreen('WelcomeRepeat', { patientId });
     } else {
-      if (country == null) {
-        // Using locale to default to a country
+      Navigator.replaceScreen('Welcome');
+    }
+  };
+
+  private handleBootstrapError = (error: Error) => {
+    Alert.alert(
+      i18n.t('splash-error.title'),
+      i18n.t('splash-error.message') + ': ' + error.message,
+      [
+        {
+          text: i18n.t('splash-error.secondary-action-title'),
+          style: 'cancel',
+        },
+        { text: i18n.t('splash-error.primary-action-title'), onPress: () => this.gotoWelcomeScreen() },
+      ],
+      { cancelable: false }
+    );
+  };
+
+  private bootstrapAsync = async (): Promise<string | null> => {
+    try {
+      this.updateUserCount();
+      const user = await this.loadUser();
+      const hasUser = !user || (!!user.userToken && !!user.userId);
+      this.updateUserCountry(hasUser);
+      if (hasUser) {
+        this.initAuthenticatedUser(user);
+        const patientId: string | null = await this.getUserPatientId(user);
+        if (!patientId) {
+          // Logged in with an account doesn't exist. Force logout.
+          await this.forceLogout();
+        }
+        return patientId;
+      }
+    } catch (error) {
+      this.handleBootstrapError(error);
+    }
+    return null;
+  };
+
+  private updateUserCount = async () => {
+    await this.userService.getStartupInfo();
+  };
+
+  private loadUser = async (): Promise<AuthenticatedUser> => {
+    return (await AsyncStorageService.GetStoredData()) as AuthenticatedUser;
+  };
+
+  private updateUserCountry = async (isLoggedIn: boolean) => {
+    const country: string | null = await this.userService.getUserCountry();
+    this.userService.initCountryConfig(country || 'GB');
+    if (isLoggedIn) {
+      // If logged in with no country default to GB as this will handle all
+      // GB users before selector was included.
+      if (country === null) {
+        await this.userService.setUserCountry('GB');
+      } else {
         await this.userService.defaultCountryFromLocale();
       }
-      Navigator.replaceScreen('Welcome');
+    }
+  };
+
+  private forceLogout = async () => {
+    ApiClientBase.unsetToken();
+    await AsyncStorageService.clearData();
+  };
+
+  private initAuthenticatedUser = async (user: AuthenticatedUser) => {
+    await ApiClientBase.setToken(user.userToken, user.userId);
+  };
+
+  private getUserPatientId = async (user: AuthenticatedUser): Promise<string | null> => {
+    try {
+      const profile = await this.userService.getProfile();
+      const patientId = profile.patients[0];
+      return patientId;
+    } catch (error) {
+      return null;
     }
   };
 

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -115,10 +115,13 @@ export class SplashScreen extends Component<Props, SplashState> {
   }
 
   private handleBootstrapError = (error: ApiException) => {
-    console.log('Caught an error', error.isRetryable);
-    console.log('[ERROR]', error);
+    console.log('Caught an error', error.isRetryable, error.response?.status);
+
+    const messageKey = error.friendlyI18n;
+    const message = messageKey ? i18n.t(messageKey) : error.message;
+
     this.setState({
-      status: error.message,
+      status: message,
       isRetryable: !!error.isRetryable,
       isRetryEnabled: false,
     });

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -191,7 +191,10 @@ export class SplashScreen extends Component<Props, SplashState> {
     const canRetry = this.state.isRetryable && this.state.isRetryEnabled;
     return (
       <View style={styles.container}>
-        <Splash status={this.state.status} onRetry={canRetry && this.reloadAppState} />
+        <Splash
+          status={this.state.status}
+          {...(canRetry ? {onRetry: this.reloadAppState} : {})}
+        />
       </View>
     );
   }

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -79,10 +79,17 @@ export class SplashScreen extends Component<Props, SplashState> {
     }
   };
 
-  private reloadAppState = async () => {
-    this.setState({ status: 'Retrying...' });
-    setTimeout(() => this.loadAppState(), BACKOFF_TIME_TO_RETRY);
+  private getBackoffDelay() {
+    return BACKOFF_TIME_TO_RETRY;
   }
+
+  private reloadAppState = async () => {
+    this.setState({
+      status: 'Retrying...',
+      isRetryEnabled: false,
+    });
+    setTimeout(() => this.loadAppState(), this.getBackoffDelay());
+  };
 
   private gotoWelcomeScreen = async (patientId: string | null) => {
     if (patientId) {

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -70,7 +70,7 @@ export class SplashScreen extends Component<Props, SplashState> {
   }
 
   private loadAppState = async () => {
-    this.setState({ status: 'Loading...' });
+    this.setState({ status: i18n.t('errors.status-loading') });
     try {
       const patientId: string | null = await this.bootstrapAsync();
       this.gotoWelcomeScreen(patientId);
@@ -85,7 +85,7 @@ export class SplashScreen extends Component<Props, SplashState> {
 
   private reloadAppState = async () => {
     this.setState({
-      status: 'Retrying...',
+      status: i18n.t('errors.status-retrying'),
       isRetryEnabled: false,
     });
     setTimeout(() => this.loadAppState(), this.getBackoffDelay());

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -36,7 +36,7 @@ type PatientListState = {
   isLoaded: boolean;
   patients: Patient[];
   shouldRefresh: boolean;
-}
+};
 
 type State = PatientListState & ApiErrorState;
 

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -9,14 +9,13 @@ import { addProfile, menuIcon, NUMBER_OF_PROFILE_AVATARS } from '../../../assets
 import { colors } from '../../../theme';
 import DaysAgo from '../../components/DaysAgo';
 import { Header } from '../../components/Screen';
-import { ClippedText, ErrorText, HeaderText, RegularText, SecondaryText } from '../../components/Text';
-import UserService from '../../core/user/UserService';
+import { ClippedText, HeaderText, RegularText, SecondaryText } from '../../components/Text';
 import i18n from '../../locale/i18n';
 import { AvatarName, getAvatarByName } from '../../utils/avatar';
 import { ScreenParamList } from '../ScreenParamList';
 import { AppException } from '../../core/ApiServiceErrors';
 import { Loading } from '../../components/Loading';
-import { offlineService } from '../../Services';
+import { offlineService, userService } from '../../Services';
 
 type RenderProps = {
   navigation: DrawerNavigationProp<ScreenParamList, 'SelectProfile'>;
@@ -68,12 +67,11 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
 
   private retryListProfiles() {
     this.setState({ status: i18n.t('errors.status-retrying'), error: null });
-    setTimeout(() => this.listProfiles(), 5000);
+    setTimeout(() => this.listProfiles(), offlineService.getRetryDelay());
   }
 
   async listProfiles() {
     this.setState({ status: i18n.t('errors.status-loading'), error: null });
-    const userService = new UserService();
     try {
       const response = await userService.listPatients();
       response &&
@@ -87,7 +85,6 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
   }
 
   async startAssessment(patientId: string) {
-    const userService = new UserService();
     const currentPatient = await userService.getCurrentPatient(patientId);
     this.props.navigation.navigate('StartAssessment', { currentPatient });
   }

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -13,7 +13,7 @@ import { ClippedText, HeaderText, RegularText, SecondaryText } from '../../compo
 import i18n from '../../locale/i18n';
 import { AvatarName, getAvatarByName } from '../../utils/avatar';
 import { ScreenParamList } from '../ScreenParamList';
-import { AppException } from '../../core/ApiServiceErrors';
+import { ApiErrorState, initialErrorState } from '../../core/ApiServiceErrors';
 import { Loading, LoadingModal } from '../../components/Loading';
 import { offlineService, userService } from '../../Services';
 
@@ -32,28 +32,19 @@ type Patient = {
   created_at?: Date;
 };
 
-interface PatientListState {
+type PatientListState = {
   isLoaded: boolean;
   patients: Patient[];
   shouldRefresh: boolean;
 }
 
-interface ApiErrorState {
-  isApiError: boolean;
-  error: AppException | null;
-  status: string;
-  onRetry?: () => void;
-}
-
-interface State extends PatientListState, ApiErrorState {}
+type State = PatientListState & ApiErrorState;
 
 const initialState = {
+  ...initialErrorState,
   patients: [],
   isLoaded: false,
-  error: null,
-  status: '',
   shouldRefresh: false,
-  isApiError: false,
 };
 
 export default class SelectProfileScreen extends Component<RenderProps, State> {

--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -12,11 +12,13 @@ import { BrandedButton, ErrorText, HeaderText, RegularText } from '../../compone
 import { ValidatedTextInput } from '../../components/ValidatedTextInput';
 import { AsyncStorageService } from '../../core/AsyncStorageService';
 import { PushNotificationService } from '../../core/PushNotificationService';
-import UserService, { isGBCountry, isUSCountry } from '../../core/user/UserService';
 import { PiiRequest } from '../../core/user/dto/UserAPIContracts';
 import i18n from '../../locale/i18n';
 import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
+import { ApiErrorState, initialErrorState } from '../../core/ApiServiceErrors';
+import { userService, offlineService } from '../../Services';
+import { LoadingModal } from '../../components/Loading';
 
 type PropsType = {
   navigation: StackNavigationProp<ScreenParamList, 'OptionalInfo'>;
@@ -25,9 +27,10 @@ type PropsType = {
 
 type State = {
   errorMessage: string;
-};
+} & ApiErrorState;
 
 const initialState: State = {
+  ...initialErrorState,
   errorMessage: '',
 };
 
@@ -44,45 +47,58 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
     this.state = initialState;
   }
 
-  private async handleSaveOptionalInfos(formData: OptionalInfoData) {
-    const patientId = this.props.route.params.patientId;
-    const userService = new UserService();
+  private async gotoNextScreen(patientId: string) {
     const currentPatient = await userService.getCurrentPatient(patientId);
+    Navigator.gotoNextScreen(this.props.route.name, { currentPatient });
+  }
 
+  private async setPushToken() {
     if (Constants.appOwnership !== 'expo') {
       const pushToken = await PushNotificationService.getPushToken(false);
       if (pushToken) {
         try {
           await userService.savePushToken(pushToken);
-          AsyncStorageService.setPushToken(pushToken);
+          await AsyncStorageService.setPushToken(pushToken);
         } catch (error) {
           this.setState({ errorMessage: i18n.t('something-went-wrong') });
         }
       }
     }
+  }
 
+  private async savePiiData(formData: OptionalInfoData) {
     const hasFormData = formData.phone?.trim() || formData.name?.trim();
 
-    if (!hasFormData) {
-      Navigator.gotoNextScreen(this.props.route.name, { currentPatient });
-    } else {
-      let piiDoc = formData.name
-        ? {
-            name: formData.name,
-          }
-        : (({} as unknown) as Partial<PiiRequest>);
+    if (hasFormData) {
+      const piiDoc = {
+        ...(formData.name && { name: formData.name }),
+        ...(formData.phone && { phone_number: formData.phone }),
+      } as Partial<PiiRequest>;
+      await userService.updatePii(piiDoc);
+    }
+  }
 
-      if (formData.phone) {
-        piiDoc = {
-          ...piiDoc,
-          phone_number: formData.phone,
-        };
-      }
-
-      userService
-        .updatePii(piiDoc)
-        .then(() => Navigator.gotoNextScreen(this.props.route.name, { currentPatient }))
-        .catch((err) => this.setState({ errorMessage: i18n.t('something-went-wrong') }));
+  private async handleSaveOptionalInfos(formData: OptionalInfoData) {
+    try {
+      const patientId = this.props.route.params.patientId;
+      await this.setPushToken();
+      await this.savePiiData(formData);
+      await this.gotoNextScreen(patientId);
+    } catch (error) {
+      this.setState({
+        isApiError: true,
+        error: error,
+        onRetry: () => {
+          this.setState({
+            status: i18n.t('errors.status-retrying'),
+            error: null,
+          });
+          setTimeout(() => {
+            this.setState({ status: i18n.t('errors.status-loading') });
+            this.handleSaveOptionalInfos(formData);
+          }, offlineService.getRetryDelay());
+        },
+      });
     }
   }
 
@@ -94,57 +110,67 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <KeyboardAvoidingView style={styles.rootContainer} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-          <Formik
-            initialValues={{ name: '', phone: '' }}
-            validationSchema={this.registerSchema}
-            onSubmit={(values: OptionalInfoData) => this.handleSaveOptionalInfos(values)}>
-            {(props) => {
-              return (
-                <View>
+      <>
+        {this.state.isApiError && (
+          <LoadingModal
+            error={this.state.error}
+            status={this.state.status}
+            onRetry={this.state.onRetry}
+            onPress={() => this.setState({ isApiError: false })}
+          />
+        )}
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <KeyboardAvoidingView style={styles.rootContainer} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+            <Formik
+              initialValues={{ name: '', phone: '' }}
+              validationSchema={this.registerSchema}
+              onSubmit={(values: OptionalInfoData) => this.handleSaveOptionalInfos(values)}>
+              {(props) => {
+                return (
                   <View>
-                    <HeaderText style={{ marginBottom: 24 }}>{i18n.t('optional-info.title')}</HeaderText>
+                    <View>
+                      <HeaderText style={{ marginBottom: 24 }}>{i18n.t('optional-info.title')}</HeaderText>
 
-                    <RegularText>{i18n.t('optional-info.description')}</RegularText>
+                      <RegularText>{i18n.t('optional-info.description')}</RegularText>
 
-                    <Form>
-                      <ValidatedTextInput
-                        placeholder={i18n.t('optional-info.name-placeholder')}
-                        value={props.values.name}
-                        onChangeText={props.handleChange('name')}
-                        onBlur={props.handleBlur('name')}
-                        error={props.touched.name && props.errors.name}
-                        returnKeyType="next"
-                        onSubmitEditing={() => {
-                          this.phoneComponent.focus();
-                        }}
-                      />
+                      <Form>
+                        <ValidatedTextInput
+                          placeholder={i18n.t('optional-info.name-placeholder')}
+                          value={props.values.name}
+                          onChangeText={props.handleChange('name')}
+                          onBlur={props.handleBlur('name')}
+                          error={props.touched.name && props.errors.name}
+                          returnKeyType="next"
+                          onSubmitEditing={() => {
+                            this.phoneComponent.focus();
+                          }}
+                        />
 
-                      <ValidatedTextInput
-                        ref={(input) => (this.phoneComponent = input)}
-                        placeholder={i18n.t('optional-info.phone-placeholder')}
-                        value={props.values.phone}
-                        onChangeText={props.handleChange('phone')}
-                        onBlur={props.handleBlur('phone')}
-                        error={props.touched.phone && props.errors.phone}
-                      />
-                      {props.errors.phone && <ErrorText>{props.errors.phone}</ErrorText>}
-                    </Form>
+                        <ValidatedTextInput
+                          ref={(input) => (this.phoneComponent = input)}
+                          placeholder={i18n.t('optional-info.phone-placeholder')}
+                          value={props.values.phone}
+                          onChangeText={props.handleChange('phone')}
+                          onBlur={props.handleBlur('phone')}
+                          error={props.touched.phone && props.errors.phone}
+                        />
+                        {props.errors.phone && <ErrorText>{props.errors.phone}</ErrorText>}
+                      </Form>
+                    </View>
+                    <View>
+                      <ErrorText>{this.state.errorMessage}</ErrorText>
+                    </View>
+
+                    <View>
+                      <BrandedButton onPress={props.handleSubmit}>{i18n.t('optional-info.button')}</BrandedButton>
+                    </View>
                   </View>
-                  <View>
-                    <ErrorText>{this.state.errorMessage}</ErrorText>
-                  </View>
-
-                  <View>
-                    <BrandedButton onPress={props.handleSubmit}>{i18n.t('optional-info.button')}</BrandedButton>
-                  </View>
-                </View>
-              );
-            }}
-          </Formik>
-        </KeyboardAvoidingView>
-      </TouchableWithoutFeedback>
+                );
+              }}
+            </Formik>
+          </KeyboardAvoidingView>
+        </TouchableWithoutFeedback>
+      </>
     );
   }
 }

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -60,7 +60,12 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
 
   handleButtonPress = async () => {
     const patientId = this.props.route.params.patientId;
-    Navigator.gotoNextScreen(this.props.route.name, { patientId });
+
+    try {
+      await Navigator.gotoNextScreen(this.props.route.name, { patientId });
+    } catch(error) {
+      console.log("[ERROR] Welcome repeat", error);
+    }
   };
 
   navigateToPrivacyPolicy = () => {

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -14,7 +14,7 @@ import UserService, { isGBCountry, isSECountry, isUSCountry } from '../../core/u
 import i18n from '../../locale/i18n';
 import Navigator, { NavigationType } from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
-import { ApiErrorState, initialErrorState, retryHandler } from '../../core/ApiServiceErrors';
+import { ApiErrorState, initialErrorState } from '../../core/ApiServiceErrors';
 import { offlineService } from '../../Services';
 import { LoadingModal } from '../../components/Loading';
 
@@ -32,8 +32,6 @@ type WelcomeRepeatScreenState = {
 const initialState = {
   ...initialErrorState,
   userCount: null,
-  // status: '',
-  // error: null,
 };
 
 export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScreenState> {


### PR DESCRIPTION
# Description


Network/Server errors come in two forms: ones that can be retried, and ones that can't or shouldn't. Errors because the User is offline, or the server is busy (429 errors) are those that can be retried. 404 errors can't be retried, the resource isn't there, retrying isn't going to change things.

When the user is presented with a retry button, we're wrapping the handler of that in a 5 second pause, but indicating that the app is retrying the request. That way, we are doing a basic throttling of requests, giving the server at least a little time to scale up to handle the current volume of requets. We can evolve that delay in future, e.g. increasing the delay after each failed request.


### Offline/Server down error-handling:

* SplashScreen - instead of a plain blue screen, there's now a Covid logo, and underneath that a status message. If requests for startup info fail (most usually because the user is offline or our server is busy), we'll display a status message underneath the logo, and after a brief pause a retry button. This eliminates the blue screen of death, and offers a recoverable way out of network failures. I've done a refactor of the processing logic to break it down into modular/componentised steps, some of this logic should be moved into their respective services as a next step.
* SelectProfileScreen - instead of an empty screen when the request for the patient list fails, we show a message with the error, and if the request is retryable, a retry button to trigger off a delayed retry of the request.
* The Bob problem: Bob appears as a profile name when the request to get the Patient document from the server fails, it currently falls back to an empty patient state, which has the default name of Bob. Now we catch when the request for the patient document fails, we present a modal dialogue displaying an error, and if the request is retryable, they have a Retry button which triggers off a delayed retry. If the request is not retryable, an OK button closes the modal, and the user remains on the same page -- here they might have the ability to go a different way.

There are five routes that can trigger the appearance of Bob:
* SelectProfileScreen -- request for that selected profile fails
* Create profile, when ConsentForOthersScreen is completed, and the request for that newly created profile fails
* OptionalInfoScreen -- in navigating to the next page retrieving the patient details of the main profile user fails
* WelcomeRepeatScreen -- when multiple profiles is turned off (e.g. Sweden), then clicking on Reports Symptoms to navigate to the first page of assessment, the request to retrieve the main profile patient details fails.

The cleanest set of changes for showing how error-handling was added to the screen is best shown on the WelcomeRepeatScreen and ConsentForOthersScreen.

The fifth way is through Create/RegisterScreen in countries that have the OptionalInfo screen turned off (this will shortly be the US). This is outstanding, and I prefer to do this at the same time as improving the error handling on the Create Account and Login pages.

In each of these screens, the logic to catch an error, and to retry the request feels like it can be refactored into something reusable, but I haven't found the right way yet. It feels like screens extending from a custom subclass of React Component is the right way. Though I suspect someone will say React Hooks :-D

### Unresolved / partially complete issues

`src/core/ApiServiceErrors` is a collection of Exceptions I use to wrap API errors. The main feature is to expose properties such as isRetryable, so we can offer the option to try again to the user. This does duplicate the library of Exceptions in `src/core/Exception`. Perhaps the next step is to refactor the new file to just have API-error-wrapping Exceptions (which is what `handleServiceError` does).

I had started a feature to track whether the user is Offline or our server was unavailable. This is currently in `src/core/offline/OfflineService.tsx`, with React component `src/components/ErrorMessageBar.tsx` and `src/components/OfflineNotice.tsx`. I'm stuck in how to best surface that, not just to display, but how to update from UserService, or how to manage the feature after it's determined the use is offline or our server is unavailable. I've left it in, and removed the original usage from `CovidApp.tsx`.


### Refactoring UserServices


`src/core/Services` is a singleton that exposes instantiated services, so we can get an instance of UserService and other services instead of instantiating it each time. That takes us one step closer to writing unit tests on services, because we have space to inject mock objects without complicating the React Native layer. 

I had a go in UserService of defining interfaces for the various Services in there that could be broken out into separate independent services. The idea is we can move out the interface to a new file, and all the named methods in UserService, then refactor that to be self contained. Before that, we need to refactor the calls to the Api into generic method calls via an API client -- UserService needs to stop being an API Client, and use an API client given to it.


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

SplashScreen:

<img width="412" alt="Screenshot 2020-05-15 at 12 08 37" src="https://user-images.githubusercontent.com/61784325/82044480-5353ea00-96a5-11ea-8c9d-6430a881df4b.png">

SelectProfileScreen:

<img width="412" alt="Screenshot 2020-05-15 at 12 11 07" src="https://user-images.githubusercontent.com/61784325/82044476-5222bd00-96a5-11ea-8426-68e9bdeed7e8.png">

Catching Bob on SelectProfileScreen:

<img width="411" alt="Screenshot 2020-05-15 at 12 11 34" src="https://user-images.githubusercontent.com/61784325/82044466-5058f980-96a5-11ea-9e38-cdf6ceba6ff2.png">


## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

* Swedish translations, @abubuwe 
* Further work on improving error handling on Login and Create account screens.
* Continuing to refactor User Services into separate self-reliant services
* Refactoring Splashpage setup logic into appropriate service instances.