### PR TITLE
Add checkmark for profiles reported today

### DIFF
--- a/src/components/DaysAgo.tsx
+++ b/src/components/DaysAgo.tsx
@@ -2,22 +2,25 @@ import moment from 'moment';
 import React, { Component } from 'react';
 
 import i18n from '../locale/i18n';
-import { RegularText, SecondaryText } from './Text';
+import { SecondaryText } from './Text';
 
 type ProgressProps = {
   timeAgo: Date | undefined;
 };
 
+export const getDaysAgo = (date: Date) => {
+  const today = moment().utc().startOf('day');
+  return today.diff(moment(date).startOf('day'), 'days');
+};
+
 export default class DaysAgo extends Component<ProgressProps> {
   render() {
     let text = i18n.t('never-reported');
-
     if (this.props.timeAgo) {
-      const today = moment().utc().startOf('day');
-      const diffDays = today.diff(moment(this.props.timeAgo).startOf('day'), 'days');
-      if (diffDays == 0) {
+      const diffDays = getDaysAgo(this.props.timeAgo);
+      if (diffDays === 0) {
         text = i18n.t('today');
-      } else if (diffDays == 1) {
+      } else if (diffDays === 1) {
         text = i18n.t('yesterday');
       } else {
         text = i18n.t('days-ago', { diffDays });

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -5,17 +5,17 @@ import React, { Component } from 'react';
 import { Image, SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import key from 'weak-key';
 
-import { addProfile, menuIcon, NUMBER_OF_PROFILE_AVATARS } from '../../../assets';
+import { addProfile, menuIcon, NUMBER_OF_PROFILE_AVATARS, tick } from '../../../assets';
 import { colors } from '../../../theme';
-import DaysAgo from '../../components/DaysAgo';
+import { offlineService, userService } from '../../Services';
+import DaysAgo, { getDaysAgo } from '../../components/DaysAgo';
+import { Loading, LoadingModal } from '../../components/Loading';
 import { Header } from '../../components/Screen';
 import { ClippedText, HeaderText, RegularText, SecondaryText } from '../../components/Text';
+import { ApiErrorState, initialErrorState } from '../../core/ApiServiceErrors';
 import i18n from '../../locale/i18n';
 import { AvatarName, getAvatarByName } from '../../utils/avatar';
 import { ScreenParamList } from '../ScreenParamList';
-import { ApiErrorState, initialErrorState } from '../../core/ApiServiceErrors';
-import { Loading, LoadingModal } from '../../components/Loading';
-import { offlineService, userService } from '../../Services';
 
 type RenderProps = {
   navigation: DrawerNavigationProp<ScreenParamList, 'SelectProfile'>;
@@ -79,7 +79,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
           isLoaded: true,
         });
     } catch (error) {
-      this.setState({ error: error });
+      this.setState({ error });
     }
   }
 
@@ -90,7 +90,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
     } catch (error) {
       this.setState({
         isApiError: true,
-        error: error,
+        error,
         onRetry: () => {
           this.setState({
             status: i18n.t('errors.status-retrying'),
@@ -146,13 +146,21 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
 
               {this.state.isLoaded ? (
                 <View style={styles.profileList}>
-                  {this.state.patients.map((patient, i) => {
+                  {this.state.patients.map((patient, _) => {
                     const avatarImage = getAvatarByName((patient.avatar_name ?? 'profile1') as AvatarName);
+                    const hasReportedToday = patient.last_reported_at && getDaysAgo(patient.last_reported_at) === 0;
                     return (
                       <View style={styles.cardContainer} key={key(patient)}>
                         <TouchableOpacity onPress={() => this.startAssessment(patient.id)}>
                           <Card style={styles.card}>
-                            <Image source={avatarImage} style={styles.avatar} resizeMode="contain" />
+                            <View style={styles.avatarContainer}>
+                              {hasReportedToday && (
+                                <View style={styles.circle}>
+                                  <Image source={tick} style={styles.tick} />
+                                </View>
+                              )}
+                              <Image source={avatarImage} style={styles.avatar} resizeMode="contain" />
+                            </View>
                             <ClippedText>{patient.name}</ClippedText>
                             <DaysAgo timeAgo={patient.last_reported_at} />
                           </Card>
@@ -199,10 +207,33 @@ const styles = StyleSheet.create({
     margin: 5,
   },
 
-  avatar: {
-    width: '80%',
-    height: 100,
+  avatarContainer: {
+    alignItems: 'center',
+    width: 100,
     marginBottom: 10,
+  },
+
+  avatar: {
+    height: 100,
+    width: 100,
+  },
+
+  tick: {
+    height: 30,
+    width: 30,
+  },
+
+  circle: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+    top: 0,
+    right: -5,
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: 'white',
   },
 
   addImage: {


### PR DESCRIPTION
# Description

This PR adds a green tick to the top right of the avatar picture if the user has reported today. Tick has been added with absolute positioning in a view of fixed size so should be in the same position regardless of screen size. Small refactor to use same logic as `DaysAgo` component.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

Tested on multiple screen sizes (see below).

## Screenshots

iPhone 11 Pro Max
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-17 at 19 44 02](https://user-images.githubusercontent.com/56440821/82157320-af229c80-9878-11ea-8418-d776641ace8f.png)

iPhone 8
![Simulator Screen Shot - iPhone 8 - 2020-05-17 at 19 44 08](https://user-images.githubusercontent.com/56440821/82157323-b649aa80-9878-11ea-82f9-0cdda07ea17c.png)

Android (Blackview BV5800)
![Android Screenshot](https://user-images.githubusercontent.com/56440821/82157351-dd07e100-9878-11ea-9bd9-9dd39b089b84.jpeg)


## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

N/A
