### PR TITLE
Switch consent screens to use new style checkbox

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -23,6 +23,10 @@ const checkboxStyles = StyleSheet.create({
     marginRight: 32,
   },
 
+  checkBoxText: {
+    borderColor: 'transparent',
+  },
+
   unselectedCheckBoxLabel: {
     color: colors.tertiary,
   },
@@ -57,9 +61,9 @@ export const CheckboxItem: React.FC<CheckboxProps> = (props) => {
       <TouchableOpacity style={checkboxStyles.checkBox} onPress={() => props.onChange(!props.value)}>
         {props.value && <Check />}
       </TouchableOpacity>
-      <TouchableWithoutFeedback onPress={() => props.onChange(!props.value)}>
+      <Item style={checkboxStyles.checkBoxText} onPress={() => props.onChange(!props.value)}>
         <RegularText style={{ ...checkboxStyles.checkboxLabel, ...labelStyle }}>{props.children}</RegularText>
-      </TouchableWithoutFeedback>
+      </Item>
     </Item>
   );
 };

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,7 +1,6 @@
 import { Item, View } from 'native-base';
 import React from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
-import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 
 import Check from '../../assets/icons/Check';
 import { colors } from '../../theme/colors';

--- a/src/features/register/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen.tsx
@@ -1,10 +1,10 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Body, CheckBox, ListItem } from 'native-base';
 import React, { Component } from 'react';
 import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 
 import { colors } from '../../../theme';
+import { CheckboxItem, CheckboxList } from '../../components/Checkbox';
 import { BrandedButton, ClickableText, RegularBoldText, RegularText } from '../../components/Text';
 import UserService, { isGBCountry, isSECountry, isUSCountry } from '../../core/user/UserService';
 import i18n from '../../locale/i18n';
@@ -152,40 +152,30 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
         </RegularText>
 
         {!this.viewOnly && (
-          <View>
-            <ListItem style={styles.permission}>
-              <CheckBox checked={this.state.processingChecked} onPress={() => this.handleToggle('processingChecked')} />
-              <Body style={styles.label}>
-                <RegularText>
-                  I consent to the processing of my personal data (including without limitation data I provide relating
-                  to my health) as set forth in this consent and in the{' '}
-                  <ClickableText
-                    onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
-                    Privacy Policy
-                  </ClickableText>
-                  .
-                </RegularText>
-              </Body>
-            </ListItem>
-            <ListItem>
-              <CheckBox checked={this.state.termsOfUseChecked} onPress={() => this.handleToggle('termsOfUseChecked')} />
-              <Body style={styles.label}>
-                <RegularText>
-                  I have read and accept Zoe Global’s{' '}
-                  <ClickableText
-                    onPress={() => this.props.navigation.navigate('TermsOfUseUS', { viewOnly: this.viewOnly })}>
-                    Terms of Use
-                  </ClickableText>{' '}
-                  and{' '}
-                  <ClickableText
-                    onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
-                    Privacy Policy
-                  </ClickableText>
-                  .
-                </RegularText>
-              </Body>
-            </ListItem>
-          </View>
+          <CheckboxList>
+            <CheckboxItem value={this.state.processingChecked} onChange={() => this.handleToggle('processingChecked')}>
+              I consent to the processing of my personal data (including without limitation data I provide relating to
+              my health) as set forth in this consent and in the{' '}
+              <ClickableText
+                onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
+                Privacy Policy
+              </ClickableText>
+              .
+            </CheckboxItem>
+            <CheckboxItem value={this.state.termsOfUseChecked} onChange={() => this.handleToggle('termsOfUseChecked')}>
+              I have read and accept Zoe Global’s{' '}
+              <ClickableText
+                onPress={() => this.props.navigation.navigate('TermsOfUseUS', { viewOnly: this.viewOnly })}>
+                Terms of Use
+              </ClickableText>{' '}
+              and{' '}
+              <ClickableText
+                onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
+                Privacy Policy
+              </ClickableText>
+              .
+            </CheckboxItem>
+          </CheckboxList>
         )}
       </ScrollView>
     );
@@ -380,46 +370,29 @@ export class ConsentScreen extends Component<PropsType, TermsState> {
         </RegularText>
 
         {!this.viewOnly && (
-          <View>
-            <ListItem style={styles.permission}>
-              <CheckBox
-                checked={this.state.swedenParticipateChecked}
-                onPress={() => this.handleToggle('swedenParticipateChecked')}
-              />
-              <Body style={styles.label}>
-                <RegularText>
-                  Jag är 18 år eller äldre och jag samtycker till att delta i studien ”Nationellt initiativ för att via
-                  en app i realtid kartlägga samhällspridningen av covid-19 i Sverige samt riskfaktorer för att drabbas
-                  av en allvarlig sjukdomsbild vid covid-19”.
-                </RegularText>
-              </Body>
-            </ListItem>
-            <ListItem>
-              <CheckBox
-                checked={this.state.swedenProcessingChecked}
-                onPress={() => this.handleToggle('swedenProcessingChecked')}
-              />
-              <Body style={styles.label}>
-                <RegularText>
-                  Jag samtycker till att personuppgifter om mig behandlas på det sätt som beskrivs i informationen till
-                  studiedeltagare ovan.
-                </RegularText>
-              </Body>
-            </ListItem>
-            <ListItem>
-              <CheckBox checked={this.state.swedenAgreeZoe} onPress={() => this.handleToggle('swedenAgreeZoe')} />
-              <Body style={styles.label}>
-                <RegularText>
-                  Jag har läst och accepterar Zoe Global Ltd{' '}
-                  <ClickableText
-                    onPress={() => this.props.navigation.navigate('PrivacyPolicySV', { viewOnly: this.viewOnly })}>
-                    integritetspolicy
-                  </ClickableText>
-                  .
-                </RegularText>
-              </Body>
-            </ListItem>
-          </View>
+          <CheckboxList>
+            <CheckboxItem
+              value={this.state.swedenParticipateChecked}
+              onChange={() => this.handleToggle('swedenParticipateChecked')}>
+              Jag är 18 år eller äldre och jag samtycker till att delta i studien ”Nationellt initiativ för att via en
+              app i realtid kartlägga samhällspridningen av covid-19 i Sverige samt riskfaktorer för att drabbas av en
+              allvarlig sjukdomsbild vid covid-19”.
+            </CheckboxItem>
+            <CheckboxItem
+              value={this.state.swedenProcessingChecked}
+              onChange={() => this.handleToggle('swedenProcessingChecked')}>
+              Jag samtycker till att personuppgifter om mig behandlas på det sätt som beskrivs i informationen till
+              studiedeltagare ovan.
+            </CheckboxItem>
+            <CheckboxItem value={this.state.swedenAgreeZoe} onChange={() => this.handleToggle('swedenAgreeZoe')}>
+              Jag har läst och accepterar Zoe Global Ltd{' '}
+              <ClickableText
+                onPress={() => this.props.navigation.navigate('PrivacyPolicySV', { viewOnly: this.viewOnly })}>
+                integritetspolicy
+              </ClickableText>
+              .
+            </CheckboxItem>
+          </CheckboxList>
         )}
       </ScrollView>
     );
@@ -461,11 +434,5 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 20,
-  },
-  permission: {
-    alignItems: 'flex-start',
-  },
-  label: {
-    marginLeft: 10,
   },
 });

--- a/src/features/register/us/NursesConsentUS.tsx
+++ b/src/features/register/us/NursesConsentUS.tsx
@@ -1,10 +1,10 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Body, CheckBox, ListItem } from 'native-base';
 import React, { Component } from 'react';
 import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 
 import { colors } from '../../../../theme';
+import { CheckboxItem, CheckboxList } from '../../../components/Checkbox';
 import { BrandedButton, ClickableText, RegularBoldText, RegularText } from '../../../components/Text';
 import UserService from '../../../core/user/UserService';
 import { ScreenParamList } from '../../ScreenParamList';
@@ -300,40 +300,30 @@ export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
           </RegularText>
 
           {!this.viewOnly && (
-            <>
-              <ListItem style={styles.permission}>
-                <CheckBox checked={this.state.processingChecked} onPress={this.handleProcessingChange} />
-                <Body style={styles.label}>
-                  <RegularText>
-                    I consent to the processing of my personal data (including without limitation data I provide
-                    relating to my health) as set forth in this consent and in the{' '}
-                    <ClickableText
-                      onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
-                      Privacy Policy
-                    </ClickableText>
-                    .
-                  </RegularText>
-                </Body>
-              </ListItem>
-              <ListItem>
-                <CheckBox checked={this.state.termsOfUseChecked} onPress={this.handleTermsOfUseChange} />
-                <Body style={styles.label}>
-                  <RegularText>
-                    I have read and accept Zoe Global’s{' '}
-                    <ClickableText
-                      onPress={() => this.props.navigation.navigate('TermsOfUseUS', { viewOnly: this.viewOnly })}>
-                      Terms of Use
-                    </ClickableText>{' '}
-                    and{' '}
-                    <ClickableText
-                      onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
-                      Privacy Policy
-                    </ClickableText>
-                    .
-                  </RegularText>
-                </Body>
-              </ListItem>
-            </>
+            <CheckboxList>
+              <CheckboxItem value={this.state.processingChecked} onChange={this.handleProcessingChange}>
+                I consent to the processing of my personal data (including without limitation data I provide relating to
+                my health) as set forth in this consent and in the{' '}
+                <ClickableText
+                  onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
+                  Privacy Policy
+                </ClickableText>
+                .
+              </CheckboxItem>
+              <CheckboxItem value={this.state.termsOfUseChecked} onChange={this.handleTermsOfUseChange}>
+                I have read and accept Zoe Global’s{' '}
+                <ClickableText
+                  onPress={() => this.props.navigation.navigate('TermsOfUseUS', { viewOnly: this.viewOnly })}>
+                  Terms of Use
+                </ClickableText>{' '}
+                and{' '}
+                <ClickableText
+                  onPress={() => this.props.navigation.navigate('PrivacyPolicyUS', { viewOnly: this.viewOnly })}>
+                  Privacy Policy
+                </ClickableText>
+                .
+              </CheckboxItem>
+            </CheckboxList>
           )}
         </ScrollView>
 
@@ -365,11 +355,5 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 20,
-  },
-  permission: {
-    alignItems: 'flex-start',
-  },
-  label: {
-    marginLeft: 10,
   },
 });


### PR DESCRIPTION
# Description

Following the re-design in #279, this PR switches the remaining checkboxes to the new style.
These were located on the consent screens. 
As a result, this PR:
[1] Switches CheckboxItem from using `TouchableWithoutFeedback` to using `Item`, in order to allow children (in this case `ClickableText`) to still function correctly. 
[2] Switches the US and SE standard consent screens to use the new checkbox style.
[3] Switches the US study consent screen to use the new checkbox style.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="300" alt="Screenshot 2020-05-17 at 19 59 06" src="https://user-images.githubusercontent.com/52913482/82157612-6370f280-987a-11ea-93a0-dfd54982c937.png"> <img width="300" alt="Screenshot 2020-05-17 at 20 00 16" src="https://user-images.githubusercontent.com/52913482/82157613-666be300-987a-11ea-931b-0c90990295a7.png">

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
