### PR TITLE
Simple storage wrapper around AsyncStorage.

### DIFF
--- a/src/core/LocalStorageService.ts
+++ b/src/core/LocalStorageService.ts
@@ -1,0 +1,27 @@
+import { AsyncStorage } from 'react-native';
+
+export interface IStorageService {
+  setObject<T>(key: string, obj: T): Promise<void>;
+  getObject<T>(key: string): Promise<T | null>;
+}
+
+class LocalStorageService implements IStorageService {
+  async setObject<T>(key: string, obj: T): Promise<void> {
+    try {
+      return await AsyncStorage.setItem(key, JSON.stringify(obj));
+    } catch (error) {
+      // Silently fail
+    }
+  }
+
+  async getObject<T>(key: string): Promise<T | null> {
+    try {
+      const val = await AsyncStorage.getItem(key);
+      return !!val ? <T>JSON.parse(val) : null;
+    } catch (error) {
+      return null;
+    }
+  }
+}
+
+export default LocalStorageService;


### PR DESCRIPTION
# Description

LocalStorageService is just a simple API wrapper around AsyncStorage, with a generic-based method interface. So it supports serialising/deserialising plain data objects, stashing them into AsyncStorage as JSON documents.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
