### PR TITLE
Create API client

### DIFF
--- a/src/core/api/ApiClient.ts
+++ b/src/core/api/ApiClient.ts
@@ -1,0 +1,21 @@
+import { ApiClientBase } from '../user/ApiClientBase';
+import { handleServiceError } from '../ApiServiceErrors';
+
+export interface IApiClient {
+  post<T>(path: string, object: T): Promise<T>;
+}
+
+export default class ApiClient extends ApiClientBase implements IApiClient {
+  protected client = ApiClientBase.client;
+
+  async post<T>(path: string, payload: T): Promise<T> {
+    try {
+      const response = await this.client.post<T>(path, payload);
+      console.log("[RESPONSE]:", response);
+      return response.data;
+    } catch (error) {
+      handleServiceError(error);
+    }
+    return {} as T;
+  }
+}

--- a/src/core/api/ApiClient.ts
+++ b/src/core/api/ApiClient.ts
@@ -11,7 +11,6 @@ export default class ApiClient extends ApiClientBase implements IApiClient {
   async post<T>(path: string, payload: T): Promise<T> {
     try {
       const response = await this.client.post<T>(path, payload);
-      console.log("[RESPONSE]:", response);
       return response.data;
     } catch (error) {
       handleServiceError(error);

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import * as Localization from 'expo-localization';
 import moment from 'moment';
 
-import { isAndroid } from '../../components/Screen';
+import { isAndroid } from '../utils/platform';
 import i18n from '../../locale/i18n';
 import { AvatarName } from '../../utils/avatar';
 import { AsyncStorageService } from '../AsyncStorageService';

--- a/src/core/utils/platform.ts
+++ b/src/core/utils/platform.ts
@@ -1,0 +1,4 @@
+import { Platform } from 'react-native';
+
+export const isAndroid = Platform.OS === 'android';
+export const isIos = Platform.OS === 'ios';


### PR DESCRIPTION
# Description

Starts an API client that wraps APIClient base, with generic HTTP methods so we can separate out the services from the backend API they persist data. This implements just enough to support PushNotificationService.

Every service that needs to communicate with the Backend API will talk to a service specific API client, which in turn talks to this API Client, which wraps Axios. Because this API client wraps the ApiClientBase it inherits the userToken management, so we can do authenticated requests without each service having to deal with it itself.

This is necessary step to break apart User Service in a meaningful way,

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [X] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
