### PR TITLE
fixing bob issues

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -30,7 +30,7 @@ const ErrorMessaging = ({ error, status, onRetry, onPress }: LoadingProps) => {
   return (
     <View>
       {!!message && <ErrorText style={{ color: colors.coral }}>{message}</ErrorText>}
-      {!message && status && <RegularText>{status}</RegularText>}
+      {!message && !!status && <RegularText>{status}</RegularText>}
       {shouldRetry && !!onRetry && (
         <View style={styles.ctaBlock}>
           <BrandedButton onPress={onRetry}>{i18n.t('errors.button-retry')}</BrandedButton>

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -87,6 +87,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
   async startAssessment(patientId: string) {
     try {
       const currentPatient = await userService.getCurrentPatient(patientId);
+      this.setState({isApiError: false});
       Navigator.startAssessment(currentPatient);
     } catch (error) {
       this.setState({

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -87,7 +87,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
   async startAssessment(patientId: string) {
     try {
       const currentPatient = await userService.getCurrentPatient(patientId);
-      this.setState({isApiError: false});
+      this.setState({ isApiError: false });
       Navigator.startAssessment(currentPatient);
     } catch (error) {
       this.setState({

--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -49,7 +49,7 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
 
   private async gotoNextScreen(patientId: string) {
     const currentPatient = await userService.getCurrentPatient(patientId);
-    this.setState({isApiError: false});
+    this.setState({ isApiError: false });
     Navigator.gotoNextScreen(this.props.route.name, { currentPatient });
   }
 

--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -49,6 +49,7 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
 
   private async gotoNextScreen(patientId: string) {
     const currentPatient = await userService.getCurrentPatient(patientId);
+    this.setState({isApiError: false});
     Navigator.gotoNextScreen(this.props.route.name, { currentPatient });
   }
 


### PR DESCRIPTION
# Description

* Bob 2: Turn off isApiError flag before exiting the SelectProfile screen.
* Bob 3: replicated it once, but not again. Have traced a possible cause of `"Text strings must be rendered within a <Text> component"` and fixed that, and applied the same fix as Bob 2 prior to navigating off the page. Can't confirm Bob 3 is fixed yet.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [X] iOS - Physical device

## Screenshots

Bob 2 fixed:
https://www.dropbox.com/l/scl/AAASpxDRtCPmauPXZE2U_s4_BIeVs1zGSmU


## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
