### PR TITLE
Fix i18n strings mismatches between en and sv-SE.

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -304,7 +304,6 @@
 
     "picker-waiting": "Waiting for results",
     "picker-test-failed": "Not clear/Test Failed",
-    "picker-never-had-test": "Never had test",
 
     "question-knows-date-of-test": "Do you know the date of your test?",
     "question-date-test-occurred": "When was your test?",
@@ -424,8 +423,6 @@
   "treatment-selection-picker-invasive-ventilation": "Invasive ventilation*",
   "treatment-selection-picker-subtext-invasive-ventilation": "* Breathing support through an inserted tube. People are usually asleep for this procedure.",
   "treatment-selection-picker-other": "Other",
-
-  "do-you-use-a-stick": "Do you regularly use a stick, walking frame or wheelchair to get about?",
 
   "have-you-been-exposed": "Have you EVER been exposed to someone with documented or suspected COVID-19 infection (such as co-workers, family members, or others)",
   "exposed-yes-documented": "Yes, documented COVID-19 cases only",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -314,7 +314,6 @@
       "question-has-chest-pain": "Känner du ovanlig smärta eller stramhet i bröstet?",
       "question-has-abdominal-pain": "Har du ont i magen/buken på ett sätt som du inte brukar ha?",
       "question-has-diarrhoea": "Har du diarré?",
-      "placeholder-has-diarrhoea": "Har du diarré?",
       "question-diarrhoea-frequency": "Hur många lösa avföringar har du haft under det senaste dygnet?",
       "required-diarrhoea-frequency": "Ange hur många lösa avföringar du har haft det senaste dygnet",
       "question-has-delirium": "Har du något av följande symtom: förvirring, desorientering eller dåsighet?",


### PR DESCRIPTION
# Description

As a result of the new i18n tests, it's picked up 3 discrepancies between en and sv-SE.

* In `sv-SE` but not in `en`: `placeholder-has-diarrhoea` -- not in use, so REMOVED
* In `en` but not `sv-SE`: `picker-never-had-test` and `do-you-use-a-stick`, both not in use, so REMOVED.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist
- [ ] I have updated mockServer

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
