### PR TITLE
Update uk thank you screen

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -475,7 +475,7 @@
 
   "thank-you-title": "Thank you for your help and vital contribution to the study of COVID-19.",
   "blog-link": "https://covid.joinzoe.com/blog",
-  "thank-you-body": "Thank you for joining millions of people supporting scientists at King’s College London to help our health services.",
+  "thank-you-body": "Thank you for reporting. As we ease lockdown, your daily reporting is more important than ever to avoid a second wave.",
   "check-in-tomorrow": "We would appreciate it if you could check back in tomorrow if you feel up to it.",
   "check-news-feed": "Please check our <b>news feed</b> for updates.",
   "faq-link": "https://covid.joinzoe.com/faq",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -475,7 +475,7 @@
 
   "thank-you-title": "Thank you for your help and vital contribution to the study of COVID-19.",
   "blog-link": "https://covid.joinzoe.com/blog",
-  "thank-you-body": "Thank you for reporting. As we ease lockdown, your daily reporting is more important than ever to avoid a second wave.",
+  "thank-you-body": "Thank you for joining millions of people supporting scientists at King’s College London to help our health services.",
   "check-in-tomorrow": "We would appreciate it if you could check back in tomorrow if you feel up to it.",
   "check-news-feed": "Please check our <b>news feed</b> for updates.",
   "faq-link": "https://covid.joinzoe.com/faq",


### PR DESCRIPTION
As part of the work around the Validation Study, we have to adjust our brand positioning alongside KCL's.

This is a simple ticket ahead of the general ThankYou screen refactor, to change the top text from "Thank you for joining millions of people supporting scientists at King's College London to help our health services"

to

"Thank you for reporting. As we ease lockdown, your daily reporting is more important than ever to avoid a second wave."