### PR TITLE
Adds 2 US cohorts

### DIFF
--- a/src/features/patient/YourStudyScreen.tsx
+++ b/src/features/patient/YourStudyScreen.tsx
@@ -4,7 +4,7 @@ import { Formik } from 'formik';
 import { cloneDeep } from 'lodash';
 import { Form, Item, Label } from 'native-base';
 import React, { Component } from 'react';
-import { KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import * as Yup from 'yup';
 
 import { CheckboxItem, CheckboxList } from '../../components/Checkbox';
@@ -64,6 +64,11 @@ const AllCohorts: CohortDefinition[] = [
     key: 'is_in_uk_guys_trust',
     label: "Guys & St Thomas' Hospital Trust",
     country: 'GB',
+  },
+  {
+    key: 'is_in_us_covid_siren',
+    label: 'COVID SIREN',
+    country: 'US',
   },
   {
     key: 'is_in_us_nurses_study',
@@ -193,6 +198,11 @@ const AllCohorts: CohortDefinition[] = [
   {
     key: 'is_in_us_louisiana_state_university',
     label: 'Louisiana State University',
+    country: 'US',
+  },
+  {
+    key: 'is_in_us_northshore_genomic_health_initiative',
+    label: 'NorthShore Genomic Health Initiative',
     country: 'US',
   },
 ];


### PR DESCRIPTION
# Description

Adds 2 US cohorts for Tuesday's launch. 


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [y] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Screenshot 2020-05-22 at 12 42 01](https://user-images.githubusercontent.com/7824212/82664523-c91dff80-9c29-11ea-948f-5c620afd1ac7.png)

![Screenshot 2020-05-22 at 12 39 56](https://user-images.githubusercontent.com/7824212/82664528-cb805980-9c29-11ea-9bb2-10fba6d3d3ff.png)


## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
