### PR TITLE
Add inline formatting of text strings.

### DIFF
--- a/markdown.d.ts
+++ b/markdown.d.ts
@@ -1,0 +1,40 @@
+declare module 'react-native-easy-markdown' {
+  import React from 'react';
+  import { StyleProp, TextStyle, ViewProps, ViewStyle } from 'react-native';
+
+  export interface IProps {
+    debug?: boolean;
+    parseInline?: boolean;
+    useDefaultStyles?: boolean;
+    renderImage?: (src: string, alt: string, title: string) => React.ReactNode;
+    renderLink?: (href: string, title: string, children: React.ReactNode) => React.ReactNode;
+    renderListBullet?: (ordered: boolean, index: number) => React.ReactNode;
+    markdownStyles?: {
+      block?: StyleProp<ViewStyle>;
+      blockQuote?: StyleProp<TextStyle>;
+      del?: StyleProp<TextStyle>;
+      em?: StyleProp<TextStyle>;
+      h1?: StyleProp<TextStyle>;
+      h2?: StyleProp<TextStyle>;
+      h3?: StyleProp<TextStyle>;
+      h4?: StyleProp<TextStyle>;
+      h5?: StyleProp<TextStyle>;
+      h6?: StyleProp<TextStyle>;
+      hr?: StyleProp<TextStyle>;
+      image?: StyleProp<TextStyle>;
+      imageWrapper?: StyleProp<ViewStyle>;
+      link?: StyleProp<TextStyle>;
+      linkWrapper?: StyleProp<TextStyle>;
+      list?: StyleProp<TextStyle>;
+      listItem?: StyleProp<TextStyle>;
+      listItemBullet?: StyleProp<TextStyle>;
+      listItemContent?: StyleProp<TextStyle>;
+      listItemNumber?: StyleProp<TextStyle>;
+      strong?: StyleProp<TextStyle>;
+      text?: StyleProp<TextStyle>;
+      u?: StyleProp<TextStyle>;
+    };
+  }
+
+  export default class Markdown extends React.Component<IProps & ViewProps> {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10812,6 +10812,14 @@
         "lodash": "^4.17.15"
       }
     },
+    "react-native-easy-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-easy-markdown/-/react-native-easy-markdown-2.0.0.tgz",
+      "integrity": "sha512-vGK41pZj/4lM9q8/Bqox/2qqfJVrSxLugBWDBNLuOqvxpBw/b3q4aUxCpP8nyBWv5BifrD8+OcdhC27bRvEFIw==",
+      "requires": {
+        "simple-markdown": "^0.4.4"
+      }
+    },
     "react-native-gesture-handler": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.5.6.tgz",
@@ -11641,6 +11649,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-markdown": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/simple-markdown/-/simple-markdown-0.4.4.tgz",
+      "integrity": "sha512-ZmlNUGR1KI12sPHeQ7dQY1qM5KfOgFqClNNVO8zQ9Pg6u7gHLCPFGD+VC7MCwpGDMd1uw3Bb2TfFfR8d6bB34A=="
     },
     "simple-plist": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
     "react-native-calendar-picker": "^6.0.6",
     "react-native-dotenv": "^0.2.0",
+    "react-native-easy-markdown": "^2.0.0",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-progress": "^4.0.3",
     "react-native-reanimated": "~1.4.0",

--- a/src/components/InlineFormatting.tsx
+++ b/src/components/InlineFormatting.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Markdown from 'react-native-easy-markdown';
+import { fontStyles, colors } from '../../theme';
+
+type FormattingProps = {
+  text: string;
+};
+
+const defaultStyles = {
+  text: {
+    ...fontStyles.bodyReg,
+    color: colors.lightBrand,
+  },
+  em: {
+    color: colors.white,
+  },
+  strong: {
+    color: colors.white,
+  },
+};
+
+export const InlineFormatting = ({ text }: FormattingProps) => {
+  return <Markdown markdownStyles={defaultStyles}>{text}</Markdown>;
+};


### PR DESCRIPTION
# Description

Allows very basic inline formatting of strings, e.g. i18n strings.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
