### PR TITLE
Fix default test picker date

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -279,6 +279,7 @@
     "update-test": "Update test",
 
     "question-select-a-date-range": "Select a date range",
+    "question-select-a-date": "Select a date",
 
     "question-mechanism": "How was this test performed?",
     "picker-nose-swab": "Someone swabbed my nose",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -248,6 +248,7 @@
     "add-test": "Lägg till test",
     "update-test": "Uppdatera test",
     "question-select-a-date-range": "Välj ett datumintervall",
+    "question-select-a-date": "Välj ett datum",
 
     "question-mechanism": "Hur utfördes testet?",
     "picker-nose-swab": "En testpinne i näsan",

--- a/src/features/assessment/CovidTestDetailScreen.tsx
+++ b/src/features/assessment/CovidTestDetailScreen.tsx
@@ -12,7 +12,7 @@ import DropdownField from '../../components/DropdownField';
 import { GenericTextField } from '../../components/GenericTextField';
 import ProgressStatus from '../../components/ProgressStatus';
 import Screen, { FieldWrapper, Header, isAndroid, ProgressBlock, screenWidth } from '../../components/Screen';
-import { BrandedButton, ClickableText, ErrorText, HeaderText } from '../../components/Text';
+import { BrandedButton, ClickableText, ErrorText, HeaderText, RegularText, CaptionText } from '../../components/Text';
 import { ValidationErrors } from '../../components/ValidationError';
 import CovidTestService from '../../core/user/CovidTestService';
 import { CovidTest } from '../../core/user/dto/CovidTestContracts';
@@ -20,6 +20,7 @@ import i18n from '../../locale/i18n';
 import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
 import { IOption } from '../patient/YourWorkScreen/helpers';
+import { colors, fontStyles } from '../../../theme';
 
 interface CovidTestData {
   knowsDateOfTest: string; // only for ux logic
@@ -254,8 +255,12 @@ export default class CovidTestDetailScreen extends Component<CovidProps, State> 
                           {...(!!this.state.dateTakenSpecific && { selectedStartDate: this.state.dateTakenSpecific })}
                         />
                       ) : (
-                        <ClickableText onPress={() => this.setState({ showDatePicker: true })}>
-                          {moment(this.state.dateTakenSpecific).format('Do of MMMM YYYY')}
+                        <ClickableText
+                          onPress={() => this.setState({ showDatePicker: true })}
+                          style={styles.placeholderText}>
+                          {!!this.state.dateTakenSpecific
+                            ? moment(this.state.dateTakenSpecific).format('Do of MMMM YYYY')
+                            : i18n.t('covid-test.required-date')}
                         </ClickableText>
                       )}
                     </Item>
@@ -340,5 +345,12 @@ export default class CovidTestDetailScreen extends Component<CovidProps, State> 
 const styles = StyleSheet.create({
   labelStyle: {
     marginBottom: 30,
+  },
+
+  placeholderText: {
+    ...fontStyles.bodyReg,
+    alignSelf: 'flex-start',
+    paddingLeft: 20,
+    paddingBottom: 10,
   },
 });

--- a/src/features/assessment/CovidTestDetailScreen.tsx
+++ b/src/features/assessment/CovidTestDetailScreen.tsx
@@ -255,12 +255,12 @@ export default class CovidTestDetailScreen extends Component<CovidProps, State> 
                           {...(!!this.state.dateTakenSpecific && { selectedStartDate: this.state.dateTakenSpecific })}
                         />
                       ) : (
-                        <ClickableText
-                          onPress={() => this.setState({ showDatePicker: true })}
-                          style={styles.placeholderText}>
-                          {!!this.state.dateTakenSpecific
-                            ? moment(this.state.dateTakenSpecific).format('Do of MMMM YYYY')
-                            : i18n.t('covid-test.required-date')}
+                        <ClickableText onPress={() => this.setState({ showDatePicker: true })} style={styles.fieldText}>
+                          {!!this.state.dateTakenSpecific ? (
+                            moment(this.state.dateTakenSpecific).format('Do of MMMM YYYY')
+                          ) : (
+                            <RegularText>{i18n.t('covid-test.required-date')}</RegularText>
+                          )}
                         </ClickableText>
                       )}
                     </Item>
@@ -283,7 +283,9 @@ export default class CovidTestDetailScreen extends Component<CovidProps, State> 
                           maxDate={this.state.today}
                         />
                       ) : (
-                        <ClickableText onPress={() => this.setState({ showRangePicker: true })}>
+                        <ClickableText
+                          onPress={() => this.setState({ showRangePicker: true })}
+                          style={styles.fieldText}>
                           {this.state.dateTakenBetweenStart && this.state.dateTakenBetweenEnd ? (
                             <>
                               {'Between '}
@@ -347,8 +349,9 @@ const styles = StyleSheet.create({
     marginBottom: 30,
   },
 
-  placeholderText: {
+  fieldText: {
     ...fontStyles.bodyReg,
+    color: colors.black,
     alignSelf: 'flex-start',
     paddingLeft: 20,
     paddingBottom: 10,


### PR DESCRIPTION
# Description

Don't show current date as the default value for the date picker. And fix the styling.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

Default placeholder text:
<img width="377" alt="Screenshot 2020-05-26 at 10 42 25" src="https://user-images.githubusercontent.com/61784325/82885986-caa73a80-9f3d-11ea-95ab-b2ad32e8c313.png">

Date selected text:
<img width="404" alt="Screenshot 2020-05-26 at 10 42 34" src="https://user-images.githubusercontent.com/61784325/82885984-ca0ea400-9f3d-11ea-8cd9-4caa281aac11.png">


## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
