### PR TITLE
Removes the donation module 

### DIFF
--- a/src/features/ThankYouScreen.tsx
+++ b/src/features/ThankYouScreen.tsx
@@ -5,13 +5,11 @@ import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 
 import { colors } from '../../theme';
 import { CovidRating, shouldAskForRating } from '../components/CovidRating';
-import Donate from '../components/Donate';
 import ProgressStatus from '../components/ProgressStatus';
 import { Header, ProgressBlock } from '../components/Screen';
 import ShareThisApp from '../components/ShareThisApp';
 import { ClickableText, HeaderText, RegularText } from '../components/Text';
 import VisitWebsite from '../components/VisitWebsite';
-import { isGBCountry } from '../core/user/UserService';
 import i18n from '../locale/i18n';
 import { ScreenParamList } from './ScreenParamList';
 
@@ -51,18 +49,8 @@ export default class ThankYouScreen extends Component<RenderProps, { askForRatin
                 <RegularText>{i18n.t('thank-you-body')}</RegularText>
               </View>
 
-              {isGBCountry() ? (
-                <>
-                  <Donate />
-                  <VisitWebsite />
-                  <ShareThisApp ctaStyle="link" />
-                </>
-              ) : (
-                <>
-                  <ShareThisApp ctaStyle="button" />
-                  <VisitWebsite />
-                </>
-              )}
+              <ShareThisApp ctaStyle="button" />
+              <VisitWebsite />
 
               <RegularText style={styles.shareSubtitle}>{i18n.t('check-in-tomorrow')}</RegularText>
 


### PR DESCRIPTION
# Description

Removes the donation module from the UK ThankYourScreen, as we don't want this live as we launch the validation study. I've left the Donation component in the code base for now. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
