### PR TITLE
Add Analytics to the Validation Study Consent

### DIFF
--- a/src/core/Analytics.ts
+++ b/src/core/Analytics.ts
@@ -16,6 +16,8 @@ export const events = {
   DELETE_ACCOUNT_DATA: 'DELETE_ACCOUNT_DATA',
   SHARE_THIS_APP: 'SHARE_THIS_APP',
   DONATE: 'DONATE',
+  JOIN_STUDY: 'JOIN_STUDY',
+  DECLINE_STUDY: 'DECLINE_STUDY',
 };
 
 // Disable Tracking of the User Properties (Only available in Expo SDK 37)

--- a/src/features/register/gb/ValidationStudyConsentScreen.tsx
+++ b/src/features/register/gb/ValidationStudyConsentScreen.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import Navigator from '../../Navigation';
 import { ScreenParamList } from '../../ScreenParamList';
+import Analytics, { events } from '@covid/core/Analytics';
 
 type PropsType = {
   navigation: StackNavigationProp<ScreenParamList, 'ValidationStudyConsent'>;
@@ -48,6 +49,7 @@ export default class ValidationStudyConsentScreen extends Component<PropsType, T
 
   handleAgreeClicked = async () => {
     if (this.state.agreeToAbove) {
+      Analytics.track(events.JOIN_STUDY);
       this.userService.setValidationStudyResponse(true, this.state.anonymizedData, this.state.reContacted);
       Navigator.resetToProfileStartAssessment(this.props.route.params.currentPatient);
     }
@@ -122,7 +124,7 @@ export default class ValidationStudyConsentScreen extends Component<PropsType, T
               either by ordering a testing kit in the mail or visiting a Regional Testing Centre. Alternatively, Zoe may
               apply for testing on your behalf to the Department of Health and Social Care, through an online platform
               where Zoe will share your name, mobile phone number, and email address to register you for testing. Swab
-              testing involves collecting a sample to test if you have COVID by inserting a long swab (like a long
+              testing involves collecting a sample to test if you have COVID by inserting a long swab (like a long
               cotton wool bud) into the back of your nose or mouth and rotating the swab several times. Organising and
               completing the Covid-19 test is optional. Once you have received your test result, you will be asked to
               report it in the Covid-19 Symptom Study app.

--- a/src/features/register/gb/ValidationStudyIntroScreen.tsx
+++ b/src/features/register/gb/ValidationStudyIntroScreen.tsx
@@ -57,7 +57,6 @@ export default class ValidationStudyIntroScreen extends Component<Props, object>
           <BrandedButton
             style={styles.mainButton}
             onPress={() => {
-              Analytics.track(events.JOIN_STUDY);
               this.props.navigation.navigate('ValidationStudyConsent', {
                 viewOnly: false,
                 currentPatient: this.props.route.params.currentPatient,

--- a/src/features/register/gb/ValidationStudyIntroScreen.tsx
+++ b/src/features/register/gb/ValidationStudyIntroScreen.tsx
@@ -13,6 +13,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import Navigator from '../../Navigation';
 import { ScreenParamList } from '../../ScreenParamList';
+import Analytics, { events } from '@covid/core/Analytics';
 
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'ValidationStudyIntro'>;
@@ -46,6 +47,7 @@ export default class ValidationStudyIntroScreen extends Component<Props, object>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             onPress={() => {
+              Analytics.track(events.DECLINE_STUDY);
               this.userService.setValidationStudyResponse(false);
               Navigator.resetToProfileStartAssessment(this.props.route.params.currentPatient);
             }}>
@@ -55,6 +57,7 @@ export default class ValidationStudyIntroScreen extends Component<Props, object>
           <BrandedButton
             style={styles.mainButton}
             onPress={() => {
+              Analytics.track(events.JOIN_STUDY);
               this.props.navigation.navigate('ValidationStudyConsent', {
                 viewOnly: false,
                 currentPatient: this.props.route.params.currentPatient,


### PR DESCRIPTION
# Description

Adds two track events on the Validation Study Consent Screen to track the who joins and who declines. 

Whilst we can infer this data from the Backend data or from the Screen View events, this will make it much much easier.

@abubuwe Proposal to cherry pick and OTA this tomorrow. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
