### PR TITLE
Pass down consent_version 

### DIFF
--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -24,6 +24,7 @@ import {
   StartupInfo,
   UserResponse,
 } from './dto/UserAPIContracts';
+import { ukValidationStudyConsentVersion } from '@covid/features/register/constants';
 
 const ASSESSMENT_VERSION = '1.4.0'; // TODO: Wire this to something automatic.
 const PATIENT_VERSION = '1.4.1'; // TODO: Wire this to something automatic.
@@ -525,14 +526,16 @@ export default class UserService extends ApiClientBase
   }
 
   async shouldAskForValidationStudy() {
-    const response = await this.client.get<AskValidationStudy>('/study_consent/status/');
+    const response = await this.client.get<AskValidationStudy>(
+      `/study_consent/status/?consent_version=${ukValidationStudyConsentVersion}`
+    );
     return response.data.should_ask_uk_validation_study;
   }
 
   setValidationStudyResponse(response: boolean, anonymizedData?: boolean, reContacted?: boolean) {
     return this.client.post('/study_consent/', {
       study: 'UK Validation Study',
-      version: 'v3',
+      version: ukValidationStudyConsentVersion,
       status: response ? 'signed' : 'declined',
       allow_future_data_use: anonymizedData,
       allow_contact_by_zoe: reContacted,

--- a/src/features/register/constants.ts
+++ b/src/features/register/constants.ts
@@ -5,3 +5,4 @@ export const consentVersionSE = 'v1';
 export const privacyPolicyVersionUS = 'v1.3';
 export const privacyPolicyVersionUK = 'v2.3';
 export const privacyPolicyVersionSE = 'v2.1';
+export const ukValidationStudyConsentVersion = 'v3';


### PR DESCRIPTION
# Description

Pass the App Consent version down to the backend, when determining whether to invite onto the study. People only the older version of the app, which have v1 of the study consent will not be invited to join. 

What's become very clear to me, is the the Consent Text needs to be in the backend. This can be done then next time we change the consent. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
