### PR TITLE
Migrate more questions to use GenericTextField

### DIFF
--- a/src/components/GenericTextField.tsx
+++ b/src/components/GenericTextField.tsx
@@ -13,11 +13,12 @@ interface GenericTextFieldProps {
   label?: string;
   placeholder?: string;
   keyboardType?: KeyboardTypeOptions;
+  showError?: boolean;
   inputProps?: any;
 }
 
 export const GenericTextField = (props: GenericTextFieldProps) => {
-  const { formikProps, name, label, placeholder, keyboardType, ...inputProps } = props;
+  const { formikProps, name, label, placeholder, keyboardType, showError, ...inputProps } = props;
   return (
     <FieldWrapper>
       <Item stackedLabel style={styles.textItemStyle}>
@@ -35,7 +36,7 @@ export const GenericTextField = (props: GenericTextFieldProps) => {
         />
       </Item>
 
-      {!!formikProps.errors[name] && (
+      {showError && !!formikProps.errors[name] && (
         <ValidationError
           // @ts-ignore - need to solve type for ValidationError error prop
           error={formikProps.errors[name]}

--- a/src/components/GenericTextField.tsx
+++ b/src/components/GenericTextField.tsx
@@ -34,8 +34,13 @@ export const GenericTextField = (props: GenericTextFieldProps) => {
           {...inputProps}
         />
       </Item>
-      // @ts-ignore - need to solve type for ValidationError error prop
-      {!!formikProps.errors[name] && <ValidationError error={formikProps.errors[name]} />}
+
+      {!!formikProps.errors[name] && (
+        <ValidationError
+          // @ts-ignore - need to solve type for ValidationError error prop
+          error={formikProps.errors[name]}
+        />
+      )}
     </FieldWrapper>
   );
 };

--- a/src/components/GenericTextField.tsx
+++ b/src/components/GenericTextField.tsx
@@ -5,6 +5,7 @@ import { KeyboardTypeOptions, StyleSheet } from 'react-native';
 
 import { FieldWrapper } from './Screen';
 import { ValidatedTextInput } from './ValidatedTextInput';
+import { ValidationError } from './ValidationError';
 
 interface GenericTextFieldProps {
   formikProps: FormikProps<any>;
@@ -33,6 +34,8 @@ export const GenericTextField = (props: GenericTextFieldProps) => {
           {...inputProps}
         />
       </Item>
+      // @ts-ignore - need to solve type for ValidationError error prop
+      {!!formikProps.errors[name] && <ValidationError error={formikProps.errors[name]} />}
     </FieldWrapper>
   );
 };

--- a/src/components/ValidatedTextInput.tsx
+++ b/src/components/ValidatedTextInput.tsx
@@ -1,8 +1,7 @@
+import { colors } from '@theme';
 import { Icon } from 'native-base';
 import React, { Component } from 'react';
 import { StyleSheet, TextInput, TextInputProps, View } from 'react-native';
-
-import { colors } from '@theme';
 
 interface Props extends TextInputProps {
   error?: any;

--- a/src/components/ValidationError.tsx
+++ b/src/components/ValidationError.tsx
@@ -1,7 +1,7 @@
+import i18n from '@covid/locale/i18n';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import i18n from '@covid/locale/i18n';
 import { ErrorText } from './Text';
 
 type ErrorProps = {

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -1,8 +1,8 @@
+import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
-import Screen, { Header, ProgressBlock, FieldWrapper } from '@covid/components/Screen';
+import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
-import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
-import { ValidationError, ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationErrors } from '@covid/components/ValidationError';
 import { PatientStateType } from '@covid/core/patient/PatientState';
 import UserService from '@covid/core/user/UserService';
 import { AssessmentInfosRequest, PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
@@ -12,9 +12,8 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik, FormikProps } from 'formik';
 import moment from 'moment';
-import { Form, Item, Label } from 'native-base';
+import { Form } from 'native-base';
 import React, { Component } from 'react';
-import { StyleSheet } from 'react-native';
 import * as Yup from 'yup';
 
 import { ScreenParamList } from '../ScreenParamList';
@@ -154,71 +153,29 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
           {(props) => {
             return (
               <Form>
-                <FieldWrapper>
-                  <Item stackedLabel style={styles.textItemStyle}>
-                    <Label>{i18n.t('level-of-isolation.question-little-interaction')}</Label>
-                    <ValidatedTextInput
-                      placeholder={i18n.t('level-of-isolation.placeholder-frequency')}
-                      value={props.values.isolationLittleInteraction}
-                      onChangeText={props.handleChange('isolationLittleInteraction')}
-                      onBlur={props.handleBlur('isolationLittleInteraction')}
-                      error={
-                        props.touched.isolationLittleInteraction &&
-                        props.errors.isolationLittleInteraction &&
-                        props.submitCount > 0
-                      }
-                      returnKeyType="next"
-                      keyboardType="numeric"
-                    />
-                  </Item>
-                  {!!props.errors.isolationLittleInteraction && props.submitCount > 0 && (
-                    <ValidationError error={props.errors.isolationLittleInteraction} />
-                  )}
-                </FieldWrapper>
+                <GenericTextField
+                  formikProps={props}
+                  placeholder={i18n.t('level-of-isolation.placeholder-frequency')}
+                  label={i18n.t('level-of-isolation.question-little-interaction')}
+                  name="isolationLittleInteraction"
+                  keyboardType="numeric"
+                />
 
-                <FieldWrapper>
-                  <Item stackedLabel style={styles.textItemStyle}>
-                    <Label>{i18n.t('level-of-isolation.question-lots-of-people')}</Label>
-                    <ValidatedTextInput
-                      placeholder={i18n.t('level-of-isolation.placeholder-frequency')}
-                      value={props.values.isolationLotsOfPeople}
-                      onChangeText={props.handleChange('isolationLotsOfPeople')}
-                      onBlur={props.handleBlur('isolationLotsOfPeople')}
-                      error={
-                        props.touched.isolationLotsOfPeople &&
-                        props.errors.isolationLotsOfPeople &&
-                        props.submitCount > 0
-                      }
-                      returnKeyType="next"
-                      keyboardType="numeric"
-                    />
-                  </Item>
-                  {!!props.errors.isolationLotsOfPeople && props.submitCount > 0 && (
-                    <ValidationError error={props.errors.isolationLotsOfPeople} />
-                  )}
-                </FieldWrapper>
+                <GenericTextField
+                  formikProps={props}
+                  placeholder={i18n.t('level-of-isolation.placeholder-frequency')}
+                  label={i18n.t('level-of-isolation.question-lots-of-people')}
+                  name="isolationLotsOfPeople"
+                  keyboardType="numeric"
+                />
 
-                <FieldWrapper>
-                  <Item stackedLabel style={styles.textItemStyle}>
-                    <Label>{i18n.t('level-of-isolation.question-healthcare-provider')}</Label>
-                    <ValidatedTextInput
-                      placeholder={i18n.t('level-of-isolation.placeholder-frequency')}
-                      value={props.values.isolationHealthcareProvider}
-                      onChangeText={props.handleChange('isolationHealthcareProvider')}
-                      onBlur={props.handleBlur('isolationHealthcareProvider')}
-                      error={
-                        props.touched.isolationHealthcareProvider &&
-                        props.errors.isolationHealthcareProvider &&
-                        props.submitCount > 0
-                      }
-                      returnKeyType="next"
-                      keyboardType="numeric"
-                    />
-                  </Item>
-                  {!!props.errors.isolationHealthcareProvider && props.submitCount > 0 && (
-                    <ValidationError error={props.errors.isolationHealthcareProvider} />
-                  )}
-                </FieldWrapper>
+                <GenericTextField
+                  formikProps={props}
+                  placeholder={i18n.t('level-of-isolation.placeholder-frequency')}
+                  label={i18n.t('level-of-isolation.question-healthcare-provider')}
+                  name="isolationHealthcareProvider"
+                  keyboardType="numeric"
+                />
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
@@ -239,9 +196,3 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
     );
   }
 }
-
-const styles = StyleSheet.create({
-  textItemStyle: {
-    borderColor: 'transparent',
-  },
-});

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -156,6 +156,7 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
                   label={i18n.t('level-of-isolation.question-little-interaction')}
                   name="isolationLittleInteraction"
                   keyboardType="numeric"
+                  showError
                 />
 
                 <GenericTextField
@@ -164,6 +165,7 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
                   label={i18n.t('level-of-isolation.question-lots-of-people')}
                   name="isolationLotsOfPeople"
                   keyboardType="numeric"
+                  showError
                 />
 
                 <GenericTextField
@@ -172,6 +174,7 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
                   label={i18n.t('level-of-isolation.question-healthcare-provider')}
                   name="isolationHealthcareProvider"
                   keyboardType="numeric"
+                  showError
                 />
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -320,24 +320,13 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
           {(props) => {
             return (
               <Form>
-                <FieldWrapper>
-                  <Item stackedLabel style={styles.textItemStyle}>
-                    <Label>{i18n.t('what-year-were-you-born')}</Label>
-                    <ValidatedTextInput
-                      placeholder={i18n.t('placeholder-year-of-birth')}
-                      value={props.values.yearOfBirth}
-                      onChangeText={props.handleChange('yearOfBirth')}
-                      onBlur={props.handleBlur('yearOfBirth')}
-                      error={props.touched.yearOfBirth && props.errors.yearOfBirth}
-                      returnKeyType="next"
-                      onSubmitEditing={() => {
-                        /* this.passwordComponent.focus(); */
-                      }}
-                      keyboardType="numeric"
-                    />
-                  </Item>
-                  {!!props.errors.yearOfBirth && <ValidationError error={props.errors.yearOfBirth} />}
-                </FieldWrapper>
+                <GenericTextField
+                  formikProps={props}
+                  label={i18n.t('what-year-were-you-born')}
+                  placeholder={i18n.t('placeholder-year-of-birth')}
+                  name="yearOfBirth"
+                  keyboardType="numeric"
+                />
 
                 <DropdownField
                   placeholder={i18n.t('placeholder-sex')}
@@ -559,24 +548,13 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                   {props.errors.weightUnit && <ValidationError error={props.errors.weightUnit} />}
                 </FieldWrapper>
 
-                <FieldWrapper>
-                  <Item stackedLabel style={styles.textItemStyle}>
-                    <Label>{i18n.t('your-postcode')}</Label>
-                    <ValidatedTextInput
-                      placeholder={i18n.t('placeholder-postcode')}
-                      value={props.values.postcode}
-                      onChangeText={props.handleChange('postcode')}
-                      onBlur={props.handleBlur('postcode')}
-                      error={props.touched.postcode && props.errors.postcode}
-                      returnKeyType="next"
-                      onSubmitEditing={() => {
-                        /* this.passwordComponent.focus(); */
-                      }}
-                      autoCompleteType="postal-code"
-                    />
-                  </Item>
-                  {!!props.errors.postcode && <ValidationError error={props.errors.postcode} />}
-                </FieldWrapper>
+                <GenericTextField
+                  formikProps={props}
+                  label={i18n.t('your-postcode')}
+                  placeholder={i18n.t('placeholder-postcode')}
+                  name="postcode"
+                  inputProps={{ autoCompleteType: 'postal-code' }}
+                />
 
                 <DropdownField
                   selectedValue={props.values.everExposed}

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -326,6 +326,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                   placeholder={i18n.t('placeholder-year-of-birth')}
                   name="yearOfBirth"
                   keyboardType="numeric"
+                  showError
                 />
 
                 <DropdownField
@@ -554,6 +555,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
                   placeholder={i18n.t('placeholder-postcode')}
                   name="postcode"
                   inputProps={{ autoCompleteType: 'postal-code' }}
+                  showError
                 />
 
                 <DropdownField

--- a/src/features/patient/fields/PeriodStoppedAge.tsx
+++ b/src/features/patient/fields/PeriodStoppedAge.tsx
@@ -1,11 +1,7 @@
-import { FormikProps } from 'formik';
-import { Item, Label } from 'native-base';
-import React, { Component } from 'react';
-
-import { FieldWrapper } from '@covid/components/Screen';
-import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
-import { ValidationError } from '@covid/components/ValidationError';
+import { GenericTextField } from '@covid/components/GenericTextField';
 import i18n from '@covid/locale/i18n';
+import { FormikProps } from 'formik';
+import React, { Component } from 'react';
 
 export interface PeriodStoppedAgeData {
   periodStoppedAge: string;
@@ -19,27 +15,13 @@ export class PeriodStoppedAge extends Component<Props, object> {
   render() {
     const formikProps = this.props.formikProps;
     return (
-      <FieldWrapper>
-        <Item
-          stackedLabel
-          style={{
-            borderColor: 'transparent',
-          }}>
-          <Label>{i18n.t('your-health.period-stopped-age')}</Label>
-          <ValidatedTextInput
-            placeholder={i18n.t('placeholder-optional')}
-            value={formikProps.values.periodStoppedAge}
-            onChangeText={formikProps.handleChange('periodStoppedAge')}
-            onBlur={formikProps.handleBlur('periodStoppedAge')}
-            error={formikProps.touched.periodStoppedAge && formikProps.errors.periodStoppedAge}
-            returnKeyType="next"
-            keyboardType="numeric"
-          />
-        </Item>
-        {!!formikProps.errors.periodStoppedAge && formikProps.submitCount > 0 && (
-          <ValidationError error={formikProps.errors.periodStoppedAge} />
-        )}
-      </FieldWrapper>
+      <GenericTextField
+        formikProps={formikProps}
+        label={i18n.t('your-health.period-stopped-age')}
+        placeholder={i18n.t('placeholder-optional')}
+        name="periodStoppedage"
+        keyboardType="numeric"
+      />
     );
   }
 }

--- a/src/features/patient/fields/PeriodStoppedAge.tsx
+++ b/src/features/patient/fields/PeriodStoppedAge.tsx
@@ -21,6 +21,7 @@ export class PeriodStoppedAge extends Component<Props, object> {
         placeholder={i18n.t('placeholder-optional')}
         name="periodStoppedage"
         keyboardType="numeric"
+        showError
       />
     );
   }

--- a/src/features/patient/fields/WeeksPregnant.tsx
+++ b/src/features/patient/fields/WeeksPregnant.tsx
@@ -1,11 +1,7 @@
-import { FormikProps } from 'formik';
-import { Item, Label } from 'native-base';
-import React, { Component } from 'react';
-
-import { FieldWrapper } from '@covid/components/Screen';
-import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
-import { ValidationError } from '@covid/components/ValidationError';
+import { GenericTextField } from '@covid/components/GenericTextField';
 import i18n from '@covid/locale/i18n';
+import { FormikProps } from 'formik';
+import React, { Component } from 'react';
 
 export interface WeeksPregnantData {
   weeksPregnant: string;
@@ -19,27 +15,13 @@ export class WeeksPregnant extends Component<Props, object> {
   render() {
     const formikProps = this.props.formikProps;
     return (
-      <FieldWrapper>
-        <Item
-          stackedLabel
-          style={{
-            borderColor: 'transparent',
-          }}>
-          <Label>{i18n.t('your-health.weeks-pregnant')}</Label>
-          <ValidatedTextInput
-            placeholder={i18n.t('placeholder-optional')}
-            value={formikProps.values.weeksPregnant}
-            onChangeText={formikProps.handleChange('weeksPregnant')}
-            onBlur={formikProps.handleBlur('weeksPregnant')}
-            error={formikProps.touched.weeksPregnant && formikProps.errors.weeksPregnant}
-            returnKeyType="next"
-            keyboardType="numeric"
-          />
-        </Item>
-        {!!formikProps.errors.weeksPregnant && formikProps.submitCount > 0 && (
-          <ValidationError error={formikProps.errors.weeksPregnant} />
-        )}
-      </FieldWrapper>
+      <GenericTextField
+        formikProps={formikProps}
+        label={i18n.t('your-health.weeks-pregnant')}
+        placeholder={i18n.t('placeholder-optional')}
+        name="weeksPregnant"
+        keyboardType="numeric"
+      />
     );
   }
 }

--- a/src/features/patient/fields/WeeksPregnant.tsx
+++ b/src/features/patient/fields/WeeksPregnant.tsx
@@ -21,6 +21,7 @@ export class WeeksPregnant extends Component<Props, object> {
         placeholder={i18n.t('placeholder-optional')}
         name="weeksPregnant"
         keyboardType="numeric"
+        showError
       />
     );
   }


### PR DESCRIPTION
# Description

Moves remaining simple text input questions to use the `GenericTextField` component. 
Moves the error message into the `GenericTextField` with an additional showError flag to maintain existing behaviour with error messages.
This PR maintains existing behaviours but is in preparation for design updates.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Out of scope and potential follow-up

Potentially add the remaining error messages to other questions that use GenericTextField and deprecate the `showError` flag. 
Add info/description to justify new questions + UX & Styling changes to `GenericTextField`s as part of #230.