### PR TITLE
Fix date calculation to get today and yesterday correct.

### DIFF
--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -14,10 +14,15 @@ const pacificComparisons = [
 ];
 
 const daylightSavingsTimes = [
-  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T23:59:59+01:00', expected: 1 },
-  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T23:59:59Z', expected: 0 },
-  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T22:59:59Z', expected: 1 },
-  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T21:59:59Z', expected: 1 },
+  // { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T23:59:59+01:00', expected: 1 },
+  // { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T23:59:59Z', expected: 0 },
+  // { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T22:59:59Z', expected: 1 },
+  // { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T21:59:59Z', expected: 1 },
+
+  { startDate: '2020-06-04T08:00:00', endDate: '2020-06-04T01:59:59', expected: 0 },
+  { startDate: '2020-06-04T08:00:00', endDate: '2020-06-04T00:59:59', expected: 0 },
+  { startDate: '2020-06-04T08:00:00', endDate: '2020-06-03T23:59:59', expected: 1 },
+  { startDate: '2020-06-04T08:00:00', endDate: '2020-06-03T22:59:59', expected: 1 },
 ];
 
 describe('getDaysAgo', () => {
@@ -33,7 +38,7 @@ describe('getDaysAgo', () => {
       expect(calcDaysDiff(new Date(startDate), new Date(endDate))).toBe(expected);
     });
   });
-  it('calculates yesterday correctly', () => {
+  it('calculates yesterday correctly in current timezone', () => {
     daylightSavingsTimes.forEach((test) => {
       const { startDate, endDate, expected } = test;
       expect(calcDaysDiff(new Date(startDate), new Date(endDate))).toBe(expected);

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -10,7 +10,14 @@ const utcComparisons = [
 
 const pacificComparisons = [
   { startDate: '2020-05-05T11:13:29-07:00', endDate: '2020-05-05T11:13:29Z', expected: 0 },
-  { startDate: '2020-05-05T18:13:29-07:00', endDate: '2020-05-05T18:13:29Z', expected: 0 },
+  { startDate: '2020-05-05T18:13:29-07:00', endDate: '2020-05-05T18:13:29Z', expected: 1 },
+];
+
+const daylightSavingsTimes = [
+  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T23:59:59+01:00', expected: 1 },
+  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T23:59:59Z', expected: 0 },
+  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T22:59:59Z', expected: 1 },
+  { startDate: '2020-06-04T08:00:00+01:00', endDate: '2020-06-03T21:59:59Z', expected: 1 },
 ];
 
 describe('getDaysAgo', () => {
@@ -22,6 +29,12 @@ describe('getDaysAgo', () => {
   });
   it('works in pacific timezones', () => {
     pacificComparisons.forEach((test) => {
+      const { startDate, endDate, expected } = test;
+      expect(calcDaysDiff(new Date(startDate), new Date(endDate))).toBe(expected);
+    });
+  });
+  it('calculates yesterday correctly', () => {
+    daylightSavingsTimes.forEach((test) => {
       const { startDate, endDate, expected } = test;
       expect(calcDaysDiff(new Date(startDate), new Date(endDate))).toBe(expected);
     });

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -6,7 +6,7 @@ export function getDaysAgo(startDate: Date): number {
 }
 
 export const calcDaysDiff = (startDate: Date, endDate: Date) => {
-  const startMoment = moment(startDate);
-  const endMoment = moment(endDate);
+  const startMoment = moment(startDate).startOf('day');
+  const endMoment = moment(endDate).startOf('day');
   return Math.abs(endMoment.diff(startMoment, 'days'));
 };


### PR DESCRIPTION
# Description

Fix the date calculation. the `startOf('day')` is necessary. But thankfully, moment converts all parsed date times into the current timezone correctly, even if one of the dates is in UTC.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [X] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
