### PR TITLE
Only set isolation questions if there's a non-blank answer.

### DIFF
--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -66,9 +66,15 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
 
     return {
       patient: patientId,
-      isolation_little_interaction: cleanIntegerVal(formData.isolationLittleInteraction),
-      isolation_lots_of_people: cleanIntegerVal(formData.isolationLotsOfPeople),
-      isolation_healthcare_provider: cleanIntegerVal(formData.isolationHealthcareProvider),
+      ...(formData.isolationLittleInteraction !== '' && {
+        isolation_little_interaction: cleanIntegerVal(formData.isolationLittleInteraction),
+      }),
+      ...(formData.isolationLotsOfPeople !== '' && {
+        isolation_lots_of_people: cleanIntegerVal(formData.isolationLotsOfPeople),
+      }),
+      ...(formData.isolationHealthcareProvider !== '' && {
+        isolation_healthcare_provider: cleanIntegerVal(formData.isolationHealthcareProvider),
+      }),
     } as Partial<AssessmentInfosRequest>;
   }
 


### PR DESCRIPTION
# Description

A quick tidy-up PR.
I noticed the Isolation question, because it's now optional is sending `NaN` as values to the backend when the field isn't filled in. So I've added a condition to only populate the value if the entered data isn't an empty string (e.g. there's something entered in the field)

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

Before:

<img width="425" alt="Screenshot 2020-06-04 at 16 11 08" src="https://user-images.githubusercontent.com/61784325/83775036-63e0fa00-a67e-11ea-86d9-dd56b41e1c82.png">


After:

<img width="437" alt="Screenshot 2020-06-04 at 16 11 20" src="https://user-images.githubusercontent.com/61784325/83775064-6e02f880-a67e-11ea-9eb1-205225244b89.png">


## Checklist

- [ ] I have updated mockServer
- [X] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
