### PR TITLE
Add missing 2nd type parameter to Push Notification api call.

### DIFF
--- a/src/core/pushNotifications/PushNotificationService.ts
+++ b/src/core/pushNotifications/PushNotificationService.ts
@@ -37,7 +37,7 @@ export class PushNotificationApiClient implements IPushTokenRemoteClient {
       ...pushToken,
       active: true,
     } as TokenInfoRequest;
-    return this.apiClient.post<TokenInfoResponse>(`/tokens/`, tokenDoc);
+    return this.apiClient.post<TokenInfoRequest, TokenInfoResponse>(`/tokens/`, tokenDoc);
   }
 }
 


### PR DESCRIPTION
# Description

`apiClient.post` was updated to accept two type parameters, but PushNotificationService wasn't updated with this breaking change. So this is to fix that. We wouldn't have noticed this in test -- though I'm surprised TestFlight didn't pick it up and crash...

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [X] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [X] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
