### PR TITLE
Refactor the DrawerToggle and Profile Card

### DIFF
--- a/src/components/DrawerToggle.tsx
+++ b/src/components/DrawerToggle.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { DrawerNavigationProp } from '@react-navigation/drawer';
+
+import { colors } from '@theme';
+import { menuIcon } from '@assets';
+import { ScreenParamList } from '@covid/features/ScreenParamList';
+
+type Props = {
+  navigation: DrawerNavigationProp<ScreenParamList, keyof ScreenParamList>;
+  style?: object;
+};
+
+export const DrawerToggle: React.FC<Props> = (props) => (
+  <TouchableOpacity
+    onPress={() => {
+      props.navigation.toggleDrawer();
+    }}>
+    <Image source={menuIcon} style={[styles.menuIcon, props.style]} />
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  menuIcon: {
+    height: 20,
+    width: 20,
+    tintColor: colors.primary,
+    alignSelf: 'flex-end',
+    marginRight: 15,
+    marginTop: 10,
+  },
+});

--- a/src/components/NewProfileCard.tsx
+++ b/src/components/NewProfileCard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Image, StyleSheet } from 'react-native';
+import { Card } from 'native-base';
+
+import { addProfile } from '@assets';
+import i18n from '@covid/locale/i18n';
+
+import { RegularText } from './Text';
+
+export const NewProfileCard: React.FC = (props) => {
+  return (
+    <Card style={styles.card}>
+      <Image source={addProfile} style={styles.addImage} resizeMode="contain" />
+      <RegularText>{i18n.t('select-profile-button')}</RegularText>
+    </Card>
+  );
+};
+
+const styles = StyleSheet.create({
+  addImage: {
+    width: '100%',
+    height: 100,
+    marginBottom: 10,
+  },
+  avatarContainer: {
+    alignItems: 'center',
+    width: 100,
+    marginBottom: 10,
+  },
+
+  avatar: {
+    height: 100,
+    width: 100,
+  },
+
+  tick: {
+    height: 30,
+    width: 30,
+  },
+  circle: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+    top: 0,
+    right: -5,
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: 'white',
+  },
+  card: {
+    width: '100%',
+    borderRadius: 16,
+    minHeight: 200,
+    paddingVertical: 20,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+});

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import { Card } from 'native-base';
+
+import { tick } from '@assets';
+import { AvatarName, getAvatarByName } from '@covid/utils/avatar';
+import { getDaysAgo } from '@covid/utils/datetime';
+
+import { Patient } from '../features/multi-profile/SelectProfileScreen';
+
+import { ClippedText } from './Text';
+import DaysAgo from './DaysAgo';
+
+type Props = {
+  patient: Patient;
+  index: number;
+};
+
+export const ProfileCard: React.FC<Props> = (props) => {
+  const patient = props.patient;
+  const avatarImage = getAvatarByName((patient.avatar_name ?? 'profile1') as AvatarName);
+  const hasReportedToday = patient.last_reported_at && getDaysAgo(patient.last_reported_at) === 0;
+  return (
+    <Card style={styles.card}>
+      <View style={styles.avatarContainer}>
+        {hasReportedToday && (
+          <View style={styles.circle}>
+            <Image source={tick} style={styles.tick} />
+          </View>
+        )}
+        <Image source={avatarImage} style={styles.avatar} resizeMode="contain" />
+      </View>
+      <ClippedText>{patient.name}</ClippedText>
+      <DaysAgo timeAgo={patient.last_reported_at} />
+    </Card>
+  );
+};
+
+const styles = StyleSheet.create({
+  avatarContainer: {
+    alignItems: 'center',
+    width: 100,
+    marginBottom: 10,
+  },
+
+  avatar: {
+    height: 100,
+    width: 100,
+  },
+
+  tick: {
+    height: 30,
+    width: 30,
+  },
+  circle: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+    top: 0,
+    right: -5,
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: 'white',
+  },
+  card: {
+    width: '100%',
+    borderRadius: 16,
+    minHeight: 200,
+    paddingVertical: 20,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+});

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { Image, SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import key from 'weak-key';
 
-import { addProfile, menuIcon, NUMBER_OF_PROFILE_AVATARS, tick } from '@assets';
+import { addProfile, NUMBER_OF_PROFILE_AVATARS, tick } from '@assets';
 import { colors } from '@theme';
 import DaysAgo from '@covid/components/DaysAgo';
 import { Loading, LoadingModal } from '@covid/components/Loading';
@@ -16,10 +16,10 @@ import i18n from '@covid/locale/i18n';
 import { AvatarName, getAvatarByName } from '@covid/utils/avatar';
 import { getDaysAgo } from '@covid/utils/datetime';
 import { offlineService, userService } from '@covid/Services';
+import { DrawerToggle } from '@covid/components/DrawerToggle';
 
 import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
-import { DrawerToggle } from '@covid/components/DrawerToggle';
 
 type RenderProps = {
   navigation: DrawerNavigationProp<ScreenParamList, 'SelectProfile'>;

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -19,6 +19,7 @@ import { offlineService, userService } from '@covid/Services';
 
 import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
+import { DrawerToggle } from '@covid/components/DrawerToggle';
 
 type RenderProps = {
   navigation: DrawerNavigationProp<ScreenParamList, 'SelectProfile'>;
@@ -136,12 +137,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
           )}
           <ScrollView contentContainerStyle={styles.scrollView}>
             <View style={styles.rootContainer}>
-              <TouchableOpacity
-                onPress={() => {
-                  this.props.navigation.toggleDrawer();
-                }}>
-                <Image source={menuIcon} style={styles.menuIcon} />
-              </TouchableOpacity>
+              <DrawerToggle navigation={this.props.navigation} style={{ tintColor: colors.primary }} />
 
               <Header>
                 <HeaderText style={{ marginBottom: 12 }}>{i18n.t('select-profile-title')}</HeaderText>
@@ -281,14 +277,5 @@ const styles = StyleSheet.create({
     marginHorizontal: 20,
     paddingHorizontal: 20,
     paddingVertical: 15,
-  },
-
-  menuIcon: {
-    height: 20,
-    width: 20,
-    tintColor: colors.primary,
-    alignSelf: 'flex-end',
-    marginRight: 15,
-    marginTop: 10,
   },
 });

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -1,32 +1,29 @@
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { RouteProp } from '@react-navigation/native';
-import { Card } from 'native-base';
 import React, { Component } from 'react';
-import { Image, SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
-import key from 'weak-key';
+import { SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 
-import { addProfile, NUMBER_OF_PROFILE_AVATARS, tick } from '@assets';
+import { NUMBER_OF_PROFILE_AVATARS } from '@assets';
 import { colors } from '@theme';
-import DaysAgo from '@covid/components/DaysAgo';
 import { Loading, LoadingModal } from '@covid/components/Loading';
 import { Header } from '@covid/components/Screen';
-import { ClippedText, HeaderText, RegularText, SecondaryText } from '@covid/components/Text';
+import { HeaderText, SecondaryText } from '@covid/components/Text';
 import { ApiErrorState, initialErrorState } from '@covid/core/api/ApiServiceErrors';
 import i18n from '@covid/locale/i18n';
-import { AvatarName, getAvatarByName } from '@covid/utils/avatar';
-import { getDaysAgo } from '@covid/utils/datetime';
 import { offlineService, userService } from '@covid/Services';
 import { DrawerToggle } from '@covid/components/DrawerToggle';
+import { ProfileCard } from '@covid/components/ProfileCard';
+import { NewProfileCard } from '@covid/components/NewProfileCard';
 
-import Navigator from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
+import Navigator from '../Navigation';
 
 type RenderProps = {
   navigation: DrawerNavigationProp<ScreenParamList, 'SelectProfile'>;
   route: RouteProp<ScreenParamList, 'SelectProfile'>;
 };
 
-type Patient = {
+export type Patient = {
   id: string;
   name?: string;
   avatar_name?: string;
@@ -91,7 +88,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
     try {
       const currentPatient = await userService.getCurrentPatient(patientId);
       this.setState({ isApiError: false });
-      await Navigator.profileSelected(index == 0, currentPatient);
+      await Navigator.profileSelected(index === 0, currentPatient);
     } catch (error) {
       this.setState({
         isApiError: true,
@@ -147,33 +144,17 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
               {this.state.isLoaded ? (
                 <View style={styles.profileList}>
                   {this.state.patients.map((patient, i) => {
-                    const avatarImage = getAvatarByName((patient.avatar_name ?? 'profile1') as AvatarName);
-                    const hasReportedToday = patient.last_reported_at && getDaysAgo(patient.last_reported_at) === 0;
                     return (
-                      <View style={styles.cardContainer} key={key(patient)}>
+                      <View style={styles.cardContainer} key={patient.id}>
                         <TouchableOpacity onPress={() => this.profileSelected(patient.id, i)}>
-                          <Card style={styles.card}>
-                            <View style={styles.avatarContainer}>
-                              {hasReportedToday && (
-                                <View style={styles.circle}>
-                                  <Image source={tick} style={styles.tick} />
-                                </View>
-                              )}
-                              <Image source={avatarImage} style={styles.avatar} resizeMode="contain" />
-                            </View>
-                            <ClippedText>{patient.name}</ClippedText>
-                            <DaysAgo timeAgo={patient.last_reported_at} />
-                          </Card>
+                          <ProfileCard patient={patient} index={i} />
                         </TouchableOpacity>
                       </View>
                     );
                   })}
 
                   <TouchableOpacity style={styles.cardContainer} key="new" onPress={() => this.gotoCreateProfile()}>
-                    <Card style={styles.card}>
-                      <Image source={addProfile} style={styles.addImage} resizeMode="contain" />
-                      <RegularText>{i18n.t('select-profile-button')}</RegularText>
-                    </Card>
+                    <NewProfileCard />
                   </TouchableOpacity>
                 </View>
               ) : (
@@ -207,50 +188,6 @@ const styles = StyleSheet.create({
     margin: 5,
   },
 
-  avatarContainer: {
-    alignItems: 'center',
-    width: 100,
-    marginBottom: 10,
-  },
-
-  avatar: {
-    height: 100,
-    width: 100,
-  },
-
-  tick: {
-    height: 30,
-    width: 30,
-  },
-
-  circle: {
-    position: 'absolute',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 1,
-    top: 0,
-    right: -5,
-    width: 34,
-    height: 34,
-    borderRadius: 17,
-    backgroundColor: 'white',
-  },
-
-  addImage: {
-    width: '100%',
-    height: 100,
-    marginBottom: 10,
-  },
-
-  card: {
-    width: '100%',
-    borderRadius: 16,
-    minHeight: 200,
-    paddingVertical: 20,
-    paddingHorizontal: 12,
-    alignItems: 'center',
-  },
-
   view: {
     backgroundColor: colors.backgroundSecondary,
   },
@@ -261,21 +198,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
 
-  content: {
-    justifyContent: 'space-between',
-    marginVertical: 32,
-    marginHorizontal: 18,
-  },
-
   rootContainer: {
     padding: 10,
-  },
-
-  shareContainer: {
-    backgroundColor: colors.white,
-    borderRadius: 10,
-    marginHorizontal: 20,
-    paddingHorizontal: 20,
-    paddingVertical: 15,
   },
 });

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -20,6 +20,7 @@ import { offlineService, pushNotificationService, userService } from '@covid/Ser
 
 import Navigator, { NavigationType } from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
+import { DrawerToggle } from '@covid/components/DrawerToggle';
 
 type PropsType = {
   navigation: DrawerNavigationProp<ScreenParamList, 'WelcomeRepeat'>;
@@ -114,16 +115,10 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
           />
         )}
         <ScrollView>
+          <View style={styles.headerContainer}>
+            <DrawerToggle navigation={this.props.navigation} style={{ tintColor: colors.white }} />
+          </View>
           <View style={styles.rootContainer}>
-            <View style={styles.headerRow}>
-              <TouchableOpacity
-                onPress={() => {
-                  this.props.navigation.toggleDrawer();
-                }}>
-                <Image source={menuIcon} style={styles.menuIcon} />
-              </TouchableOpacity>
-            </View>
-
             <View style={styles.covidIconBackground}>
               <Image source={covidIcon} style={styles.covidIcon} resizeMode="contain" />
             </View>
@@ -156,16 +151,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.brand,
   },
+  headerContainer: {
+    paddingTop: 10,
+    paddingHorizontal: 10,
+  },
   rootContainer: {
     paddingHorizontal: 24,
-    paddingTop: 24,
-    flex: 1,
     alignItems: 'center',
-  },
-  headerRow: {
-    alignSelf: 'stretch',
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
+    flex: 1,
   },
   covidIconBackground: {
     backgroundColor: colors.predict,
@@ -189,11 +182,6 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
 
-  menuIcon: {
-    height: 20,
-    width: 20,
-    tintColor: colors.white,
-  },
   reportContainer: {
     padding: 20,
   },

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -17,10 +17,10 @@ import { isSECountry, isUSCountry } from '@covid/core/user/UserService';
 import { cleanIntegerVal } from '@covid/core/utils/number';
 import i18n from '@covid/locale/i18n';
 import { offlineService, pushNotificationService, userService } from '@covid/Services';
+import { DrawerToggle } from '@covid/components/DrawerToggle';
 
 import Navigator, { NavigationType } from '../Navigation';
 import { ScreenParamList } from '../ScreenParamList';
-import { DrawerToggle } from '@covid/components/DrawerToggle';
 
 type PropsType = {
   navigation: DrawerNavigationProp<ScreenParamList, 'WelcomeRepeat'>;


### PR DESCRIPTION
# Description

[Series of PR's for the Delete Profile feature]

Refactor the drawer toggle into separate component, which is used on the WelcomeRepeatScreen and the SelectProfileScreen. 

This also aligns the icon so they are in the same position across both screen - and the same position as the "close" icon on the drawer. 


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="473" alt="Screenshot 2020-06-09 at 14 33 00" src="https://user-images.githubusercontent.com/7824212/84154054-826c3a00-aa5e-11ea-89a8-86acd0d9aedd.png">
<img width="463" alt="Screenshot 2020-06-09 at 14 33 03" src="https://user-images.githubusercontent.com/7824212/84154070-86985780-aa5e-11ea-925a-a2b8a91ada24.png">

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
