### PR TITLE
Hide edit profile icon on main profile

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -29,11 +29,15 @@ export const ProfileCard: React.FC<Props> = (props) => {
 
   return (
     <Card style={styles.card}>
-      <View style={styles.infoContainer}>
-        <TouchableOpacity onPress={() => handleEdit()}>
-          <InfoCircle />
-        </TouchableOpacity>
-      </View>
+      {profile.reported_by_another ? (
+        <View style={styles.infoContainer}>
+          <TouchableOpacity onPress={() => handleEdit()}>
+            <InfoCircle />
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <View style={styles.placeholder} />
+      )}
 
       <View style={styles.avatarContainer}>
         {hasReportedToday && <GreenTick />}
@@ -66,5 +70,9 @@ const styles = StyleSheet.create({
     paddingBottom: 20,
     paddingHorizontal: 12,
     alignItems: 'center',
+  },
+  placeholder: {
+    height: 20,
+    width: 20,
   },
 });


### PR DESCRIPTION
# Description

Hide edit profile icon on main profile, as there is nothing interesting for the user to do on the main profile at the moment. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Screenshot 2020-06-12 at 10 45 30](https://user-images.githubusercontent.com/7824212/84489625-e0d12c80-ac99-11ea-9441-6530ad1c9dfa.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
