### PR TITLE
Fix backend value for duplicate account archive reason.

### DIFF
--- a/src/features/multi-profile/ArchiveReasonScreen.tsx
+++ b/src/features/multi-profile/ArchiveReasonScreen.tsx
@@ -20,7 +20,7 @@ export const ArchiveReasonScreen: React.FC<RenderProps> = (props) => {
   const reasons = [
     {
       text: i18n.t('archive-reason.choice-duplicate-account'),
-      value: 'duplicate',
+      value: 'duplicate_account',
     },
     {
       text: i18n.t('archive-reason.choice-no-report'),


### PR DESCRIPTION
Posted value didn't match corresponding backend value.