### PR TITLE
Pass adVersion down when accepting / declining Study Invite

### DIFF
--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from 'axios';
 import * as Localization from 'expo-localization';
 
-import { ukValidationStudyConsentVersion } from '@covid/features/register/constants';
+import { ukValidationStudyAdVersion, ukValidationStudyConsentVersion } from '@covid/features/register/constants';
 import i18n from '@covid/locale/i18n';
 import { AvatarName } from '@covid/utils/avatar';
 import { getDaysAgo } from '@covid/utils/datetime';
@@ -493,6 +493,7 @@ export default class UserService extends ApiClientBase
     return this.client.post('/study_consent/', {
       study: 'UK Validation Study',
       version: ukValidationStudyConsentVersion,
+      ad_version: ukValidationStudyAdVersion,
       status: response ? 'signed' : 'declined',
       allow_future_data_use: anonymizedData,
       allow_contact_by_zoe: reContacted,

--- a/src/features/register/constants.ts
+++ b/src/features/register/constants.ts
@@ -6,3 +6,4 @@ export const privacyPolicyVersionUS = 'v1.3';
 export const privacyPolicyVersionUK = 'v2.3';
 export const privacyPolicyVersionSE = 'v2.1';
 export const ukValidationStudyConsentVersion = 'v3';
+export const ukValidationStudyAdVersion = 'v2';


### PR DESCRIPTION
# Description

This PR passes the Study Consent adVersion (v2) in this case. So we can track how many times we've asked the user different versions of the Study Advert. 

Related backend PR:
https://github.com/zoe/covid-app/pull/214

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
