### PR TITLE
Fixes for fetching welcome screen text from backend. 

### DIFF
--- a/mock-server/mockServer.ts
+++ b/mock-server/mockServer.ts
@@ -155,6 +155,23 @@ app.get('/area_stats/', (_, res) => {
   });
 });
 
+app.get('/text/list/', (_, res) => {
+  return res.status(200).send({
+    ThankYou: null,
+    Welcome: null,
+    WelcomeRepeat: {
+      title_text: 'RESEARCH',
+      body_text: 'Follow the discoveries \\nyou made possible"',
+      body_link: 'https://www.youtube.com/watch?v=oHg5SJYRHA0',
+      link_text: 'Visit the website',
+      body_photo: null,
+      experiment_name: null,
+      cohort_id: null,
+      analytics: null,
+    },
+  });
+});
+
 /**
  * Patient
  */

--- a/src/core/content/ContentService.ts
+++ b/src/core/content/ContentService.ts
@@ -38,7 +38,7 @@ export default class ContentService implements IContentService {
 
   async getWelcomeRepeatContent() {
     if (!this.screenContent) {
-      this.screenContent = await this.apiClient.getScreenContent(UserService.getLocale(), UserService.userCountry);
+      this.screenContent = await this.apiClient.getScreenContent(UserService.userCountry, UserService.getLocale());
     }
     return this.screenContent.WelcomeRepeat;
   }


### PR DESCRIPTION
# Description

- Switch countryCode and langauge when calling function
- Adds a mock server.  

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [x] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
