### PR TITLE
Fixes for locale when fetching AppText

### DIFF
--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -401,9 +401,9 @@ export default class UserService extends ApiClientBase
 
   async defaultCountryFromLocale() {
     const country = () => {
-      if (Localization.locale == 'en-GB') {
+      if (Localization.locale === 'en-GB') {
         return 'GB';
-      } else if (Localization.locale == 'sv-SE') {
+      } else if (Localization.locale === 'sv-SE') {
         return 'SE';
       } else {
         return 'US';
@@ -462,7 +462,7 @@ export default class UserService extends ApiClientBase
 
   private static setLocaleFromCountry(countryCode: string) {
     let USLocale = 'en';
-    if (Localization.locale == 'es-US') {
+    if (Localization.locale === 'es-US') {
       USLocale = 'es';
     }
 
@@ -476,7 +476,7 @@ export default class UserService extends ApiClientBase
   }
 
   static getLocale() {
-    return Localization.locale.split('-')[0];
+    return i18n.locale.split('-')[0];
   }
 
   async shouldAskForValidationStudy(onThankYouScreen: boolean): Promise<boolean> {

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -55,7 +55,6 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
     await pushNotificationService.refreshPushToken();
 
     const content = await contentService.getWelcomeRepeatContent();
-    console.log('CONTENT: ' + JSON.stringify(content));
     this.setState({ calloutBoxContent: content });
   }
 


### PR DESCRIPTION
# Description

Currently the languageLocale sent on the query_params on the backend call for App Text is set from Localisation.locale - which could be any language code as it's based on the device setting, 

This PR changes it get set this query param from i18n.locale. This can only be one of `en`, `es` or `sv`. 

This also changes the behaviour the what is save on user creation on the user.language_code backend model. This is better! 

I've tested country accounts for US, SE and GB with device language as "English" and then again with "French" 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
