### PR TITLE
Fix validation error alignment

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -593,8 +593,7 @@
   "select-profile-last-report": "Last report:",
   "default-profile-name": "Me",
 
-  "validation-error-text": "Please fill in or correct the above information: %{info}",
-  "validation-error-text-no-info": "Please fill in or correct the above information",
+  "validation-error-text": "Please fill in or correct the above information",
 
   "race-question": "Which of the following best describes your ethnicity?",
   "race-other-question": "Please specify your ethnicity",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -765,8 +765,7 @@
   "select-profile-last-report": "Último informe:",
   "default-profile-name": "Yo",
 
-  "validation-error-text": "Complete o corrija la información anterior: %{info}",
-  "validation-error-text-no-info": "Complete o corrija la información anterior",
+  "validation-error-text": "Complete o corrija la información anterior",
 
   "race-question": "¿Cuál es su raza? (marque todas las que correspondan):",
   "race-other-question": "Especifique su raza",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -523,8 +523,7 @@
   "choose-one-of-these-options": "Välj ett av alternativen",
   "prefer-not-to-say": "Föredrar att inte svara",
 
-  "validation-error-text": "Fyll i eller korrigera informationen ovan: %{info}",
-  "validation-error-text-no-info": "Fyll i eller korrigera informationen ovan",
+  "validation-error-text": "Fyll i eller korrigera informationen ovan",
 
   "website-home": "https://covid.joinzoe.com/",
 

--- a/src/components/DropdownField.tsx
+++ b/src/components/DropdownField.tsx
@@ -146,7 +146,7 @@ export const DropdownField: React.FC<DropdownFieldProps> = ({
         </View>
       </ModalDropdown>
       {!!error && (
-        <View style={{ marginTop: 6, marginHorizontal: -16 }}>
+        <View style={{ marginTop: 4, marginHorizontal: 4 }}>
           <ValidationError error={error} />
         </View>
       )}

--- a/src/components/ValidationError.tsx
+++ b/src/components/ValidationError.tsx
@@ -33,11 +33,13 @@ export const ValidationErrors: React.FC<ErrorsProps> = ({ errors }) => (
 
 const styles = StyleSheet.create({
   validationError: {
-    marginVertical: 0,
+    marginBottom: 0,
+    marginTop: 4,
+    marginHorizontal: 6,
   },
 
   validationErrors: {
-    marginVertical: 8,
-    marginHorizontal: 8,
+    marginVertical: 4,
+    marginHorizontal: 4,
   },
 });

--- a/src/components/ValidationError.tsx
+++ b/src/components/ValidationError.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import i18n from '@covid/locale/i18n';
-
 import { ErrorText } from './Text';
 
 type ErrorProps = {
@@ -17,29 +15,10 @@ export const ValidationError: React.FC<ErrorProps> = ({ error }) => {
   );
 };
 
-type ErrorsProps = {
-  errors: object;
-};
-
-export const ValidationErrors: React.FC<ErrorsProps> = ({ errors }) => (
-  <View style={styles.validationErrors}>
-    <ErrorText>
-      {i18n.t('validation-error-text', {
-        info: Object.keys(errors).join(', '),
-      })}
-    </ErrorText>
-  </View>
-);
-
 const styles = StyleSheet.create({
   validationError: {
     marginBottom: 0,
     marginTop: 4,
     marginHorizontal: 6,
-  },
-
-  validationErrors: {
-    marginVertical: 4,
-    marginHorizontal: 4,
   },
 });

--- a/src/features/assessment/CovidTestDetailScreen.tsx
+++ b/src/features/assessment/CovidTestDetailScreen.tsx
@@ -14,7 +14,7 @@ import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ClickableText, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import CovidTestService from '@covid/core/user/CovidTestService';
 import { CovidTest } from '@covid/core/user/dto/CovidTestContracts';
 import AssessmentCoordinator from '@covid/features/assessment/AssessmentCoordinator';
@@ -331,7 +331,7 @@ export default class CovidTestDetailScreen extends Component<CovidProps, State> 
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton onPress={props.handleSubmit}>

--- a/src/features/assessment/DescribeSymptomsScreen.tsx
+++ b/src/features/assessment/DescribeSymptomsScreen.tsx
@@ -12,7 +12,7 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import { AssessmentInfosRequest } from '@covid/core/assessment/dto/AssessmentInfosRequest';
 import UserService from '@covid/core/user/UserService';
 import { cleanFloatVal } from '@covid/core/utils/number';
@@ -468,7 +468,7 @@ export default class DescribeSymptomsScreen extends Component<SymptomProps, Stat
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton onPress={props.handleSubmit} enable={this.state.enableSubmit}>

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -2,16 +2,16 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik, FormikProps } from 'formik';
 import moment from 'moment';
-import { Form, Item, Label, Text } from 'native-base';
+import { Form } from 'native-base';
 import React, { Component } from 'react';
 import * as Yup from 'yup';
 import { StyleSheet } from 'react-native';
 
 import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
-import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
+import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
-import { ValidationError, ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import { AssessmentInfosRequest } from '@covid/core/assessment/dto/AssessmentInfosRequest';
 import { PatientStateType } from '@covid/core/patient/PatientState';
 import UserService from '@covid/core/user/UserService';
@@ -20,20 +20,8 @@ import { cleanIntegerVal } from '@covid/core/utils/number';
 import AssessmentCoordinator from '@covid/features/assessment/AssessmentCoordinator';
 import i18n from '@covid/locale/i18n';
 import { assessmentService } from '@covid/Services';
-import { CheckboxList } from '@covid/components/Checkbox';
-import {
-  SupplementValue,
-  supplementValues,
-  VitaminSupplementData,
-  VitaminSupplementsQuestion,
-} from '@covid/features/patient/fields/VitaminQuestion';
 import { colors, fontStyles } from '@theme';
 import { FaceMaskData, FaceMaskQuestion, TypeOfMaskValues } from '@covid/features/assessment/fields/FaceMaskQuestion';
-import { BloodPressureData } from '@covid/features/patient/fields/BloodPressureMedicationQuestion';
-import { RaceEthnicityData } from '@covid/features/patient/fields/RaceEthnicityQuestion';
-import { PeriodData } from '@covid/features/patient/fields/PeriodQuestion';
-import { HormoneTreatmentData } from '@covid/features/patient/fields/HormoneTreatmentQuestion';
-import { AtopyData } from '@covid/features/patient/fields/AtopyQuestions';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -215,7 +203,7 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -8,7 +8,7 @@ import * as Yup from 'yup';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import UserService, { isUSCountry } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import AssessmentCoordinator from '@covid/features/assessment/AssessmentCoordinator';
@@ -313,7 +313,7 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton onPress={props.handleSubmit}>

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -1,7 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik, FormikProps } from 'formik';
-import { Form, Item, Label, Text } from 'native-base';
+import { Form, Text } from 'native-base';
 import React, { Component } from 'react';
 import { StyleSheet } from 'react-native';
 import * as Yup from 'yup';
@@ -9,13 +9,12 @@ import * as Yup from 'yup';
 import DropdownField from '@covid/components/DropdownField';
 import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
-import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
+import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
-import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
-import { ValidationError, ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import { isUSCountry } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
-import { cleanIntegerVal, cleanFloatVal } from '@covid/core/utils/number';
+import { cleanFloatVal, cleanIntegerVal } from '@covid/core/utils/number';
 import i18n from '@covid/locale/i18n';
 import { userService } from '@covid/Services';
 
@@ -393,7 +392,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton

--- a/src/features/patient/PreviousExposure.tsx
+++ b/src/features/patient/PreviousExposure.tsx
@@ -3,7 +3,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik } from 'formik';
 import { Form, Item, Label } from 'native-base';
 import React, { Component } from 'react';
-import { KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import * as Yup from 'yup';
 
 import { CheckboxItem, CheckboxList } from '@covid/components/Checkbox';
@@ -12,7 +12,7 @@ import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import UserService from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import i18n from '@covid/locale/i18n';
@@ -304,7 +304,7 @@ export default class PreviousExposureScreen extends Component<HealthProps, State
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton onPress={props.handleSubmit}>{i18n.t('next-question')}</BrandedButton>

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -3,7 +3,6 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik, FormikProps } from 'formik';
 import { Form } from 'native-base';
 import React, { Component } from 'react';
-import { KeyboardAvoidingView, Platform } from 'react-native';
 import * as Yup from 'yup';
 
 import DropdownField from '@covid/components/DropdownField';
@@ -11,7 +10,7 @@ import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import UserService, { isUSCountry } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { AtopyData, AtopyQuestions } from '@covid/features/patient/fields/AtopyQuestions';
@@ -21,13 +20,13 @@ import { stripAndRound } from '@covid/utils/helpers';
 import { ScreenParamList } from '../ScreenParamList';
 
 import { BloodPressureData, BloodPressureMedicationQuestion } from './fields/BloodPressureMedicationQuestion';
-import { HormoneTreatmentQuestion, HormoneTreatmentData, TreatmentValue } from './fields/HormoneTreatmentQuestion';
+import { HormoneTreatmentData, HormoneTreatmentQuestion, TreatmentValue } from './fields/HormoneTreatmentQuestion';
 import { PeriodData, PeriodQuestion, periodValues } from './fields/PeriodQuestion';
 import {
-  VitaminSupplementsQuestion,
-  VitaminSupplementData,
   SupplementValue,
   supplementValues,
+  VitaminSupplementData,
+  VitaminSupplementsQuestion,
 } from './fields/VitaminQuestion';
 
 export interface YourHealthData
@@ -424,7 +423,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors as string[]} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton onPress={props.handleSubmit}>{i18n.t('next-question')}</BrandedButton>

--- a/src/features/patient/YourStudyScreen.tsx
+++ b/src/features/patient/YourStudyScreen.tsx
@@ -12,7 +12,7 @@ import { GenericTextField } from '@covid/components/GenericTextField';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import UserService, { isGBCountry, isUSCountry } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import i18n from '@covid/locale/i18n';
@@ -333,7 +333,7 @@ export default class YourStudyScreen extends Component<YourStudyProps, State> {
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
                 {!!Object.keys(props.errors).length && props.submitCount > 0 && (
-                  <ValidationErrors errors={props.errors} />
+                  <ValidationError error={i18n.t('validation-error-text')} />
                 )}
 
                 <BrandedButton onPress={props.handleSubmit}>{i18n.t('next-question')}</BrandedButton>

--- a/src/features/patient/YourWorkScreen/index.tsx
+++ b/src/features/patient/YourWorkScreen/index.tsx
@@ -7,9 +7,9 @@ import * as Yup from 'yup';
 import { CheckboxItem, CheckboxList } from '@covid/components/Checkbox';
 import DropdownField from '@covid/components/DropdownField';
 import ProgressStatus from '@covid/components/ProgressStatus';
-import Screen, { FieldWrapper, Header, isAndroid, ProgressBlock } from '@covid/components/Screen';
+import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
-import { ValidationErrors } from '@covid/components/ValidationError';
+import { ValidationError } from '@covid/components/ValidationError';
 import UserService from '@covid/core/user/UserService';
 import {
   AvailabilityAlwaysOptions,
@@ -22,7 +22,7 @@ import {
 } from '@covid/core/user/dto/UserAPIContracts';
 import i18n from '@covid/locale/i18n';
 
-import { initialState, IOption, State, YourWorkData, YourWorkProps } from './helpers';
+import { initialState, State, YourWorkData, YourWorkProps } from './helpers';
 
 export default class YourWorkScreen extends Component<YourWorkProps, State> {
   constructor(props: YourWorkProps) {
@@ -384,7 +384,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
                   )}
 
                   <ErrorText>{this.state.errorMessage}</ErrorText>
-                  {!!Object.keys(errors).length && props.submitCount > 0 && <ValidationErrors errors={errors} />}
+                  {!!Object.keys(errors).length && props.submitCount > 0 && (
+                    <ValidationError error={i18n.t('validation-error-text')} />
+                  )}
 
                   <BrandedButton
                     onPress={handleSubmit}


### PR DESCRIPTION
# Description

[1] Fixes validation error alignment so that dropdowns and generic text fields are aligned
[2] Remove the list of formik field names that need changing and replaces with a simple error. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

[1]

![Screenshot 2020-06-17 at 14 19 44](https://user-images.githubusercontent.com/7824212/84907646-5cbce180-b0ab-11ea-8984-d55e655e7477.png)


[2]
![Screenshot 2020-06-17 at 14 19 25](https://user-images.githubusercontent.com/7824212/84907246-df916c80-b0aa-11ea-86f6-009b6542207b.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_

