### PR TITLE
Update README.md with fix for deprecated module import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ These are some known, common issues and their solutions:
 
 - Solution: Change some of the source code or restart the expo project running `expo start -c`
 
+2. Unable to resolve module `deprecated-react-native-listview`
+
+- Solution: Running `rm -rf $TMPDIR/metro-cache` has been reported to solve the problem. 
+
 ## License
 
 Distributed under the Apache 2.0 License. See `LICENSE` for more information.


### PR DESCRIPTION
This feels tailored for Mac users, not sure if it'd work (or if the issue would even apply) to WIndows users. 
Any comments/changes welcome but this feels straightforward