### PR TITLE
Only require diabetes answers if user has diabetes & not provided det…

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -634,6 +634,8 @@
   "never-had-test": "I have never had a COVID test",
   "above-list-correct": "The above list is correct",
 
+  "unsure": "Unsure",
+
   "errors": {
     "button-retry": "Retry",
     "button-okay": "Ok",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -634,8 +634,6 @@
   "never-had-test": "I have never had a COVID test",
   "above-list-correct": "The above list is correct",
 
-  "unsure": "Unsure",
-
   "errors": {
     "button-retry": "Retry",
     "button-okay": "Ok",

--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -23,6 +23,7 @@ export type PatientStateType = {
   hasHormoneTreatmentAnswer: boolean;
   hasVitaminAnswer: boolean;
   hasAtopyAnswers: boolean;
+  hasDiabetes: boolean;
   hasDiabetesAnswers: boolean;
   hasHayfever: boolean;
 };
@@ -47,6 +48,7 @@ const initPatientState = {
   hasHormoneTreatmentAnswer: true,
   hasVitaminAnswer: true,
   hasAtopyAnswers: true,
+  hasDiabetes: true,
   hasDiabetesAnswers: true,
 } as Partial<PatientStateType>;
 

--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -48,7 +48,7 @@ const initPatientState = {
   hasHormoneTreatmentAnswer: true,
   hasVitaminAnswer: true,
   hasAtopyAnswers: true,
-  hasDiabetes: true,
+  hasDiabetes: false,
   hasDiabetesAnswers: true,
 } as Partial<PatientStateType>;
 

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -292,6 +292,7 @@ export default class UserService extends ApiClientBase
     const shouldAskStudy = (isUSCountry() && consent && consent.document === 'US Nurses') || isGBCountry();
 
     const hasAtopyAnswers = patient.has_hayfever != null;
+    const hasDiabetes = patient.has_diabetes;
     const hasDiabetesAnswers = patient.diabetes_type != null;
     const hasHayfever = patient.has_hayfever;
 
@@ -312,6 +313,7 @@ export default class UserService extends ApiClientBase
       shouldAskLevelOfIsolation,
       shouldAskStudy,
       hasAtopyAnswers,
+      hasDiabetes,
       hasDiabetesAnswers,
       hasHayfever,
     };

--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -203,6 +203,7 @@ export type PatientInfosRequest = {
   diabetes_treatment_rapid_insulin: boolean;
   diabetes_treatment_other_injection: boolean;
   diabetes_treatment_other_oral: boolean;
+  diabetes_treatment_pfnts: boolean;
   diabetes_oral_biguanide: boolean;
   diabetes_oral_sulfonylurea: boolean;
   diabetes_oral_dpp4: boolean;

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -152,7 +152,7 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
       needHormoneTreatmentAnswer: !currentPatient.hasHormoneTreatmentAnswer,
       needVitaminAnswer: !currentPatient.hasVitaminAnswer,
       needAtopyAnswers: !currentPatient.hasAtopyAnswers,
-      needDiabetesAnswers: !currentPatient.hasDiabetesAnswers,
+      needDiabetesAnswers: !currentPatient.hasDiabetesAnswers && currentPatient.hasDiabetes,
     });
   }
 

--- a/src/features/patient/fields/DiabetesOralMedsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesOralMedsQuestion.tsx
@@ -20,6 +20,7 @@ enum DiabetesOralMedsFieldnames {
   THIAZOLIDNEDIONES = 'diabetes_oral_thiazolidinediones',
   ORAL_SGLT2 = 'diabetes_oral_sglt2',
   OTHER_MED_NOT_LISTED = 'diabetes_oral_other_medication_not_listed',
+  PREFER_NOT_TO_SAY = 'prefer_not_to_say',
 }
 
 export interface DiabetesOralMedsData {
@@ -42,6 +43,11 @@ const DIABETES_ORAL_MEDS_CHECKBOXES = [
   {
     fieldName: DiabetesOralMedsFieldnames.OTHER_MED_NOT_LISTED,
     label: i18n.t('diabetes.answer-other-oral-meds-not-listed'),
+    value: false,
+  },
+  {
+    fieldName: DiabetesOralMedsFieldnames.PREFER_NOT_TO_SAY,
+    label: i18n.t('prefer-not-to-say'),
     value: false,
   },
 ];
@@ -139,7 +145,7 @@ DiabetesOralMedsQuestion.schema = Yup.object().shape({
   }),
   diabetesOralOtherMedication: Yup.string().when('diabetesOralOtherMedicationNotListed', {
     is: (val: boolean) => val,
-    then: Yup.string().required(),
+    then: Yup.string(),
   }),
 });
 
@@ -155,7 +161,7 @@ DiabetesOralMedsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {
   data.diabetesOralMeds.forEach((item) => {
     if (item === DiabetesOralMedsFieldnames.OTHER_MED_NOT_LISTED) {
       dto.diabetes_oral_other_medication = data.diabetesOralOtherMedication;
-    } else {
+    } else if (item !== DiabetesOralMedsFieldnames.PREFER_NOT_TO_SAY) {
       dto[item] = true;
     }
   });

--- a/src/features/patient/fields/DiabetesOralMedsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesOralMedsQuestion.tsx
@@ -20,7 +20,6 @@ enum DiabetesOralMedsFieldnames {
   THIAZOLIDNEDIONES = 'diabetes_oral_thiazolidinediones',
   ORAL_SGLT2 = 'diabetes_oral_sglt2',
   OTHER_MED_NOT_LISTED = 'diabetes_oral_other_medication_not_listed',
-  PREFER_NOT_TO_SAY = 'prefer_not_to_say',
 }
 
 export interface DiabetesOralMedsData {
@@ -43,11 +42,6 @@ const DIABETES_ORAL_MEDS_CHECKBOXES = [
   {
     fieldName: DiabetesOralMedsFieldnames.OTHER_MED_NOT_LISTED,
     label: i18n.t('diabetes.answer-other-oral-meds-not-listed'),
-    value: false,
-  },
-  {
-    fieldName: DiabetesOralMedsFieldnames.PREFER_NOT_TO_SAY,
-    label: i18n.t('prefer-not-to-say'),
     value: false,
   },
 ];
@@ -161,7 +155,7 @@ DiabetesOralMedsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {
   data.diabetesOralMeds.forEach((item) => {
     if (item === DiabetesOralMedsFieldnames.OTHER_MED_NOT_LISTED) {
       dto.diabetes_oral_other_medication = data.diabetesOralOtherMedication;
-    } else if (item !== DiabetesOralMedsFieldnames.PREFER_NOT_TO_SAY) {
+    } else {
       dto[item] = true;
     }
   });

--- a/src/features/patient/fields/DiabetesQuestions.tsx
+++ b/src/features/patient/fields/DiabetesQuestions.tsx
@@ -33,6 +33,7 @@ export enum DiabetesTypeValues {
   GESTATIONAL = 'gestational',
   OTHER = 'other',
   UNSURE = 'unsure',
+  PREFER_NOT_TO_SAY = 'prefer_not_to_say',
 }
 
 export enum HemoglobinMeasureUnits {
@@ -46,6 +47,7 @@ const DIABETES_TYPE_DROPDOWN = [
   { label: i18n.t('diabetes.answer-gestational'), value: DiabetesTypeValues.GESTATIONAL },
   { label: i18n.t('diabetes.answer-unsure'), value: DiabetesTypeValues.UNSURE },
   { label: i18n.t('diabetes.answer-other'), value: DiabetesTypeValues.OTHER },
+  { label: i18n.t('prefer-not-to-say'), value: DiabetesTypeValues.PREFER_NOT_TO_SAY },
 ];
 
 const HEMOGLOBIN_MEASURE_UNITS_DROPDOWN = [
@@ -155,20 +157,20 @@ DiabetesQuestions.schema = Yup.object()
 
     diabetesTypeOther: Yup.string().when('diabetesType', {
       is: (val: string) => val === DiabetesTypeValues.OTHER,
-      then: Yup.string().required(),
+      then: Yup.string(),
     }),
 
     a1cMeasurementPercent: Yup.number().when('hemoglobinMeasureUnit', {
       is: (val: string) => val === HemoglobinMeasureUnits.PERCENT,
-      then: Yup.number().required(),
+      then: Yup.number(),
     }),
 
     a1cMeasurementMol: Yup.number().when('hemoglobinMeasureUnit', {
       is: (val: string) => val === HemoglobinMeasureUnits.MOL,
-      then: Yup.number().required(),
+      then: Yup.number(),
     }),
 
-    diabetesDiagnosisYear: Yup.number().typeError().required().integer().min(1900).max(2020),
+    diabetesDiagnosisYear: Yup.number().typeError().integer().min(1900).max(2020),
   })
   .concat(DiabetesTreamentsQuestion.schema)
   .concat(DiabetesOralMedsQuestion.schema);

--- a/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
@@ -19,7 +19,6 @@ enum DiabetesTreatmentsFieldnames {
   OTHER_INJECTION = 'diabetes_treatment_other_injection',
   OTHER_ORAL = 'diabetes_treatment_other_oral',
   PREFER_NOT_TO_SAY = 'diabetes_treatment_pfnts',
-  UNSURE = 'unsure',
 }
 
 const DIABETES_TREATMENT_CHECKBOXES = [
@@ -48,11 +47,6 @@ const DIABETES_TREATMENT_CHECKBOXES = [
   {
     fieldName: DiabetesTreatmentsFieldnames.PREFER_NOT_TO_SAY,
     label: i18n.t('prefer-not-to-say'),
-    value: false,
-  },
-  {
-    fieldName: DiabetesTreatmentsFieldnames.UNSURE,
-    label: i18n.t('unsure'),
     value: false,
   },
 ];
@@ -158,9 +152,7 @@ DiabetesTreamentsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {
     diabetes_treatment_pfnts: false,
   };
   data.diabetesTreatments.forEach((item) => {
-    if (item !== DiabetesTreatmentsFieldnames.UNSURE) {
-      dto[item] = true;
-    }
+    dto[item] = true;
   });
   return dto;
 };

--- a/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
@@ -18,7 +18,8 @@ enum DiabetesTreatmentsFieldnames {
   RAPID_INSULIN = 'diabetes_treatment_rapid_insulin',
   OTHER_INJECTION = 'diabetes_treatment_other_injection',
   OTHER_ORAL = 'diabetes_treatment_other_oral',
-  PREFER_NOT_TO_SAY = 'prefer_not_to_say',
+  PREFER_NOT_TO_SAY = 'diabetes_treatment_pfnts',
+  UNSURE = 'unsure',
 }
 
 const DIABETES_TREATMENT_CHECKBOXES = [
@@ -47,6 +48,11 @@ const DIABETES_TREATMENT_CHECKBOXES = [
   {
     fieldName: DiabetesTreatmentsFieldnames.PREFER_NOT_TO_SAY,
     label: i18n.t('prefer-not-to-say'),
+    value: false,
+  },
+  {
+    fieldName: DiabetesTreatmentsFieldnames.UNSURE,
+    label: i18n.t('unsure'),
     value: false,
   },
 ];
@@ -149,9 +155,10 @@ DiabetesTreamentsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {
     diabetes_treatment_rapid_insulin: false,
     diabetes_treatment_other_injection: false,
     diabetes_treatment_other_oral: false,
+    diabetes_treatment_pfnts: false,
   };
   data.diabetesTreatments.forEach((item) => {
-    if (item !== DiabetesTreatmentsFieldnames.PREFER_NOT_TO_SAY) {
+    if (item !== DiabetesTreatmentsFieldnames.UNSURE) {
       dto[item] = true;
     }
   });

--- a/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
@@ -18,6 +18,7 @@ enum DiabetesTreatmentsFieldnames {
   RAPID_INSULIN = 'diabetes_treatment_rapid_insulin',
   OTHER_INJECTION = 'diabetes_treatment_other_injection',
   OTHER_ORAL = 'diabetes_treatment_other_oral',
+  PREFER_NOT_TO_SAY = 'prefer_not_to_say',
 }
 
 const DIABETES_TREATMENT_CHECKBOXES = [
@@ -41,6 +42,11 @@ const DIABETES_TREATMENT_CHECKBOXES = [
   {
     fieldName: DiabetesTreatmentsFieldnames.OTHER_ORAL,
     label: i18n.t('diabetes.answer-other-oral-meds'),
+    value: false,
+  },
+  {
+    fieldName: DiabetesTreatmentsFieldnames.PREFER_NOT_TO_SAY,
+    label: i18n.t('prefer-not-to-say'),
     value: false,
   },
 ];
@@ -145,7 +151,9 @@ DiabetesTreamentsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {
     diabetes_treatment_other_oral: false,
   };
   data.diabetesTreatments.forEach((item) => {
-    dto[item] = true;
+    if (item !== DiabetesTreatmentsFieldnames.PREFER_NOT_TO_SAY) {
+      dto[item] = true;
+    }
   });
   return dto;
 };


### PR DESCRIPTION
# Description

- Added new dropdown options for answer **Prefer not to say**
- Added checkbox item for diabetes treatment answer **Prefer not to say**
- Added checkbox item for diabetes treatment answer **Unsure**
- Added new field `diabetes_treatment_pfnts` to `PatientInfosRequest` for diabetes treatment answer **Prefer not to say**
- Updated `needDiabetesAnswers` logic to only show to user who has diabetes & have not provided any details.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

None.

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

None.
