### PR TITLE
Bug fixes on new diabetes questions

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -895,7 +895,7 @@
   },
 
   "diabetes": {
-    "justification": "You previously indicated that you had diabetes, which is an important risk factor for COVID. Our scientists have a couple of follow up questions to understand more about this.",
+    "justification": "You previously indicated that you had diabetes, which is an important risk factor for COVID. Our scientists have a couple of follow up questions to understand more about this. These questions are completely optional.",
     "which-type": "What kind of diabetes do you have?",
     "answer-type-1": "Type 1 diabetes",
     "answer-type-2": "Type 2 diabetes",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -920,6 +920,7 @@
     "answer-meglitinides": "Meglitinides (e.g. repaglinide, nateglinide)",
     "answer-thiazolidinediones": "Thiazolidinediones or Glitazones (e.g. rosiglitazone, pioglitazone)",
     "answer-sglt": "SGLT-2 inhibitors (e.g. canagliflozin, dapagliflozin)",
-    "answer-other-oral-meds-not-listed": "Other oral diabetes medication not listed:"
+    "answer-other-oral-meds-not-listed": "Other oral diabetes medication not listed",
+    "please-select-diabetes-treatment": "Please select one or more of the above"
   }
 }

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -897,7 +897,7 @@
   },
 
   "diabetes": {
-    "justification": "Indicó previamente que tenía diabetes lo cual es un factor de riesgo para COVID. Nuestros científicos tienen un par de preguntas más para entenderla mejor.",
+    "justification": "Indicó previamente que tenía diabetes lo cual es un factor de riesgo para COVID. Nuestros científicos tienen un par de preguntas más para entenderla mejor. Estas preguntas son opcionales.",
     "which-type": "¿Qué tipo de diabetes le han diagnosticado?",
     "answer-type-1": "Diabetes tipo 1",
     "answer-type-2": "Diabetes tipo 2",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -922,6 +922,7 @@
     "answer-meglitinides": "Meglitinidas (ej. repaglinide, nateglinide)",
     "answer-thiazolidinediones": "Thiazolidinediones o glitazones (ej. rosiglitazone, pioglitazone)",
     "answer-sglt": "Inhibidores del SGLT-2(ej. canagliflozin, dapagliflozin)",
-    "answer-other-oral-meds-not-listed": "Otras medicamentos tomados por vía oral no incluidos en esta lista"
+    "answer-other-oral-meds-not-listed": "Otras medicamentos tomados por vía oral no incluidos en esta lista",
+    "please-select-diabetes-treatment": "Seleccione uno o más de los anteriores"
   }
 }

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -893,7 +893,7 @@
   },
 
   "diabetes": {
-    "justification": "Du angav tidigare att du har diabetes, vilket är en viktig riskfaktor för covid-19. Våra forskare har några uppföljande frågor för att de ska förstå mer om detta.",
+    "justification": "Du angav tidigare att du har diabetes, vilket är en viktig riskfaktor för covid-19. Våra forskare har några uppföljande frågor för att de ska förstå mer om detta. Alla frågor är helt frivilliga.",
     "which-type": "Vilken typ av diabetes har du?",
     "answer-type-1": "Diabetes typ 1",
     "answer-type-2": "Diabetes typ 2",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -918,6 +918,7 @@
     "answer-meglitinides": "Meglitinider (t.ex. NovoNorm® eller Repaglinid®)",
     "answer-thiazolidinediones": "Glitazoner (t.ex. Actos® eller Pioglitazone®)",
     "answer-sglt": "SGLT-2-hämmare (t.ex. Jardiance®, Forxiga®, Steglatro® eller Invokana®)",
-    "answer-other-oral-meds-not-listed": "Annan sorts tabletter som inte finns med i listan (fritext)"
+    "answer-other-oral-meds-not-listed": "Annan sorts tabletter som inte finns med i listan (fritext)",
+    "please-select-diabetes-treatment": "Välj ett eller flera av alternativen ovan"
   }
 }

--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -25,6 +25,7 @@ export type PatientStateType = {
   hasAtopyAnswers: boolean;
   hasDiabetes: boolean;
   hasDiabetesAnswers: boolean;
+  shouldAskExtendedDiabetes: boolean;
   hasHayfever: boolean;
 };
 
@@ -48,8 +49,7 @@ const initPatientState = {
   hasHormoneTreatmentAnswer: true,
   hasVitaminAnswer: true,
   hasAtopyAnswers: true,
-  hasDiabetes: false,
-  hasDiabetesAnswers: true,
+  shouldAskExtendedDiabetes: false,
 } as Partial<PatientStateType>;
 
 export const getInitialPatientState = (patientId: string): PatientStateType => {

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -294,6 +294,7 @@ export default class UserService extends ApiClientBase
     const hasAtopyAnswers = patient.has_hayfever != null;
     const hasDiabetes = patient.has_diabetes;
     const hasDiabetesAnswers = patient.diabetes_type != null;
+    const shouldAskExtendedDiabetes = !hasDiabetesAnswers && hasDiabetes;
     const hasHayfever = patient.has_hayfever;
 
     return {

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -312,6 +312,7 @@ export default class UserService extends ApiClientBase
       isReportedByAnother,
       isSameHousehold,
       shouldAskLevelOfIsolation,
+      shouldAskExtendedDiabetes,
       shouldAskStudy,
       hasAtopyAnswers,
       hasDiabetes,

--- a/src/features/assessment/AssessmentCoordinator.ts
+++ b/src/features/assessment/AssessmentCoordinator.ts
@@ -142,12 +142,12 @@ export class AssessmentCoordinator {
   static mustBackFillProfile(currentPatient: PatientStateType, config: ConfigType) {
     return (
       ((config.showRaceQuestion || config.showEthnicityQuestion) && !currentPatient.hasRaceEthnicityAnswer) ||
+      currentPatient.shouldAskExtendedDiabetes ||
       !currentPatient.hasPeriodAnswer ||
       !currentPatient.hasHormoneTreatmentAnswer ||
       !currentPatient.hasBloodPressureAnswer ||
       !currentPatient.hasVitaminAnswer ||
-      !currentPatient.hasAtopyAnswers ||
-      !currentPatient.hasDiabetesAnswers
+      !currentPatient.hasAtopyAnswers
     );
   }
 

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -152,7 +152,7 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
       needHormoneTreatmentAnswer: !currentPatient.hasHormoneTreatmentAnswer,
       needVitaminAnswer: !currentPatient.hasVitaminAnswer,
       needAtopyAnswers: !currentPatient.hasAtopyAnswers,
-      needDiabetesAnswers: !currentPatient.hasDiabetesAnswers && currentPatient.hasDiabetes,
+      needDiabetesAnswers: currentPatient.shouldAskExtendedDiabetes,
     });
   }
 

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -173,7 +173,10 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
         if (formData.vitaminSupplements?.length) currentPatient.hasVitaminAnswer = true;
         if (formData.hasHayfever) currentPatient.hasAtopyAnswers = true;
         if (formData.hasHayfever == 'yes') currentPatient.hasHayfever = true;
-        if (formData.diabetesType) currentPatient.hasDiabetesAnswers = true;
+        if (formData.diabetesType) {
+          currentPatient.hasDiabetesAnswers = true;
+          currentPatient.shouldAskExtendedDiabetes = false;
+        }
         AssessmentCoordinator.gotoNextScreen(this.props.route.name);
       })
       .catch((err) => {

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -288,6 +288,13 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
       };
     }
 
+    if (infos.has_diabetes) {
+      infos = {
+        ...infos,
+        ...DiabetesQuestions.createDTO(formData),
+      };
+    }
+
     return infos;
   }
 

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -288,7 +288,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
       };
     }
 
-    if (infos.has_diabetes) {
+    if (this.state.showDiabetesQuestion) {
       infos = {
         ...infos,
         ...DiabetesQuestions.createDTO(formData),
@@ -375,7 +375,7 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
                   label={i18n.t('your-health.have-diabetes')}
                 />
 
-                {props.values.hasDiabetes === 'yes' && (
+                {this.state.showDiabetesQuestion && (
                   <DiabetesQuestions formikProps={props as FormikProps<DiabetesData>} />
                 )}
 

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -193,7 +193,11 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
         currentPatient.hasHormoneTreatmentAnswer = true;
         currentPatient.hasVitaminAnswer = true;
         currentPatient.hasAtopyAnswers = true;
-        if (formData.hasHayfever == 'yes') currentPatient.hasHayfever = true;
+        if (formData.diabetesType) {
+          currentPatient.hasDiabetesAnswers = true;
+          currentPatient.shouldAskExtendedDiabetes = false;
+        }
+        if (formData.hasHayfever === 'yes') currentPatient.hasHayfever = true;
 
         this.props.navigation.navigate('PreviousExposure', { currentPatient });
       })

--- a/src/features/patient/fields/DiabetesOralMedsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesOralMedsQuestion.tsx
@@ -135,7 +135,7 @@ DiabetesOralMedsQuestion.initialFormValues = (): DiabetesOralMedsData => {
 DiabetesOralMedsQuestion.schema = Yup.object().shape({
   diabetesOralMeds: Yup.array<string>().when('diabetesTreatmentOtherOral', {
     is: (val: boolean) => val,
-    then: Yup.array<string>().min(1),
+    then: Yup.array<string>(),
   }),
   diabetesOralOtherMedication: Yup.string().when('diabetesOralOtherMedicationNotListed', {
     is: (val: boolean) => val,

--- a/src/features/patient/fields/DiabetesQuestions.tsx
+++ b/src/features/patient/fields/DiabetesQuestions.tsx
@@ -33,7 +33,7 @@ export enum DiabetesTypeValues {
   GESTATIONAL = 'gestational',
   OTHER = 'other',
   UNSURE = 'unsure',
-  PREFER_NOT_TO_SAY = 'prefer_not_to_say',
+  PREFER_NOT_TO_SAY = 'pfnts',
 }
 
 export enum HemoglobinMeasureUnits {

--- a/src/features/patient/fields/DiabetesQuestions.tsx
+++ b/src/features/patient/fields/DiabetesQuestions.tsx
@@ -179,7 +179,7 @@ DiabetesQuestions.createDTO = (data) => {
   const dto = {
     diabetes_type: data.diabetesType,
     diabetes_type_other: data.diabetesTypeOther,
-    diabetes_diagnosis_year: cleanIntegerVal(data.diabetesDiagnosisYear),
+    ...(data.diabetesDiagnosisYear && { diabetes_diagnosis_year: cleanIntegerVal(data.diabetesDiagnosisYear) }),
     ...DiabetesTreamentsQuestion.createDTO(data),
     ...DiabetesOralMedsQuestion.createDTO(data),
   };
@@ -191,10 +191,11 @@ DiabetesQuestions.createDTO = (data) => {
 
   switch (data.hemoglobinMeasureUnit) {
     case HemoglobinMeasureUnits.PERCENT:
-      dto.a1c_measurement_percent = cleanFloatVal(data.a1cMeasurementPercent ?? '0');
+      console.log(data.a1cMeasurementPercent, !data.a1cMeasurementPercent);
+      if (data.a1cMeasurementPercent) dto.a1c_measurement_percent = cleanFloatVal(data.a1cMeasurementPercent ?? '0');
       break;
     case HemoglobinMeasureUnits.MOL:
-      dto.a1c_measurement_mmol = cleanFloatVal(data.a1cMeasurementMol ?? '0');
+      if (data.a1cMeasurementMol) dto.a1c_measurement_mmol = cleanFloatVal(data.a1cMeasurementMol ?? '0');
       break;
   }
 

--- a/src/features/patient/fields/DiabetesQuestions.tsx
+++ b/src/features/patient/fields/DiabetesQuestions.tsx
@@ -191,7 +191,6 @@ DiabetesQuestions.createDTO = (data) => {
 
   switch (data.hemoglobinMeasureUnit) {
     case HemoglobinMeasureUnits.PERCENT:
-      console.log(data.a1cMeasurementPercent, !data.a1cMeasurementPercent);
       if (data.a1cMeasurementPercent) dto.a1c_measurement_percent = cleanFloatVal(data.a1cMeasurementPercent ?? '0');
       break;
     case HemoglobinMeasureUnits.MOL:

--- a/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
@@ -138,7 +138,7 @@ DiabetesTreamentsQuestion.initialFormValues = (): DiabetesTreatmentsData => {
 };
 
 DiabetesTreamentsQuestion.schema = Yup.object().shape({
-  diabetesTreatments: Yup.array<string>().min(1, i18n.t('please-select-diabetes-treatment')),
+  diabetesTreatments: Yup.array<string>().min(1, i18n.t('diabetes.please-select-diabetes-treatment')),
 });
 
 DiabetesTreamentsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {

--- a/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
+++ b/src/features/patient/fields/DiabetesTreatmentsQuestion.tsx
@@ -138,7 +138,7 @@ DiabetesTreamentsQuestion.initialFormValues = (): DiabetesTreatmentsData => {
 };
 
 DiabetesTreamentsQuestion.schema = Yup.object().shape({
-  diabetesTreatments: Yup.array<string>().min(1),
+  diabetesTreatments: Yup.array<string>().min(1, i18n.t('please-select-diabetes-treatment')),
 });
 
 DiabetesTreamentsQuestion.createDTO = (data): Partial<PatientInfosRequest> => {


### PR DESCRIPTION
# Description

[1] Adjusted justification copy to indicate questions are optional
[2] Switched to using a shouldAskExtendedDiabetes variable to conditionally render on the backfill page
[3] Switch BACK to using state to conditionally render questions on the YourHealth screen
[4] Add diabetes DTO to payload on YourHealth screen
[5] Updated DiabetesTreatment pfnts option as was too long for backends max_length
[6] Conditionally add numeric values to payload on Diabetes questions
[7] Add meaningful and translatable error message to Treatment question when no option selected
[8] Remove validation on oral meds question (users can simply not answer)

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
