### PR TITLE
Add's Lifestyles questions

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -935,6 +935,7 @@
       "same": "Stayed the same",
       "pfnts": "Prefer not to say"
     },
+    "weight-difference": "By how much (an estimate is fine)?",
     "diet-change": {
       "question": "How was your diet changed in your opinion?",
       "increased": "It has become healthier",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -921,5 +921,48 @@
     "answer-thiazolidinediones": "Thiazolidinediones or Glitazones (e.g. rosiglitazone, pioglitazone)",
     "answer-sglt": "SGLT-2 inhibitors (e.g. canagliflozin, dapagliflozin)",
     "answer-other-oral-meds-not-listed": "Other oral diabetes medication not listed:"
+  },
+
+  "lifestyle": {
+    "title": "Diet & Lifestyle",
+    "explanation": "The following questions on weight, nutrition and exercise are to help us understand whether COVID may be impacting our health in these areas and how significant these effects are. These questions are all optional.",
+    "text": "Since March when COVID became prevalent:",
+    "please-select-option": "Please select an option",
+    "weight-change": {
+      "question": "How has your weight changed?",
+      "increased": "Increased",
+      "decreased": "Decreased",
+      "same": "Stayed the same",
+      "pfnts": "Prefer not to say"
+    },
+    "diet-change": {
+      "question": "How was your diet changed in your opinion?",
+      "increased": "It has become healthier",
+      "decreased": "It has become more unhealthy",
+      "same": "It has stayed the same",
+      "pfnts": "Prefer not to say"
+    },
+    "snacking-change": {
+      "question": "How has your snacking changed?",
+      "increased": "I am snacking more",
+      "decreased": "I am snacking less",
+      "same": "My snacking levels are the same",
+      "pfnts": "Prefer not to say"
+    },
+    "alcohol-change": {
+      "question": "How has your alcohol consumption changed? ",
+      "no-alcohol": "I don't drink alcohol",
+      "increased": "I am drinking more alcohol",
+      "decreased": "I am drinking less alcohol",
+      "same": "I am drinking less alcohol",
+      "pfnts": "Prefer not to say"
+    },
+    "activity-change": {
+      "question": "Have your physical activity levels changed?",
+      "increased": "Yes, increased",
+      "decreased": "Yes, decreased",
+      "same": "No change, has remained the same",
+      "pfnts": "Prefer not to say"
+    }
   }
 }

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -924,7 +924,7 @@
   },
 
   "lifestyle": {
-    "title": "Diet & Lifestyle",
+    "title": "Diet & lifestyle",
     "explanation": "The following questions on weight, nutrition and exercise are to help us understand whether COVID may be impacting our health in these areas and how significant these effects are. These questions are all optional.",
     "text": "Since March when COVID became prevalent:",
     "please-select-option": "Please select an option",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -926,45 +926,45 @@
   },
 
   "lifestyle": {
-    "title": "",
-    "explanation": "",
-    "text": "",
-    "please-select-option": "Please select an option",
+    "title": "Dieta y estilo de vida",
+    "explanation": "Las siguientes preguntas sobre peso, nutrición y ejercicio nos ayudan a entender si COVID puede afectar nuestra salud en estas áreas y la importancia de estos efectos. Estas preguntas son opcionales.",
+    "text": "Hasta Marzo cuando COVID se hizo frecuente:",
+    "please-select-option": "Seleccione una opción",
     "weight-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Cómo ha cambiado su peso?",
+      "increased": "Aumentado",
+      "decreased": "Disminuido",
+      "same": "Se ha mantenido igual",
+      "pfnts": "Prefiero no decir"
     },
     "diet-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "En su opinion, cómo ha cambiado su dieta?",
+      "increased": "Se ha vuelto más saludable",
+      "decreased": "Se ha vuelto menos saludable",
+      "same": "Se ha mantenido igual",
+      "pfnts": "Prefiero no decir"
     },
     "snacking-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Cómo ha cambiado su snacking?",
+      "increased": "Estoy comiendo más snacks",
+      "decreased": "Estoy comiendo menos snacks",
+      "same": "Mi niveles de snacking son iguales",
+      "pfnts": "Prefiero no decir"
     },
     "alcohol-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "no-alcohol": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Cómo ha cambiado su consumo de alcohol?",
+      "increased": "Estoy tomando más",
+      "decreased": "Estoy tomando menos",
+      "no-alcohol": "No tomo",
+      "same": "Mi consumo mantiene igual",
+      "pfnts": "Prefiero no decir"
     },
     "activity-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Ha cambiado su nivel de la actividad física?",
+      "increased": "Sí, ha aumentado",
+      "decreased": "Sí, ha disminuido",
+      "same": "No, ha mantenido igual",
+      "pfnts": "Prefiero no decir"
     }
   }
 }

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -937,6 +937,7 @@
       "same": "Se ha mantenido igual",
       "pfnts": "Prefiero no decir"
     },
+    "weight-difference": "Cuánto ha cambiado (un estimado está bien)?",
     "diet-change": {
       "question": "En su opinion, cómo ha cambiado su dieta?",
       "increased": "Se ha vuelto más saludable",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -923,5 +923,48 @@
     "answer-thiazolidinediones": "Thiazolidinediones o glitazones (ej. rosiglitazone, pioglitazone)",
     "answer-sglt": "Inhibidores del SGLT-2(ej. canagliflozin, dapagliflozin)",
     "answer-other-oral-meds-not-listed": "Otras medicamentos tomados por vía oral no incluidos en esta lista"
+  },
+
+  "lifestyle": {
+    "title": "",
+    "explanation": "",
+    "text": "",
+    "please-select-option": "Please select an option",
+    "weight-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "diet-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "snacking-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "alcohol-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "no-alcohol": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "activity-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    }
   }
 }

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -933,6 +933,7 @@
       "same": "Oförändrad",
       "pfnts": "Föredrar att inte berätta"
     },
+    "weight-difference": "Med hur mycket (en uppskattning räcker)?",
     "diet-change": {
       "question": "Hur tycker du att din kost har förändrats?",
       "increased": "Den har blivit hälsosammare",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -919,5 +919,48 @@
     "answer-thiazolidinediones": "Glitazoner (t.ex. Actos® eller Pioglitazone®)",
     "answer-sglt": "SGLT-2-hämmare (t.ex. Jardiance®, Forxiga®, Steglatro® eller Invokana®)",
     "answer-other-oral-meds-not-listed": "Annan sorts tabletter som inte finns med i listan (fritext)"
+  },
+
+  "lifestyle": {
+    "title": "",
+    "explanation": "",
+    "text": "",
+    "please-select-option": "Please select an option",
+    "weight-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "diet-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "snacking-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "alcohol-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "no-alcohol": "",
+      "same": "",
+      "pfnts": ""
+    },
+    "activity-change": {
+      "question": "",
+      "increased": "",
+      "decreased": "",
+      "same": "",
+      "pfnts": ""
+    }
   }
 }

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -922,45 +922,45 @@
   },
 
   "lifestyle": {
-    "title": "",
-    "explanation": "",
-    "text": "",
-    "please-select-option": "Please select an option",
+    "title": "Kost & livsstil",
+    "explanation": "Följande frågor om vikt, kost och fysisk aktivitet ska hjälpa oss att förstå om covid-19 eventuellt påverkar din hälsa inom dessa områden och hur betydande dessa effekter är. Det är helt frivilligt att svara på frågorna.",
+    "text": "Sedan mars månad när covid-19 blev allmänt förekommande i samhället:",
+    "please-select-option": "Välj ett alternativ",
     "weight-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Hur har din vikt förändrats?",
+      "increased": "Ökat",
+      "decreased": "Minskat",
+      "same": "Oförändrad",
+      "pfnts": "Föredrar att inte berätta"
     },
     "diet-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Hur tycker du att din kost har förändrats?",
+      "increased": "Den har blivit hälsosammare",
+      "decreased": "Den har blivit ohälsosammare",
+      "same": "Den är oförändrad",
+      "pfnts": "Föredrar att inte berätta"
     },
     "snacking-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Hur har ditt småätande förändrats?",
+      "increased": "Jag småäter mer (snacks)",
+      "decreased": "Jag småäter mindre (snacks)",
+      "same": "Jag småäter lika mycket som innan",
+      "pfnts": "Föredrar att inte berätta"
     },
     "alcohol-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "no-alcohol": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Hur har din alkoholkonsumtion förändrats?",
+      "increased": "Jag dricker mer alkohol",
+      "decreased": "Jag dricker mindre alkohol",
+      "no-alcohol": "Jag dricker inte alkohol",
+      "same": "Min alkoholkonsumtion är oförändrad",
+      "pfnts": "Föredrar att inte berätta"
     },
     "activity-change": {
-      "question": "",
-      "increased": "",
-      "decreased": "",
-      "same": "",
-      "pfnts": ""
+      "question": "Har dina nivåer av fysisk aktivitet förändrats?",
+      "increased": "Ja, ökat",
+      "decreased": "Ja, minskat",
+      "same": "Ingen förändring, oförändrade",
+      "pfnts": "Föredrar att inte berätta"
     }
   }
 }

--- a/mock-server/config.ts
+++ b/mock-server/config.ts
@@ -17,6 +17,9 @@ const config: DbConfig = {
   covidTests: {
     path: 'covid_tests.json',
   },
+  lifestyle: {
+    path: 'lifestyles.json',
+  },
   consents: {
     path: 'consents.json',
   },

--- a/mock-server/mockDb.ts
+++ b/mock-server/mockDb.ts
@@ -1,12 +1,12 @@
 import config from './config';
 import helpers from './helpers';
-import { Patient, Assessment, CovidTest, Consent, StudyConsent } from './types';
+import { Patient, Assessment, CovidTest, Consent, StudyConsent, Lifestyle } from './types';
 
 const dbPath = './mock-server/db';
 
 export default () => {
   const { bootstrap, get, save } = helpers(dbPath);
-  const { patients, assessments, covidTests, consents, studyConsents } = config;
+  const { patients, assessments, covidTests, consents, lifestyles, studyConsents } = config;
 
   bootstrap(config);
 
@@ -19,6 +19,10 @@ export default () => {
       get: (assessmentId?: string) => get<Assessment>(assessments.path)(assessmentId),
       save: (assessmentId: string, assessment: Assessment): Assessment =>
         save<Assessment>(assessments.path)(assessmentId, assessment),
+    },
+    lifestyles: {
+      get: (id?: string) => get<Lifestyle>(lifestyles.path)(id),
+      save: (id: string, lifestyle: Lifestyle): Lifestyle => save<Lifestyle>(lifestyles.path)(id, lifestyle),
     },
     covidTests: {
       get: (testId?: string) => get<CovidTest>(covidTests.path)(testId),

--- a/mock-server/mockServer.ts
+++ b/mock-server/mockServer.ts
@@ -1,5 +1,5 @@
 import mockDb from './mockDb';
-import { Patient, Assessment } from './types';
+import { Patient, Assessment, Lifestyle } from './types';
 import express = require('express');
 import bodyParser = require('body-parser');
 import uuid = require('uuid');
@@ -210,6 +210,18 @@ app.post('/patients/', (req, res) => {
 app.get('/patient_list/', (_, res) => {
   res.header('Content-type', 'application/json');
   return res.send(db.patients.get());
+});
+
+/**
+ * Lifestyle
+ */
+
+app.post('/lifestyles/', (req, res) => {
+  const { body: lifestyle } = req as { body: Lifestyle };
+  const id = uuid.v1();
+
+  res.header('Content-type', 'application/json');
+  return res.send(db.lifestyles.save(id, { ...lifestyle, id }));
 });
 
 /**

--- a/mock-server/types.ts
+++ b/mock-server/types.ts
@@ -12,6 +12,11 @@ export interface Assessment {
   profile_attributes_updated_at: string;
 }
 
+export interface Lifestyle {
+  id: string;
+  patient: string;
+}
+
 export interface CovidTest {
   id: string;
   patient: string;

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -60,6 +60,7 @@ import TermsOfUseUSScreen from '@covid/features/register/us/TermsOfUseUSScreen';
 import i18n from '@covid/locale/i18n';
 import { EditProfileScreen } from '@covid/features/multi-profile/EditProfileScreen';
 import { ArchiveReasonScreen } from '@covid/features/multi-profile/ArchiveReasonScreen';
+import LifestyleScreen from '@covid/features/assessment/LifestyleScreen';
 
 const Stack = createStackNavigator<ScreenParamList>();
 const Drawer = createDrawerNavigator();
@@ -214,6 +215,7 @@ export default class CovidApp extends Component<object, State> {
         <Stack.Screen name="SelectProfile" component={SelectProfileScreen} options={noHeader} />
         <Stack.Screen name="AdultOrChild" component={AdultOrChildScreen} options={noHeader} />
         <Stack.Screen name="ProfileBackDate" component={ProfileBackDateScreen} options={noHeader} />
+        <Stack.Screen name="Lifestyle" component={LifestyleScreen} options={noHeader} />
         <Stack.Screen name="ValidationStudyIntro" component={ValidationStudyIntroScreen} options={noHeader} />
         <Stack.Screen name="ValidationStudyConsent" component={ValidationStudyConsentScreen} options={noHeader} />
         <Stack.Screen name="ValidationStudyInfo" component={ValidationStudyInfoScreen} options={noHeader} />

--- a/src/core/assessment/AssessmentApiClient.ts
+++ b/src/core/assessment/AssessmentApiClient.ts
@@ -1,3 +1,6 @@
+import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
+import { LifestyleResponse } from '@covid/core/assessment/dto/LifestyleResponse';
+
 import appConfig from '../../../appConfig';
 import { IApiClient } from '../api/ApiClient';
 
@@ -9,6 +12,7 @@ const API_ASSESSMENTS = '/assessments/';
 export interface IAssessmentRemoteClient {
   addAssessment(assessment: AssessmentInfosRequest): Promise<AssessmentResponse>;
   updateAssessment(assessmentId: string, assessment: AssessmentInfosRequest): Promise<AssessmentResponse>;
+  addLifeStyle(patientId: string, payload: LifestyleRequest): Promise<LifestyleResponse>;
 }
 
 export class AssessmentApiClient implements IAssessmentRemoteClient {
@@ -28,5 +32,16 @@ export class AssessmentApiClient implements IAssessmentRemoteClient {
   updateAssessment(assessmentId: string, assessment: AssessmentInfosRequest): Promise<AssessmentResponse> {
     const assessmentUrl = `/assessments/${assessmentId}/`;
     return this.apiClient.patch<AssessmentInfosRequest, AssessmentResponse>(assessmentUrl, assessment);
+  }
+
+  addLifeStyle(patientId: string, payload: LifestyleRequest): Promise<LifestyleResponse> {
+    const url = '/lifestyles/';
+
+    payload = {
+      ...payload,
+      patient: patientId,
+      version: appConfig.lifestyleVersion,
+    };
+    return this.apiClient.post<LifestyleRequest, LifestyleResponse>(url, payload);
   }
 }

--- a/src/core/assessment/AssessmentService.ts
+++ b/src/core/assessment/AssessmentService.ts
@@ -1,3 +1,6 @@
+import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
+import { LifestyleResponse } from '@covid/core/assessment/dto/LifestyleResponse';
+
 import { IAssessmentRemoteClient } from './AssessmentApiClient';
 import { IAssessmentState } from './AssessmentState';
 import { AssessmentInfosRequest } from './dto/AssessmentInfosRequest';
@@ -9,6 +12,7 @@ export interface IAssessmentService {
   initAssessment(): void;
   saveAssessment(assessmentId: AssessmentId, assessment: Partial<AssessmentInfosRequest>): Promise<AssessmentResponse>;
   completeAssessment(assessmentId: AssessmentId, assessment: Partial<AssessmentInfosRequest> | null): Promise<boolean>;
+  saveLifestyle(patientId: string, payload: Partial<LifestyleRequest>): Promise<LifestyleResponse>;
 }
 
 export default class AssessmentService implements IAssessmentService {
@@ -72,5 +76,10 @@ export default class AssessmentService implements IAssessmentService {
 
     const response = this.sendFullAssessmentToApi();
     return !!response;
+  }
+
+  async saveLifestyle(patientId: string, lifestyle: Partial<LifestyleRequest>): Promise<LifestyleResponse> {
+    const response = await this.apiClient.addLifeStyle(patientId, lifestyle as LifestyleRequest);
+    return response;
   }
 }

--- a/src/core/assessment/dto/LifestyleRequest.ts
+++ b/src/core/assessment/dto/LifestyleRequest.ts
@@ -1,0 +1,11 @@
+export type LifestyleRequest = {
+  id: string;
+  version: string; // document/schema version
+  patient: string; //	Patient id
+
+  weight_change: string;
+  diet_change: string;
+  snacking_change: string;
+  activity_change: string;
+  alcohol_change: string;
+};

--- a/src/core/assessment/dto/LifestyleRequest.ts
+++ b/src/core/assessment/dto/LifestyleRequest.ts
@@ -4,6 +4,8 @@ export type LifestyleRequest = {
   patient: string; //	Patient id
 
   weight_change: string;
+  weight_change_pounds: number;
+  weight_change_kg: number;
   diet_change: string;
   snacking_change: string;
   activity_change: string;

--- a/src/core/assessment/dto/LifestyleResponse.ts
+++ b/src/core/assessment/dto/LifestyleResponse.ts
@@ -1,0 +1,3 @@
+export type LifestyleResponse = {
+  id: string;
+};

--- a/src/core/patient/PatientState.ts
+++ b/src/core/patient/PatientState.ts
@@ -18,6 +18,7 @@ export type PatientStateType = {
   isSameHousehold: boolean;
   shouldAskLevelOfIsolation: boolean;
   shouldAskStudy: boolean;
+  shouldAskLifestyleQuestion: boolean;
   hasRaceEthnicityAnswer: boolean;
   hasPeriodAnswer: boolean;
   hasHormoneTreatmentAnswer: boolean;
@@ -42,6 +43,7 @@ const initPatientState = {
   isSameHousehold: false,
   shouldAskLevelOfIsolation: false,
   shouldAskStudy: false,
+  shouldAskLifestyleQuestion: false,
   hasRaceEthnicityAnswer: true,
   hasPeriodAnswer: true,
   hasHormoneTreatmentAnswer: true,

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -286,6 +286,7 @@ export default class UserService extends ApiClientBase
 
     const hasVitaminAnswer = !!patient.vs_asked_at;
     const shouldAskLevelOfIsolation = UserService.shouldAskLevelOfIsolation(patient.last_asked_level_of_isolation);
+    const shouldAskLifestyleQuestion = patient.should_ask_lifestyle_questions;
 
     // Decide whether patient needs to answer YourStudy questions
     const consent = await this.getConsentSigned();
@@ -314,6 +315,7 @@ export default class UserService extends ApiClientBase
       hasAtopyAnswers,
       hasDiabetesAnswers,
       hasHayfever,
+      shouldAskLifestyleQuestion,
     };
   }
 

--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -159,6 +159,7 @@ export type PatientInfosRequest = {
   race_other: string;
   ethnicity: string;
   last_asked_level_of_isolation: Date;
+  should_ask_lifestyle_questions: boolean;
 
   // period fields
   period_status: string;

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -63,6 +63,7 @@ export type ScreenParamList = {
   TreatmentSelection: { assessmentData: AssessmentData; location: string };
   TreatmentOther: { assessmentData: AssessmentData; location: string };
   ProfileBackDate: { assessmentData: AssessmentData };
+  Lifestyle: { assessmentData: AssessmentData };
 
   // Completion screens
   ThankYou: undefined;

--- a/src/features/assessment/AssessmentCoordinator.ts
+++ b/src/features/assessment/AssessmentCoordinator.ts
@@ -38,6 +38,13 @@ export class AssessmentCoordinator {
       this.navigation.navigate('CovidTest', { assessmentData: this.assessmentData });
     },
     CovidTest: () => {
+      if (this.assessmentData.currentPatient.shouldAskLifestyleQuestion) {
+        this.navigation.navigate('Lifestyle', { assessmentData: this.assessmentData });
+      } else {
+        this.navigation.navigate('HowYouFeel', { assessmentData: this.assessmentData });
+      }
+    },
+    Lifestyle: () => {
       this.navigation.navigate('HowYouFeel', { assessmentData: this.assessmentData });
     },
     CovidTestDetail: () => {

--- a/src/features/assessment/LifestyleScreen.tsx
+++ b/src/features/assessment/LifestyleScreen.tsx
@@ -1,0 +1,131 @@
+import { RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { Form, View } from 'native-base';
+import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
+import { Formik, FormikProps } from 'formik';
+import * as Yup from 'yup';
+
+import ProgressStatus from '@covid/components/ProgressStatus';
+import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
+import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
+import AssessmentCoordinator from '@covid/features/assessment/AssessmentCoordinator';
+import i18n from '@covid/locale/i18n';
+import { assessmentService } from '@covid/Services';
+import { ValidationError } from '@covid/components/ValidationError';
+
+import { ScreenParamList } from '../ScreenParamList';
+
+import { LifestyleData, LifestyleQuestion } from './fields/LifestyleQuestion';
+
+type Props = {
+  navigation: StackNavigationProp<ScreenParamList, 'Lifestyle'>;
+  route: RouteProp<ScreenParamList, 'Lifestyle'>;
+};
+
+type State = {
+  errorMessage: string;
+  submitting: boolean;
+};
+
+const initialState: State = {
+  errorMessage: '',
+  submitting: false,
+};
+
+export default class LifestyleScreen extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = initialState;
+    AssessmentCoordinator.resetNavigation(props.navigation);
+  }
+
+  checkFormFilled = (props: FormikProps<any>) => {
+    if (Object.keys(props.errors).length && props.submitCount > 0) return false;
+    if (Object.keys(props.values).length === 0 && props.submitCount > 0) return false;
+    return true;
+  };
+
+  private async updateLifestyle(values: LifestyleData) {
+    if (this.state.submitting) return;
+
+    this.setState({ submitting: true });
+
+    try {
+      const patientID = AssessmentCoordinator.assessmentData.currentPatient.patientId;
+      const payload = LifestyleQuestion.createMasksDTO(values);
+      await assessmentService.saveLifestyle(patientID, payload);
+      AssessmentCoordinator.gotoNextScreen(this.props.route.name);
+    } catch (error) {
+      this.setState({ errorMessage: i18n.t('something-went-wrong') });
+      throw error;
+    }
+  }
+
+  registerSchema = Yup.object().shape({
+    weightChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    dietChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    snackingChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    activityChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    alcoholChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+  });
+
+  render() {
+    const currentPatient = AssessmentCoordinator.assessmentData.currentPatient;
+    return (
+      <Screen profile={currentPatient.profile} navigation={this.props.navigation}>
+        <Header>
+          <HeaderText>{i18n.t('lifestyle.title')}</HeaderText>
+        </Header>
+
+        <ProgressBlock>
+          <ProgressStatus step={3} maxSteps={5} />
+        </ProgressBlock>
+
+        <View style={styles.container}>
+          <RegularText>
+            {i18n.t('lifestyle.explanation')}
+            {'\n'}
+          </RegularText>
+
+          <RegularText>{i18n.t('lifestyle.text')}</RegularText>
+        </View>
+
+        <Formik
+          initialValues={LifestyleQuestion.initialFormValues()}
+          validationSchema={this.registerSchema}
+          onSubmit={(values: LifestyleData) => {
+            return this.updateLifestyle(values);
+          }}>
+          {(props) => {
+            return (
+              <Form style={styles.form}>
+                <LifestyleQuestion formikProps={props} />
+
+                <ErrorText>{this.state.errorMessage}</ErrorText>
+                {!!Object.keys(props.errors).length && props.submitCount > 0 && (
+                  <ValidationError error={i18n.t('validation-error-text')} />
+                )}
+
+                <BrandedButton
+                  onPress={props.handleSubmit}
+                  enable={this.checkFormFilled(props)}
+                  hideLoading={!props.isSubmitting}>
+                  {i18n.t('next-question')}
+                </BrandedButton>
+              </Form>
+            );
+          }}
+        </Formik>
+      </Screen>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 16,
+    marginHorizontal: 16,
+  },
+  form: {},
+});

--- a/src/features/assessment/LifestyleScreen.tsx
+++ b/src/features/assessment/LifestyleScreen.tsx
@@ -16,7 +16,12 @@ import { ValidationError } from '@covid/components/ValidationError';
 
 import { ScreenParamList } from '../ScreenParamList';
 
-import { LifestyleData, LifestyleQuestion } from './fields/LifestyleQuestion';
+import {
+  createLifestyleDTO,
+  LifestyleData,
+  lifeStyleInitialValues,
+  LifestyleQuestion,
+} from './fields/LifestyleQuestion';
 
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'Lifestyle'>;
@@ -53,7 +58,7 @@ export default class LifestyleScreen extends Component<Props, State> {
 
     try {
       const patientID = AssessmentCoordinator.assessmentData.currentPatient.patientId;
-      const payload = LifestyleQuestion.createMasksDTO(values);
+      const payload = createLifestyleDTO(values);
       await assessmentService.saveLifestyle(patientID, payload);
       AssessmentCoordinator.gotoNextScreen(this.props.route.name);
     } catch (error) {
@@ -92,7 +97,7 @@ export default class LifestyleScreen extends Component<Props, State> {
         </View>
 
         <Formik
-          initialValues={LifestyleQuestion.initialFormValues()}
+          initialValues={lifeStyleInitialValues()}
           validationSchema={this.registerSchema}
           onSubmit={(values: LifestyleData) => {
             return this.updateLifestyle(values);

--- a/src/features/assessment/LifestyleScreen.tsx
+++ b/src/features/assessment/LifestyleScreen.tsx
@@ -2,7 +2,6 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Form, View } from 'native-base';
 import React, { Component } from 'react';
-import { StyleSheet } from 'react-native';
 import { Formik, FormikProps } from 'formik';
 
 import ProgressStatus from '@covid/components/ProgressStatus';
@@ -73,7 +72,7 @@ export default class LifestyleScreen extends Component<Props, State> {
           <ProgressStatus step={3} maxSteps={5} />
         </ProgressBlock>
 
-        <View style={styles.container}>
+        <View style={{ margin: 16 }}>
           <RegularText>
             {i18n.t('lifestyle.explanation')}
             {'\n'}
@@ -84,13 +83,13 @@ export default class LifestyleScreen extends Component<Props, State> {
 
         <Formik
           initialValues={LifestyleQuestion.initialFormValues()}
-          validationSchema={LifestyleQuestion.schema}
+          validationSchema={LifestyleQuestion.schema()}
           onSubmit={(values: LifestyleData) => {
             return this.updateLifestyle(values);
           }}>
           {(props) => {
             return (
-              <Form style={styles.form}>
+              <Form>
                 <LifestyleQuestion formikProps={props} />
 
                 <ErrorText>{this.state.errorMessage}</ErrorText>
@@ -112,11 +111,3 @@ export default class LifestyleScreen extends Component<Props, State> {
     );
   }
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginTop: 16,
-    marginHorizontal: 16,
-  },
-  form: {},
-});

--- a/src/features/assessment/LifestyleScreen.tsx
+++ b/src/features/assessment/LifestyleScreen.tsx
@@ -4,7 +4,6 @@ import { Form, View } from 'native-base';
 import React, { Component } from 'react';
 import { StyleSheet } from 'react-native';
 import { Formik, FormikProps } from 'formik';
-import * as Yup from 'yup';
 
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
@@ -16,12 +15,7 @@ import { ValidationError } from '@covid/components/ValidationError';
 
 import { ScreenParamList } from '../ScreenParamList';
 
-import {
-  createLifestyleDTO,
-  LifestyleData,
-  lifeStyleInitialValues,
-  LifestyleQuestion,
-} from './fields/LifestyleQuestion';
+import { LifestyleData, LifestyleQuestion } from './fields/LifestyleQuestion';
 
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'Lifestyle'>;
@@ -58,7 +52,7 @@ export default class LifestyleScreen extends Component<Props, State> {
 
     try {
       const patientID = AssessmentCoordinator.assessmentData.currentPatient.patientId;
-      const payload = createLifestyleDTO(values);
+      const payload = LifestyleQuestion.createDTO(values);
       await assessmentService.saveLifestyle(patientID, payload);
       AssessmentCoordinator.gotoNextScreen(this.props.route.name);
     } catch (error) {
@@ -66,14 +60,6 @@ export default class LifestyleScreen extends Component<Props, State> {
       throw error;
     }
   }
-
-  registerSchema = Yup.object().shape({
-    weightChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-    dietChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-    snackingChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-    activityChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-    alcoholChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-  });
 
   render() {
     const currentPatient = AssessmentCoordinator.assessmentData.currentPatient;
@@ -97,8 +83,8 @@ export default class LifestyleScreen extends Component<Props, State> {
         </View>
 
         <Formik
-          initialValues={lifeStyleInitialValues()}
-          validationSchema={this.registerSchema}
+          initialValues={LifestyleQuestion.initialFormValues()}
+          validationSchema={LifestyleQuestion.schema}
           onSubmit={(values: LifestyleData) => {
             return this.updateLifestyle(values);
           }}>

--- a/src/features/assessment/YourCovidTestsScreen.tsx
+++ b/src/features/assessment/YourCovidTestsScreen.tsx
@@ -111,12 +111,15 @@ export default class YourCovidTestsScreen extends Component<Props, State> {
         <Screen profile={currentPatient.profile} navigation={this.props.navigation}>
           <Header>
             <HeaderText>{i18n.t('your-covid-tests')}</HeaderText>
-            <RegularText style={styles.topText}>{i18n.t('please-add-test-below')}</RegularText>
           </Header>
 
           <ProgressBlock>
             <ProgressStatus step={2} maxSteps={5} />
           </ProgressBlock>
+
+          <View style={styles.list}>
+            <RegularText style={styles.topText}>{i18n.t('please-add-test-below')}</RegularText>
+          </View>
 
           <View style={styles.list}>
             {this.state.covidTests.map((item: CovidTest) => {

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -36,7 +36,7 @@ export enum ChangeValue {
 
 export interface FormikLifestyleQuestionInputFC<P, Data> extends React.FC<P> {
   initialFormValues: () => Data;
-  schema: Yup.ObjectSchema;
+  schema: () => Yup.ObjectSchema;
   createDTO: (data: Data) => Partial<LifestyleRequest>;
 }
 
@@ -148,13 +148,15 @@ LifestyleQuestion.initialFormValues = (): LifestyleData => {
   };
 };
 
-LifestyleQuestion.schema = Yup.object().shape({
-  weightChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-  dietChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-  snackingChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-  activityChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-  alcoholChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
-});
+LifestyleQuestion.schema = () => {
+  return Yup.object().shape({
+    weightChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    dietChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    snackingChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    activityChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+    alcoholChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+  });
+};
 
 LifestyleQuestion.createDTO = (formData: LifestyleData): Partial<LifestyleRequest> => {
   let dto = {

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -1,0 +1,135 @@
+import { FormikProps } from 'formik';
+import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
+
+import i18n from '@covid/locale/i18n';
+import { FieldWrapper } from '@covid/components/Screen';
+import DropdownField from '@covid/components/DropdownField';
+import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
+
+export interface LifestyleData {
+  weightChange: string;
+  dietChange: string;
+  snackingChange: string;
+  activityChange: string;
+  alcoholChange: string;
+}
+
+interface Props {
+  formikProps: FormikProps<LifestyleData>;
+}
+
+export enum ChangeValue {
+  INCREASED = 'increased',
+  DECREASED = 'decreased',
+  SAME = 'same',
+  PFNTS = 'pfnts',
+  NO_ALCOHOL = 'no_alcohol',
+}
+
+export class LifestyleQuestion extends Component<Props, object> {
+  static initialFormValues = (): LifestyleData => {
+    return {
+      weightChange: '',
+      dietChange: '',
+      snackingChange: '',
+      activityChange: '',
+      alcoholChange: '',
+    };
+  };
+
+  static createMasksDTO = (form: LifestyleData) => {
+    return {
+      weight_change: form.weightChange,
+      diet_change: form.dietChange,
+      snacking_change: form.snackingChange,
+      activity_change: form.activityChange,
+      alcohol_change: form.alcoholChange,
+    } as Partial<LifestyleRequest>;
+  };
+
+  weightChangeOptions = [
+    { label: i18n.t('lifestyle.weight-change.increased'), value: ChangeValue.INCREASED },
+    { label: i18n.t('lifestyle.weight-change.decreased'), value: ChangeValue.DECREASED },
+    { label: i18n.t('lifestyle.weight-change.same'), value: ChangeValue.SAME },
+    { label: i18n.t('lifestyle.weight-change.pfnts'), value: ChangeValue.PFNTS },
+  ];
+
+  dietChangeOptions = [
+    { label: i18n.t('lifestyle.diet-change.increased'), value: ChangeValue.INCREASED },
+    { label: i18n.t('lifestyle.diet-change.decreased'), value: ChangeValue.DECREASED },
+    { label: i18n.t('lifestyle.diet-change.same'), value: ChangeValue.SAME },
+    { label: i18n.t('lifestyle.diet-change.pfnts'), value: ChangeValue.PFNTS },
+  ];
+
+  snackChangeOptions = [
+    { label: i18n.t('lifestyle.snacking-change.increased'), value: ChangeValue.INCREASED },
+    { label: i18n.t('lifestyle.snacking-change.decreased'), value: ChangeValue.DECREASED },
+    { label: i18n.t('lifestyle.snacking-change.same'), value: ChangeValue.SAME },
+    { label: i18n.t('lifestyle.snacking-change.pfnts'), value: ChangeValue.PFNTS },
+  ];
+
+  alcoholChangeOptions = [
+    { label: i18n.t('lifestyle.alcohol-change.increased'), value: ChangeValue.INCREASED },
+    { label: i18n.t('lifestyle.alcohol-change.decreased'), value: ChangeValue.DECREASED },
+    { label: i18n.t('lifestyle.alcohol-change.no-alcohol'), value: ChangeValue.NO_ALCOHOL },
+    { label: i18n.t('lifestyle.alcohol-change.same'), value: ChangeValue.SAME },
+    { label: i18n.t('lifestyle.alcohol-change.pfnts'), value: ChangeValue.PFNTS },
+  ];
+
+  activityChangeOptions = [
+    { label: i18n.t('lifestyle.activity-change.increased'), value: ChangeValue.INCREASED },
+    { label: i18n.t('lifestyle.activity-change.decreased'), value: ChangeValue.DECREASED },
+    { label: i18n.t('lifestyle.activity-change.same'), value: ChangeValue.SAME },
+    { label: i18n.t('lifestyle.activity-change.pfnts'), value: ChangeValue.PFNTS },
+  ];
+
+  render() {
+    const { formikProps } = this.props;
+    return (
+      <FieldWrapper>
+        <DropdownField
+          label={i18n.t('lifestyle.weight-change.question')}
+          selectedValue={formikProps.values.weightChange}
+          onValueChange={formikProps.handleChange('weightChange')}
+          error={formikProps.touched.weightChange && formikProps.errors.weightChange}
+          items={this.weightChangeOptions}
+        />
+
+        <DropdownField
+          label={i18n.t('lifestyle.diet-change.question')}
+          selectedValue={formikProps.values.dietChange}
+          onValueChange={formikProps.handleChange('dietChange')}
+          error={formikProps.touched.dietChange && formikProps.errors.dietChange}
+          items={this.dietChangeOptions}
+        />
+
+        <DropdownField
+          label={i18n.t('lifestyle.snacking-change.question')}
+          selectedValue={formikProps.values.snackingChange}
+          onValueChange={formikProps.handleChange('snackingChange')}
+          error={formikProps.touched.snackingChange && formikProps.errors.snackingChange}
+          items={this.snackChangeOptions}
+        />
+
+        <DropdownField
+          label={i18n.t('lifestyle.alcohol-change.question')}
+          selectedValue={formikProps.values.alcoholChange}
+          onValueChange={formikProps.handleChange('alcoholChange')}
+          error={formikProps.touched.alcoholChange && formikProps.errors.alcoholChange}
+          items={this.alcoholChangeOptions}
+        />
+
+        <DropdownField
+          label={i18n.t('lifestyle.activity-change.question')}
+          selectedValue={formikProps.values.activityChange}
+          onValueChange={formikProps.handleChange('activityChange')}
+          error={formikProps.touched.activityChange && formikProps.errors.activityChange}
+          items={this.activityChangeOptions}
+        />
+      </FieldWrapper>
+    );
+  }
+}
+
+const styles = StyleSheet.create({});

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -1,14 +1,10 @@
 import { FormikProps } from 'formik';
-import React, { Component } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { Form } from 'native-base';
+import React from 'react';
 
 import i18n from '@covid/locale/i18n';
 import { FieldWrapper } from '@covid/components/Screen';
 import DropdownField from '@covid/components/DropdownField';
 import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
-import { isUSCountry } from '@covid/core/user/UserService';
-import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { userService } from '@covid/Services';
 import { cleanFloatVal } from '@covid/core/utils/number';
 import { WeightData, WeightQuestion } from '@covid/features/patient/fields/WeightQuestion';
@@ -37,67 +33,67 @@ export enum ChangeValue {
   NO_ALCOHOL = 'no_alcohol',
 }
 
-export class LifestyleQuestion extends Component<Props, object> {
-  static initialFormValues = (): LifestyleData => {
-    const features = userService.getConfig();
+export function lifeStyleInitialValues(): LifestyleData {
+  const features = userService.getConfig();
 
-    return {
-      weightChange: '',
-      dietChange: '',
-      snackingChange: '',
-      activityChange: '',
-      alcoholChange: '',
-      weight: '',
-      stones: '',
-      pounds: '',
-      weightUnit: features.defaultWeightUnit,
-    };
+  return {
+    weightChange: '',
+    dietChange: '',
+    snackingChange: '',
+    activityChange: '',
+    alcoholChange: '',
+    weight: '',
+    stones: '',
+    pounds: '',
+    weightUnit: features.defaultWeightUnit,
   };
+}
 
-  static createMasksDTO = (formData: LifestyleData) => {
-    let dto = {
-      weight_change: formData.weightChange,
-      diet_change: formData.dietChange,
-      snacking_change: formData.snackingChange,
-      activity_change: formData.activityChange,
-      alcohol_change: formData.alcoholChange,
-    } as Partial<LifestyleRequest>;
+export function createLifestyleDTO(formData: LifestyleData) {
+  let dto = {
+    weight_change: formData.weightChange,
+    diet_change: formData.dietChange,
+    snacking_change: formData.snackingChange,
+    activity_change: formData.activityChange,
+    alcohol_change: formData.alcoholChange,
+  } as Partial<LifestyleRequest>;
 
-    if (formData.weightUnit === 'lbs') {
-      let pounds = cleanFloatVal(formData.pounds);
-      if (formData.stones) {
-        const stones = cleanFloatVal(formData.stones) || 0;
-        pounds += stones * 14;
-      }
-      dto = { ...dto, weight_change_pounds: pounds };
-    } else {
-      dto = { ...dto, weight_change_kg: cleanFloatVal(formData.weight) };
+  if (formData.weightUnit === 'lbs') {
+    let pounds = cleanFloatVal(formData.pounds);
+    if (formData.stones) {
+      const stones = cleanFloatVal(formData.stones) || 0;
+      pounds += stones * 14;
     }
-    return dto;
-  };
+    dto = { ...dto, weight_change_pounds: pounds };
+  } else {
+    dto = { ...dto, weight_change_kg: cleanFloatVal(formData.weight) };
+  }
+  return dto;
+}
 
-  weightChangeOptions = [
+export const LifestyleQuestion: React.FC<Props> = (props: Props) => {
+  const weightChangeOptions = [
     { label: i18n.t('lifestyle.weight-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.weight-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.weight-change.same'), value: ChangeValue.SAME },
     { label: i18n.t('lifestyle.weight-change.pfnts'), value: ChangeValue.PFNTS },
   ];
 
-  dietChangeOptions = [
+  const dietChangeOptions = [
     { label: i18n.t('lifestyle.diet-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.diet-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.diet-change.same'), value: ChangeValue.SAME },
     { label: i18n.t('lifestyle.diet-change.pfnts'), value: ChangeValue.PFNTS },
   ];
 
-  snackChangeOptions = [
+  const snackChangeOptions = [
     { label: i18n.t('lifestyle.snacking-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.snacking-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.snacking-change.same'), value: ChangeValue.SAME },
     { label: i18n.t('lifestyle.snacking-change.pfnts'), value: ChangeValue.PFNTS },
   ];
 
-  alcoholChangeOptions = [
+  const alcoholChangeOptions = [
     { label: i18n.t('lifestyle.alcohol-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.alcohol-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.alcohol-change.no-alcohol'), value: ChangeValue.NO_ALCOHOL },
@@ -105,99 +101,64 @@ export class LifestyleQuestion extends Component<Props, object> {
     { label: i18n.t('lifestyle.alcohol-change.pfnts'), value: ChangeValue.PFNTS },
   ];
 
-  activityChangeOptions = [
+  const activityChangeOptions = [
     { label: i18n.t('lifestyle.activity-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.activity-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.activity-change.same'), value: ChangeValue.SAME },
     { label: i18n.t('lifestyle.activity-change.pfnts'), value: ChangeValue.PFNTS },
   ];
 
-  render() {
-    const { formikProps } = this.props;
-    return (
-      <FieldWrapper>
-        <DropdownField
-          label={i18n.t('lifestyle.weight-change.question')}
-          selectedValue={formikProps.values.weightChange}
-          onValueChange={formikProps.handleChange('weightChange')}
-          error={formikProps.touched.weightChange && formikProps.errors.weightChange}
-          items={this.weightChangeOptions}
+  const { formikProps } = props;
+
+  return (
+    <FieldWrapper>
+      <DropdownField
+        label={i18n.t('lifestyle.weight-change.question')}
+        selectedValue={formikProps.values.weightChange}
+        onValueChange={formikProps.handleChange('weightChange')}
+        error={formikProps.touched.weightChange && formikProps.errors.weightChange}
+        items={weightChangeOptions}
+      />
+
+      {(formikProps.values.weightChange === ChangeValue.INCREASED ||
+        formikProps.values.weightChange === ChangeValue.DECREASED) && (
+        <WeightQuestion
+          formikProps={formikProps as FormikProps<WeightData>}
+          label={i18n.t('lifestyle.weight-difference')}
         />
+      )}
 
-        {(formikProps.values.weightChange === ChangeValue.INCREASED ||
-          formikProps.values.weightChange === ChangeValue.DECREASED) && (
-          <WeightQuestion
-            formikProps={formikProps as FormikProps<WeightData>}
-            label={i18n.t('lifestyle.weight-difference')}
-          />
-        )}
+      <DropdownField
+        label={i18n.t('lifestyle.diet-change.question')}
+        selectedValue={formikProps.values.dietChange}
+        onValueChange={formikProps.handleChange('dietChange')}
+        error={formikProps.touched.dietChange && formikProps.errors.dietChange}
+        items={dietChangeOptions}
+      />
 
-        <DropdownField
-          label={i18n.t('lifestyle.diet-change.question')}
-          selectedValue={formikProps.values.dietChange}
-          onValueChange={formikProps.handleChange('dietChange')}
-          error={formikProps.touched.dietChange && formikProps.errors.dietChange}
-          items={this.dietChangeOptions}
-        />
+      <DropdownField
+        label={i18n.t('lifestyle.snacking-change.question')}
+        selectedValue={formikProps.values.snackingChange}
+        onValueChange={formikProps.handleChange('snackingChange')}
+        error={formikProps.touched.snackingChange && formikProps.errors.snackingChange}
+        items={snackChangeOptions}
+      />
 
-        <DropdownField
-          label={i18n.t('lifestyle.snacking-change.question')}
-          selectedValue={formikProps.values.snackingChange}
-          onValueChange={formikProps.handleChange('snackingChange')}
-          error={formikProps.touched.snackingChange && formikProps.errors.snackingChange}
-          items={this.snackChangeOptions}
-        />
+      <DropdownField
+        label={i18n.t('lifestyle.alcohol-change.question')}
+        selectedValue={formikProps.values.alcoholChange}
+        onValueChange={formikProps.handleChange('alcoholChange')}
+        error={formikProps.touched.alcoholChange && formikProps.errors.alcoholChange}
+        items={alcoholChangeOptions}
+      />
 
-        <DropdownField
-          label={i18n.t('lifestyle.alcohol-change.question')}
-          selectedValue={formikProps.values.alcoholChange}
-          onValueChange={formikProps.handleChange('alcoholChange')}
-          error={formikProps.touched.alcoholChange && formikProps.errors.alcoholChange}
-          items={this.alcoholChangeOptions}
-        />
-
-        <DropdownField
-          label={i18n.t('lifestyle.activity-change.question')}
-          selectedValue={formikProps.values.activityChange}
-          onValueChange={formikProps.handleChange('activityChange')}
-          error={formikProps.touched.activityChange && formikProps.errors.activityChange}
-          items={this.activityChangeOptions}
-        />
-      </FieldWrapper>
-    );
-  }
-}
-
-const styles = StyleSheet.create({
-  fieldRow: {
-    flexDirection: 'row',
-  },
-  primaryField: {
-    flex: 6,
-  },
-
-  primaryFieldRow: {
-    flex: 6,
-    flexDirection: 'row',
-  },
-
-  tertiaryField: {
-    flex: 5,
-    marginRight: 8,
-  },
-
-  stonesField: {
-    flex: 5,
-    marginRight: 4,
-  },
-
-  poundsField: {
-    flex: 5,
-    marginLeft: 4,
-  },
-
-  secondaryField: {
-    flex: 2,
-    margin: -8,
-  },
-});
+      <DropdownField
+        label={i18n.t('lifestyle.activity-change.question')}
+        selectedValue={formikProps.values.activityChange}
+        onValueChange={formikProps.handleChange('activityChange')}
+        error={formikProps.touched.activityChange && formikProps.errors.activityChange}
+        items={activityChangeOptions}
+      />
+    </FieldWrapper>
+  );
+};

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -1,5 +1,6 @@
 import { FormikProps } from 'formik';
 import React from 'react';
+import * as Yup from 'yup';
 
 import i18n from '@covid/locale/i18n';
 import { FieldWrapper } from '@covid/components/Screen';
@@ -33,45 +34,13 @@ export enum ChangeValue {
   NO_ALCOHOL = 'no_alcohol',
 }
 
-export function lifeStyleInitialValues(): LifestyleData {
-  const features = userService.getConfig();
-
-  return {
-    weightChange: '',
-    dietChange: '',
-    snackingChange: '',
-    activityChange: '',
-    alcoholChange: '',
-    weight: '',
-    stones: '',
-    pounds: '',
-    weightUnit: features.defaultWeightUnit,
-  };
+export interface FormikLifestyleQuestionInputFC<P, Data> extends React.FC<P> {
+  initialFormValues: () => Data;
+  schema: Yup.ObjectSchema;
+  createDTO: (data: Data) => Partial<LifestyleRequest>;
 }
 
-export function createLifestyleDTO(formData: LifestyleData) {
-  let dto = {
-    weight_change: formData.weightChange,
-    diet_change: formData.dietChange,
-    snacking_change: formData.snackingChange,
-    activity_change: formData.activityChange,
-    alcohol_change: formData.alcoholChange,
-  } as Partial<LifestyleRequest>;
-
-  if (formData.weightUnit === 'lbs') {
-    let pounds = cleanFloatVal(formData.pounds);
-    if (formData.stones) {
-      const stones = cleanFloatVal(formData.stones) || 0;
-      pounds += stones * 14;
-    }
-    dto = { ...dto, weight_change_pounds: pounds };
-  } else {
-    dto = { ...dto, weight_change_kg: cleanFloatVal(formData.weight) };
-  }
-  return dto;
-}
-
-export const LifestyleQuestion: React.FC<Props> = (props: Props) => {
+export const LifestyleQuestion: FormikLifestyleQuestionInputFC<Props, LifestyleData> = (props: Props) => {
   const weightChangeOptions = [
     { label: i18n.t('lifestyle.weight-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.weight-change.decreased'), value: ChangeValue.DECREASED },
@@ -161,4 +130,50 @@ export const LifestyleQuestion: React.FC<Props> = (props: Props) => {
       />
     </FieldWrapper>
   );
+};
+
+LifestyleQuestion.initialFormValues = (): LifestyleData => {
+  const features = userService.getConfig();
+
+  return {
+    weightChange: '',
+    dietChange: '',
+    snackingChange: '',
+    activityChange: '',
+    alcoholChange: '',
+    weight: '',
+    stones: '',
+    pounds: '',
+    weightUnit: features.defaultWeightUnit,
+  };
+};
+
+LifestyleQuestion.schema = Yup.object().shape({
+  weightChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+  dietChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+  snackingChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+  activityChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+  alcoholChange: Yup.string().required(i18n.t('lifestyle.please-select-option')),
+});
+
+LifestyleQuestion.createDTO = (formData: LifestyleData): Partial<LifestyleRequest> => {
+  let dto = {
+    weight_change: formData.weightChange,
+    diet_change: formData.dietChange,
+    snacking_change: formData.snackingChange,
+    activity_change: formData.activityChange,
+    alcohol_change: formData.alcoholChange,
+  } as Partial<LifestyleRequest>;
+
+  if (formData.weightUnit === 'lbs') {
+    let pounds = cleanFloatVal(formData.pounds);
+    if (formData.stones) {
+      const stones = cleanFloatVal(formData.stones) || 0;
+      pounds += stones * 14;
+    }
+    dto = { ...dto, weight_change_pounds: pounds };
+  } else {
+    dto = { ...dto, weight_change_kg: cleanFloatVal(formData.weight) };
+  }
+  return dto;
 };

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -1,6 +1,7 @@
 import { FormikProps } from 'formik';
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { Form } from 'native-base';
 
 import i18n from '@covid/locale/i18n';
 import { FieldWrapper } from '@covid/components/Screen';
@@ -10,6 +11,7 @@ import { isUSCountry } from '@covid/core/user/UserService';
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { userService } from '@covid/Services';
 import { cleanFloatVal } from '@covid/core/utils/number';
+import { WeightData, WeightQuestion } from '@covid/features/patient/fields/WeightQuestion';
 
 export interface LifestyleData {
   weightChange: string;
@@ -124,75 +126,10 @@ export class LifestyleQuestion extends Component<Props, object> {
 
         {(formikProps.values.weightChange === ChangeValue.INCREASED ||
           formikProps.values.weightChange === ChangeValue.DECREASED) && (
-          <>
-            {isUSCountry() ? (
-              <ValidatedTextInput
-                placeholder={i18n.t('placeholder-pounds')}
-                value={formikProps.values.pounds}
-                onChangeText={formikProps.handleChange('pounds')}
-                onBlur={formikProps.handleBlur('pounds')}
-                error={formikProps.touched.pounds && formikProps.errors.pounds}
-                returnKeyType="next"
-                onSubmitEditing={() => {}}
-                keyboardType="numeric"
-              />
-            ) : (
-              <View style={styles.fieldRow}>
-                {formikProps.values.weightUnit === 'kg' ? (
-                  <View style={styles.primaryField}>
-                    <ValidatedTextInput
-                      placeholder={i18n.t('placeholder-weight')}
-                      value={formikProps.values.weight}
-                      onChangeText={formikProps.handleChange('weight')}
-                      onBlur={formikProps.handleBlur('weight')}
-                      error={formikProps.touched.weight && formikProps.errors.weight}
-                      returnKeyType="next"
-                      onSubmitEditing={() => {}}
-                      keyboardType="numeric"
-                    />
-                  </View>
-                ) : (
-                  <View style={styles.primaryFieldRow}>
-                    <View style={styles.stonesField}>
-                      <ValidatedTextInput
-                        placeholder={i18n.t('placeholder-stones')}
-                        value={formikProps.values.stones}
-                        onChangeText={formikProps.handleChange('stones')}
-                        onBlur={formikProps.handleBlur('stones')}
-                        error={formikProps.touched.stones && formikProps.errors.stones}
-                        returnKeyType="next"
-                        onSubmitEditing={() => {}}
-                        keyboardType="numeric"
-                      />
-                    </View>
-                    <View style={styles.poundsField}>
-                      <ValidatedTextInput
-                        placeholder={i18n.t('placeholder-pounds')}
-                        value={formikProps.values.pounds}
-                        onChangeText={formikProps.handleChange('pounds')}
-                        onBlur={formikProps.handleBlur('pounds')}
-                        error={formikProps.touched.pounds && formikProps.errors.pounds}
-                        returnKeyType="next"
-                        onSubmitEditing={() => {}}
-                        keyboardType="numeric"
-                      />
-                    </View>
-                  </View>
-                )}
-                <View style={styles.secondaryField}>
-                  <DropdownField
-                    onlyPicker
-                    selectedValue={formikProps.values.weightUnit}
-                    onValueChange={formikProps.handleChange('weightUnit')}
-                    items={[
-                      { label: 'lbs', value: 'lbs' },
-                      { label: 'kg', value: 'kg' },
-                    ]}
-                  />
-                </View>
-              </View>
-            )}
-          </>
+          <WeightQuestion
+            formikProps={formikProps as FormikProps<WeightData>}
+            label={i18n.t('lifestyle.weight-difference')}
+          />
         )}
 
         <DropdownField

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -347,7 +347,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
 
                 <HeightQuestion formikProps={props as FormikProps<HeightData>} />
 
-                <WeightQuestion formikProps={props as FormikProps<WeightData>} />
+                <WeightQuestion formikProps={props as FormikProps<WeightData>} label={i18n.t('your-weight')} />
 
                 <GenericTextField
                   formikProps={props}

--- a/src/features/patient/fields/WeightQuestion.tsx
+++ b/src/features/patient/fields/WeightQuestion.tsx
@@ -24,12 +24,13 @@ interface FCWithStatic<P> extends React.FC<P> {
 
 interface Props {
   formikProps: FormikProps<WeightData>;
+  label: string;
 }
 
-export const WeightQuestion: FCWithStatic<Props> = ({ formikProps }) => {
+export const WeightQuestion: FCWithStatic<Props> = ({ formikProps, label }) => {
   return (
     <FieldWrapper style={styles.fieldWrapper}>
-      <RegularText>{i18n.t('your-weight')}</RegularText>
+      <RegularText>{label}</RegularText>
       {isUSCountry() ? (
         <ValidatedTextInput
           placeholder={i18n.t('placeholder-pounds')}


### PR DESCRIPTION
# Description

- Adds a Lifestyle Screen that hosts 5 questions. 
- These questions are posted to a new API endpoint, but is logically within the assessment flow
- In the future, we might re-ask this question, which would post a new entry in the Lifestyle table in the backend
- A minor refactor alllows us to reuse the WeightQuesion from the AboutYou Screen here. 
- Updated mockserver
- Asking this question / displaying the screen in the assessment is driven by a flag returned by the Patient endpoin. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [x] I have updated mockServer
- [x] I've added analytics as relevant
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
