### PR TITLE
Update one of the lifestyle answer to include unsure.

### DIFF
--- a/appConfig.ts
+++ b/appConfig.ts
@@ -6,4 +6,5 @@ export default {
 
   assessmentVersion: '1.5.0',
   patientVersion: '1.5.0',
+  lifestyleVerison: '1.0.1',
 };

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -944,7 +944,7 @@
       "increased": "Increased",
       "decreased": "Decreased",
       "same": "Stayed the same",
-      "pfnts": "Prefer not to say"
+      "unsure-pfnts": "Unsure / Prefer not to say"
     },
     "weight-difference": "By how much (an estimate is fine)?",
     "diet-change": {
@@ -952,14 +952,14 @@
       "increased": "It has become healthier",
       "decreased": "It has become more unhealthy",
       "same": "It has stayed the same",
-      "pfnts": "Prefer not to say"
+      "unsure-pfnts": "Unsure / Prefer not to say"
     },
     "snacking-change": {
       "question": "How has your snacking changed?",
       "increased": "I am snacking more",
       "decreased": "I am snacking less",
       "same": "My snacking levels are the same",
-      "pfnts": "Prefer not to say"
+      "unsure-pfnts": "Unsure / Prefer not to say"
     },
     "alcohol-change": {
       "question": "How has your alcohol consumption changed? ",
@@ -967,14 +967,14 @@
       "increased": "I am drinking more alcohol",
       "decreased": "I am drinking less alcohol",
       "same": "My alcohol consumption is the same",
-      "pfnts": "Prefer not to say"
+      "unsure-pfnts": "Unsure / Prefer not to say"
     },
     "activity-change": {
       "question": "Have your physical activity levels changed?",
       "increased": "Yes, increased",
       "decreased": "Yes, decreased",
       "same": "No change, has remained the same",
-      "pfnts": "Prefer not to say"
+      "unsure-pfnts": "Unsure / Prefer not to say"
     }
   }
 }

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -946,7 +946,7 @@
       "increased": "Aumentado",
       "decreased": "Disminuido",
       "same": "Se ha mantenido igual",
-      "pfnts": "Prefiero no decir"
+      "unsure-pfnts": "Insegura / Prefiero no decir"
     },
     "weight-difference": "Cuánto ha cambiado (un estimado está bien)?",
     "diet-change": {
@@ -954,14 +954,14 @@
       "increased": "Se ha vuelto más saludable",
       "decreased": "Se ha vuelto menos saludable",
       "same": "Se ha mantenido igual",
-      "pfnts": "Prefiero no decir"
+      "unsure-pfnts": "Insegura / Prefiero no decir"
     },
     "snacking-change": {
       "question": "Cómo ha cambiado su snacking?",
       "increased": "Estoy comiendo más snacks",
       "decreased": "Estoy comiendo menos snacks",
       "same": "Mi niveles de snacking son iguales",
-      "pfnts": "Prefiero no decir"
+      "unsure-pfnts": "Insegura / Prefiero no decir"
     },
     "alcohol-change": {
       "question": "Cómo ha cambiado su consumo de alcohol?",
@@ -969,14 +969,14 @@
       "decreased": "Estoy tomando menos",
       "no-alcohol": "No tomo",
       "same": "Mi consumo mantiene igual",
-      "pfnts": "Prefiero no decir"
+      "unsure-pfnts": "Insegura / Prefiero no decir"
     },
     "activity-change": {
       "question": "Ha cambiado su nivel de la actividad física?",
       "increased": "Sí, ha aumentado",
       "decreased": "Sí, ha disminuido",
       "same": "No, ha mantenido igual",
-      "pfnts": "Prefiero no decir"
+      "unsure-pfnts": "Insegura / Prefiero no decir"
     }
   }
 }

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -942,7 +942,7 @@
       "increased": "Ökat",
       "decreased": "Minskat",
       "same": "Oförändrad",
-      "pfnts": "Föredrar att inte berätta"
+      "unsure-pfnts": "Osäker / Föredrar att inte berätta"
     },
     "weight-difference": "Med hur mycket (en uppskattning räcker)?",
     "diet-change": {
@@ -950,14 +950,14 @@
       "increased": "Den har blivit hälsosammare",
       "decreased": "Den har blivit ohälsosammare",
       "same": "Den är oförändrad",
-      "pfnts": "Föredrar att inte berätta"
+      "unsure-pfnts": "Osäker / Föredrar att inte berätta"
     },
     "snacking-change": {
       "question": "Hur har ditt småätande förändrats?",
       "increased": "Jag småäter mer (snacks)",
       "decreased": "Jag småäter mindre (snacks)",
       "same": "Jag småäter lika mycket som innan",
-      "pfnts": "Föredrar att inte berätta"
+      "unsure-pfnts": "Osäker / Föredrar att inte berätta"
     },
     "alcohol-change": {
       "question": "Hur har din alkoholkonsumtion förändrats?",
@@ -965,14 +965,14 @@
       "decreased": "Jag dricker mindre alkohol",
       "no-alcohol": "Jag dricker inte alkohol",
       "same": "Min alkoholkonsumtion är oförändrad",
-      "pfnts": "Föredrar att inte berätta"
+      "unsure-pfnts": "Osäker / Föredrar att inte berätta"
     },
     "activity-change": {
       "question": "Har dina nivåer av fysisk aktivitet förändrats?",
       "increased": "Ja, ökat",
       "decreased": "Ja, minskat",
       "same": "Ingen förändring, oförändrade",
-      "pfnts": "Föredrar att inte berätta"
+      "unsure-pfnts": "Osäker / Föredrar att inte berätta"
     }
   }
 }

--- a/src/core/assessment/AssessmentService.ts
+++ b/src/core/assessment/AssessmentService.ts
@@ -79,7 +79,10 @@ export default class AssessmentService implements IAssessmentService {
   }
 
   async saveLifestyle(patientId: string, lifestyle: Partial<LifestyleRequest>): Promise<LifestyleResponse> {
-    const response = await this.apiClient.addLifeStyle(patientId, lifestyle as LifestyleRequest);
+    const response = await this.apiClient.addLifeStyle(patientId, {
+      ...lifestyle,
+      verison: '1.0.1',
+    } as LifestyleRequest);
     return response;
   }
 }

--- a/src/core/assessment/AssessmentService.ts
+++ b/src/core/assessment/AssessmentService.ts
@@ -1,6 +1,8 @@
 import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
 import { LifestyleResponse } from '@covid/core/assessment/dto/LifestyleResponse';
 
+import appConfig from '../../../appConfig';
+
 import { IAssessmentRemoteClient } from './AssessmentApiClient';
 import { IAssessmentState } from './AssessmentState';
 import { AssessmentInfosRequest } from './dto/AssessmentInfosRequest';
@@ -81,7 +83,7 @@ export default class AssessmentService implements IAssessmentService {
   async saveLifestyle(patientId: string, lifestyle: Partial<LifestyleRequest>): Promise<LifestyleResponse> {
     const response = await this.apiClient.addLifeStyle(patientId, {
       ...lifestyle,
-      verison: '1.0.1',
+      verison: appConfig.lifestyleVerison,
     } as LifestyleRequest);
     return response;
   }

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -45,21 +45,21 @@ export const LifestyleQuestion: FormikLifestyleQuestionInputFC<Props, LifestyleD
     { label: i18n.t('lifestyle.weight-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.weight-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.weight-change.same'), value: ChangeValue.SAME },
-    { label: i18n.t('lifestyle.weight-change.pfnts'), value: ChangeValue.PFNTS },
+    { label: i18n.t('lifestyle.weight-change.unsure-pfnts'), value: ChangeValue.PFNTS },
   ];
 
   const dietChangeOptions = [
     { label: i18n.t('lifestyle.diet-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.diet-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.diet-change.same'), value: ChangeValue.SAME },
-    { label: i18n.t('lifestyle.diet-change.pfnts'), value: ChangeValue.PFNTS },
+    { label: i18n.t('lifestyle.diet-change.unsure-pfnts'), value: ChangeValue.PFNTS },
   ];
 
   const snackChangeOptions = [
     { label: i18n.t('lifestyle.snacking-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.snacking-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.snacking-change.same'), value: ChangeValue.SAME },
-    { label: i18n.t('lifestyle.snacking-change.pfnts'), value: ChangeValue.PFNTS },
+    { label: i18n.t('lifestyle.snacking-change.unsure-pfnts'), value: ChangeValue.PFNTS },
   ];
 
   const alcoholChangeOptions = [
@@ -67,14 +67,14 @@ export const LifestyleQuestion: FormikLifestyleQuestionInputFC<Props, LifestyleD
     { label: i18n.t('lifestyle.alcohol-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.alcohol-change.no-alcohol'), value: ChangeValue.NO_ALCOHOL },
     { label: i18n.t('lifestyle.alcohol-change.same'), value: ChangeValue.SAME },
-    { label: i18n.t('lifestyle.alcohol-change.pfnts'), value: ChangeValue.PFNTS },
+    { label: i18n.t('lifestyle.alcohol-change.unsure-pfnts'), value: ChangeValue.PFNTS },
   ];
 
   const activityChangeOptions = [
     { label: i18n.t('lifestyle.activity-change.increased'), value: ChangeValue.INCREASED },
     { label: i18n.t('lifestyle.activity-change.decreased'), value: ChangeValue.DECREASED },
     { label: i18n.t('lifestyle.activity-change.same'), value: ChangeValue.SAME },
-    { label: i18n.t('lifestyle.activity-change.pfnts'), value: ChangeValue.PFNTS },
+    { label: i18n.t('lifestyle.activity-change.unsure-pfnts'), value: ChangeValue.PFNTS },
   ];
 
   const { formikProps } = props;


### PR DESCRIPTION
# Description

Add Unsure as an option of Lifestyle Questions

Quick front end change to language only. Change "Prefer not to say" → "Unsure / Prefer Not to Say".

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
