### PR TITLE
bug/Move version position on DrawerMenu

### DIFF
--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -81,9 +81,15 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   return (
     <SafeAreaView style={styles.drawerRoot}>
       <View style={styles.container}>
-        <TouchableOpacity onPress={() => props.navigation.goBack()}>
-          <Image style={styles.closeIcon} source={closeIcon} />
-        </TouchableOpacity>
+        <View style={styles.topBar}>
+          <CaptionText>
+            {Constants.manifest.revisionId ? Constants.manifest.revisionId : Constants.manifest.version}
+            {isDevChannel() && ` (DEV)`}
+          </CaptionText>
+          <TouchableOpacity onPress={() => props.navigation.goBack()}>
+            <Image style={styles.closeIcon} source={closeIcon} />
+          </TouchableOpacity>
+        </View>
         <MenuItem
           label={i18n.t('research-updates')}
           onPress={() => {
@@ -100,14 +106,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
         <MenuItem label={i18n.t('delete-my-data')} onPress={() => showDeleteAlert()} />
         <View style={{ flex: 1 }} />
         <MenuItem label={i18n.t('logout')} onPress={() => logout()} />
-        <View style={styles.versionDetails}>
-          <CaptionText style={styles.versionText}>{userEmail}</CaptionText>
-          <CaptionText style={styles.versionText}>
-            {Constants.manifest.version}
-            {Constants.manifest.revisionId && ` : ${Constants.manifest.revisionId}`}
-            {isDevChannel() && ` (DEV)`}
-          </CaptionText>
-        </View>
+        <CaptionText style={styles.versionText}>{userEmail}</CaptionText>
       </View>
     </SafeAreaView>
   );
@@ -136,7 +135,7 @@ const styles = StyleSheet.create({
     width: 24,
     marginEnd: 16,
   },
-  versionDetails: {
+  topBar: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -144,5 +143,6 @@ const styles = StyleSheet.create({
   },
   versionText: {
     marginTop: 8,
+    paddingLeft: 8,
   },
 });


### PR DESCRIPTION
# Description

Moves the position of the version. This is because, when also showing the revisionID, it was spilling out of the Menu and onto the WelcomeRepeat screen.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/52913482/85718192-2f44e900-b6e6-11ea-9954-52d818e703c3.png)

