### PR TITLE
Inject user service so loadUser is not unnecessarily called

### DIFF
--- a/src/components/ContributionCounter.tsx
+++ b/src/components/ContributionCounter.tsx
@@ -5,10 +5,12 @@ import reactStringReplace from 'react-string-replace';
 
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
 
 import { RegularBoldText, RegularText } from './Text';
 import { ITest } from './types';
+import { useInjection } from '@covid/provider/services.hooks';
+import { Services } from '@covid/provider/services.types';
 
 interface ContributionCounterProps extends ITest {
   variant: number;
@@ -17,7 +19,7 @@ interface ContributionCounterProps extends ITest {
 
 export const ContributionCounter = (props: ContributionCounterProps) => {
   if (props.count) {
-    const userService = new UserService();
+    const userService = useInjection<ICoreService>(Services.User);
     const features = userService.getConfig();
     const delimiter = features ? features.thousandSeparator : ',';
 

--- a/src/components/ContributionCounter.tsx
+++ b/src/components/ContributionCounter.tsx
@@ -6,11 +6,11 @@ import reactStringReplace from 'react-string-replace';
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
 import UserService, { ICoreService } from '@covid/core/user/UserService';
+import { useInjection } from '@covid/provider/services.hooks';
+import { Services } from '@covid/provider/services.types';
 
 import { RegularBoldText, RegularText } from './Text';
 import { ITest } from './types';
-import { useInjection } from '@covid/provider/services.hooks';
-import { Services } from '@covid/provider/services.types';
 
 interface ContributionCounterProps extends ITest {
   variant: number;

--- a/src/features/CountrySelectScreen.tsx
+++ b/src/features/CountrySelectScreen.tsx
@@ -6,7 +6,9 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { gbFlag, svFlag, usFlag } from '@assets';
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from './ScreenParamList';
 
@@ -20,7 +22,8 @@ const GB_CODE = 'GB';
 const SV_CODE = 'SE';
 
 export class CountrySelectScreen extends Component<Props, object> {
-  private userService = new UserService();
+  @lazyInject(Services.User)
+  userService: ICoreService;
 
   constructor(props: Props) {
     super(props);

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -12,12 +12,14 @@ import {
   View,
 } from 'react-native';
 
-import { colors, fontStyles } from '@theme';
+import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService, { isUSCountry } from '@covid/core/user/UserService';
+import { ICoreService, isUSCountry } from '@covid/core/user/UserService';
 import { UserNotFoundException } from '@covid/core/Exception';
 import Analytics from '@covid/core/Analytics';
 import { BrandedButton, ClickableText, HeaderLightText, RegularText } from '@covid/components/Text';
+import { Services } from '@covid/provider/services.types';
+import { lazyInject } from '@covid/provider/services';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -42,6 +44,9 @@ export class LoginScreen extends Component<PropsType, StateType> {
   private username = '';
   private password = '';
 
+  @lazyInject(Services.User)
+  userService: ICoreService;
+
   constructor(props: PropsType) {
     super(props);
     this.state = initialState;
@@ -64,8 +69,7 @@ export class LoginScreen extends Component<PropsType, StateType> {
       return;
     }
 
-    const userService = new UserService();
-    userService
+    this.userService
       .login(username, this.password)
       .then((response) => {
         const isTester = response.user.is_tester;

--- a/src/features/register/Welcome2Screen/Welcome2Screen.tsx
+++ b/src/features/register/Welcome2Screen/Welcome2Screen.tsx
@@ -4,16 +4,17 @@ import { Image, Linking, SafeAreaView, ScrollView, TouchableOpacity, View } from
 
 import { usPartners, gbPartners, svPartners } from '@assets';
 import { BrandedButton, ClickableText, RegularBoldText, RegularText } from '@covid/components/Text';
-import UserService, { isGBCountry, isSECountry, isUSCountry } from '@covid/core/user/UserService';
+import UserService, { ICoreService, isGBCountry, isSECountry, isUSCountry } from '@covid/core/user/UserService';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import i18n from '@covid/locale/i18n';
+import { useInjection } from '@covid/provider/services.hooks';
+import { IContentService } from '@covid/core/content/ContentService';
+import { Services } from '@covid/provider/services.types';
 
 import CountryIpModal from '../CountryIpModal';
 import { getLocaleFlagIcon } from '../helpers';
 
 import styles from './styles';
-
-const userService = new UserService();
 
 const Slash = () => <RegularBoldText style={styles.slash}> / </RegularBoldText>;
 
@@ -22,6 +23,8 @@ type PropsType = {
 };
 
 const Welcome2Screen: FC<PropsType> = ({ navigation }) => {
+  const userService = useInjection<ICoreService>(Services.User);
+
   const [ipModalVisible, setIpModalVisible] = useState(false);
 
   const onLoginPress = useCallback(() => navigation.navigate('Login'), [navigation.navigate]);


### PR DESCRIPTION
# Description

LoadUser was being called and reseting the selected country. If logged in this doesn't matter, but on the initial screens it would cause the wrong country to be selected.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device
