### PR TITLE
Bugs/remove manual user service init

### DIFF
--- a/src/Services.ts
+++ b/src/Services.ts
@@ -16,7 +16,6 @@ import ExpoPushTokenEnvironment from './core/pushNotifications/expo';
 const apiClient = new ApiClient();
 const localStorageService = new LocalStorageService();
 
-export const userService = new UserService();
 export const offlineService = new OfflineService();
 
 const contentApiClient = new ContentApiClient(apiClient);

--- a/src/components/AppRating.tsx
+++ b/src/components/AppRating.tsx
@@ -5,9 +5,11 @@ import { Linking, Platform, StyleSheet, TouchableOpacity } from 'react-native';
 
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService, { isSECountry, isUSCountry } from '@covid/core/user/UserService';
+import { isSECountry, isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { ModalContainer } from '@covid/components/ModalContainer';
-import { contentService, userService } from '@covid/Services';
+import { contentService } from '@covid/Services';
+import { container } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { RegularBoldText, RegularText } from './Text';
 
@@ -24,7 +26,7 @@ const SEiOSLink = `https://apps.apple.com/se/app/covid-symptom-study/id150352961
 const AndroidLink = `market://details?id=${Constants.manifest.android.package}`;
 
 export async function shouldAskForRating(): Promise<boolean> {
-  const profile = await userService.getProfile();
+  const profile = await container.get<ICoreService>(Services.User).getProfile();
   const eligibleToAskForRating = profile.ask_for_rating;
   const askedToRateStatus = await contentService.getAskedToRateStatus();
   return !askedToRateStatus && eligibleToAskForRating;
@@ -35,7 +37,6 @@ export class AppRating extends Component<PropsType, State> {
     isModalOpen: true,
     showTakeToStore: false,
   };
-  private userService = new UserService();
 
   decline = () => {
     contentService.setAskedToRateStatus('asked');

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -43,6 +43,7 @@ const ErrorMessaging = ({ error, status, onRetry, onPress }: LoadingProps) => {
           <BrandedButton onPress={onPress}>{i18n.t('errors.button-okay')}</BrandedButton>
         </View>
       )}
+      {error && console.log(error)}
     </View>
   );
 };

--- a/src/components/USStudyInvite.tsx
+++ b/src/components/USStudyInvite.tsx
@@ -5,9 +5,10 @@ import { closeIcon, blobs } from '@assets';
 import { RegularText, HeaderText } from '@covid/components/Text';
 import { colors, fontStyles } from '@theme';
 import { AssessmentData } from '@covid/core/assessment/AssessmentCoordinator';
-import { isUSCountry } from '@covid/core/user/UserService';
+import { isUSCountry, ICoreService } from '@covid/core/user/UserService';
+import { useInjection } from '@covid/provider/services.hooks';
+import { Services } from '@covid/provider/services.types';
 import i18n from '@covid/locale/i18n';
-import { userService } from '@covid/Services';
 import Analytics, { events } from '@covid/core/Analytics';
 
 import { BrandedButton } from './BrandedButton';
@@ -17,6 +18,7 @@ type StudyInviteProps = {
 };
 
 export const USStudyInvite: React.FC<StudyInviteProps> = (props: StudyInviteProps) => {
+  const userService = useInjection<ICoreService>(Services.User);
   const [modalVisible, setModalVisible] = useState(false);
   const { currentPatient } = props.assessmentData;
 

--- a/src/core/Experiments.ts
+++ b/src/core/Experiments.ts
@@ -1,5 +1,8 @@
 import Analytics from '@covid/core/Analytics';
-import { userService } from '@covid/Services';
+import { container } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
+
+import { ICoreService } from './user/UserService';
 
 export const experiments = {
   Experiment_001: 'Experiment_001', // Test alternative external callouts on UK Thank You Pags
@@ -25,7 +28,7 @@ function getVariant(hash: string, totalVariants: number): string {
 }
 
 export async function startExperiment(experimentName: string, totalVariants: number): Promise<string | null> {
-  const profile = await userService.getProfile();
+  const profile = await container.get<ICoreService>(Services.User).getProfile();
   const variant = getVariant(profile.username, totalVariants);
   const payload: { [index: string]: string } = {};
   payload[experimentName] = variant;

--- a/src/core/assessment/AssessmentCoordinator.ts
+++ b/src/core/assessment/AssessmentCoordinator.ts
@@ -3,7 +3,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { ConfigType } from '@covid/core/Config';
 import { IAssessmentService } from '@covid/core/assessment/AssessmentService';
 import { PatientStateType } from '@covid/core/patient/PatientState';
-import UserService, { isSECountry, isUSCountry } from '@covid/core/user/UserService';
+import UserService, { isSECountry, isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { CovidTest } from '@covid/core/user/dto/CovidTestContracts';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import { AppCoordinator } from '@covid/features/AppCoordinator';
@@ -22,7 +22,7 @@ export type AssessmentData = {
 
 export class AssessmentCoordinator {
   navigation: NavigationType;
-  userService: UserService;
+  userService: ICoreService;
   assessmentService: IAssessmentService;
   assessmentData: AssessmentData;
   appCoordinator: AppCoordinator;
@@ -66,7 +66,7 @@ export class AssessmentCoordinator {
     appCoordinator: AppCoordinator,
     navigation: NavigationType,
     assessmentData: AssessmentData,
-    userService: UserService,
+    userService: ICoreService,
     assessmentService: IAssessmentService
   ) => {
     this.appCoordinator = appCoordinator;

--- a/src/core/patient/PatientCoordinator.ts
+++ b/src/core/patient/PatientCoordinator.ts
@@ -1,7 +1,7 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 
 import { PatientStateType } from '@covid/core/patient/PatientState';
-import UserService from '@covid/core/user/UserService';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import { AppCoordinator } from '@covid/features/AppCoordinator';
 
@@ -19,7 +19,7 @@ export type PatientData = {
 export class PatientCoordinator {
   appCoordinator: AppCoordinator;
   navigation: NavigationType;
-  userService: UserService;
+  userService: ICoreService;
   patientData: PatientData;
 
   screenFlow: ScreenFlow = {
@@ -44,7 +44,7 @@ export class PatientCoordinator {
     appCoordinator: AppCoordinator,
     navigation: NavigationType,
     patientData: PatientData,
-    userService: UserService
+    userService: ICoreService
   ) => {
     this.appCoordinator = appCoordinator;
     this.navigation = navigation;

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -46,6 +46,9 @@ export interface IUserService {
   deleteRemoteUserData(): Promise<any>;
   loadUser(): Promise<AuthenticatedUser | null>;
   getFirstPatientId(): Promise<string | null>;
+  setValidationStudyResponse(response: boolean, anonymizedData?: boolean, reContacted?: boolean): void;
+  setUSStudyInviteResponse(patientId: string, response: boolean): void;
+  shouldAskForValidationStudy(onThankYouScreen: boolean): Promise<boolean>;
 }
 
 export interface IProfileService {
@@ -102,6 +105,7 @@ export default class UserService extends ApiClientBase implements ICoreService {
   constructor(private useAsyncStorage: boolean = true) {
     super();
     this.loadUser();
+    console.log('User service init');
   }
 
   configEncoded = {
@@ -130,6 +134,7 @@ export default class UserService extends ApiClientBase implements ICoreService {
   }
 
   public async logout() {
+    console.log('[User Service] Logout');
     await this.deleteLocalUserData();
   }
 
@@ -158,6 +163,7 @@ export default class UserService extends ApiClientBase implements ICoreService {
   };
 
   async loadUser(): Promise<AuthenticatedUser | null> {
+    console.log('Load user');
     const user = await AsyncStorageService.GetStoredData();
     const hasUser = !!user && !!user!.userToken && !!user!.userId;
     this.updateUserCountry(hasUser);
@@ -166,6 +172,7 @@ export default class UserService extends ApiClientBase implements ICoreService {
       const patientId: string | null = await this.getFirstPatientId();
       if (!patientId) {
         // Logged in with an account doesn't exist. Force logout.
+        console.log('No user');
         await this.logout();
       }
     }
@@ -429,6 +436,7 @@ export default class UserService extends ApiClientBase implements ICoreService {
   }
 
   async setConsentSigned(document: string, version: string, privacy_policy_version: string) {
+    console.log('setConsentSigned', document);
     const consent = {
       document,
       version,

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -3,11 +3,13 @@ import { StackNavigationProp } from '@react-navigation/stack';
 
 import { ConfigType } from '@covid/core/Config';
 import { PatientStateType } from '@covid/core/patient/PatientState';
-import UserService, { isGBCountry, isUSCountry } from '@covid/core/user/UserService';
+import UserService, { isGBCountry, isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
-import { assessmentService, userService } from '@covid/Services';
+import { assessmentService } from '@covid/Services';
 import { Profile } from '@covid/features/multi-profile/SelectProfileScreen';
 import patientCoordinator from '@covid/core/patient/PatientCoordinator';
+import { Services } from '@covid/provider/services.types';
+import { lazyInject } from '@covid/provider/services';
 
 import { ScreenParamList } from './ScreenParamList';
 
@@ -24,8 +26,9 @@ type RouteParamsType = PatientIdParamType | CurrentPatientParamType | ConsentVie
 export type NavigationType = StackNavigationProp<ScreenParamList, keyof ScreenParamList>;
 
 export class AppCoordinator {
+  @lazyInject(Services.User)
+  userService: ICoreService;
   navigation: NavigationType;
-  userService: UserService;
 
   screenFlow: any = {
     // End of registration flows
@@ -63,10 +66,6 @@ export class AppCoordinator {
       }
     },
   };
-
-  constructor() {
-    this.userService = new UserService();
-  }
 
   setNavigation(navigation: NavigationType) {
     this.navigation = navigation;
@@ -106,6 +105,7 @@ export class AppCoordinator {
       this.startAssessmentFlow(currentPatient);
     }
   }
+
   startPatientFlow(currentPatient: PatientStateType) {
     patientCoordinator.init(this, this.navigation, { currentPatient }, this.userService);
     patientCoordinator.startPatient();
@@ -134,7 +134,7 @@ export class AppCoordinator {
   }
 
   async profileSelected(mainProfile: boolean, currentPatient: PatientStateType) {
-    if (isGBCountry() && mainProfile && (await userService.shouldAskForValidationStudy(false))) {
+    if (isGBCountry() && mainProfile && (await this.userService.shouldAskForValidationStudy(false))) {
       this.navigation.navigate('ValidationStudyIntro', { currentPatient });
     } else {
       this.startAssessmentFlow(currentPatient);

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -33,19 +33,19 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   const userService = useInjection<IUserService>(Services.User);
   const [userEmail, setUserEmail] = useState<string>('');
 
+  const fetchEmail = async () => {
+    try {
+      const profile = await userService.getProfile();
+      setUserEmail(profile?.username ?? '');
+    } catch (_) {
+      setUserEmail('');
+    }
+  };
+
   useEffect(() => {
-    console.log('use effect');
     if (userEmail !== '') return;
-    console.log('about to fetch profile');
-    userService
-      .getProfile()
-      .then((currentProfile) => {
-        setUserEmail(currentProfile?.username ?? '');
-      })
-      .catch((_) => {
-        setUserEmail('');
-      });
-  }, []);
+    fetchEmail();
+  }, [userService.hasUser]);
 
   function showDeleteAlert() {
     Alert.alert(
@@ -71,7 +71,6 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   }
 
   function logout() {
-    console.log('[Splash Screen] Logout');
     setUserEmail(''); // Reset email
     userService.logout();
     props.navigation.reset({

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -34,7 +34,9 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   const [userEmail, setUserEmail] = useState<string>('');
 
   useEffect(() => {
+    console.log('use effect');
     if (userEmail !== '') return;
+    console.log('about to fetch profile');
     userService
       .getProfile()
       .then((currentProfile) => {
@@ -43,7 +45,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
       .catch((_) => {
         setUserEmail('');
       });
-  });
+  }, []);
 
   function showDeleteAlert() {
     Alert.alert(
@@ -69,6 +71,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   }
 
   function logout() {
+    console.log('[Splash Screen] Logout');
     setUserEmail(''); // Reset email
     userService.logout();
     props.navigation.reset({

--- a/src/features/ViralThankYouScreen.tsx
+++ b/src/features/ViralThankYouScreen.tsx
@@ -11,7 +11,7 @@ import { social, surveyInvite } from '@assets';
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
 import { AreaStatsResponse } from '@covid/core/user/dto/UserAPIContracts';
-import UserService from '@covid/core/user/UserService';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
 import Analytics, { events } from '@covid/core/Analytics';
 import { BrandedButton, ClickableText, RegularBoldText, RegularText } from '@covid/components/Text';
 import BrandedSpinner from '@covid/components/Spinner';
@@ -19,6 +19,8 @@ import { isAndroid } from '@covid/components/Screen';
 import { AppRating, shouldAskForRating } from '@covid/components/AppRating';
 import { contentService } from '@covid/Services';
 import { ExternalCallout } from '@covid/components/ExternalCallout';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from './ScreenParamList';
 
@@ -36,6 +38,9 @@ type State = {
 };
 
 export default class ViralThankYouScreen extends Component<Props, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -48,8 +53,7 @@ export default class ViralThankYouScreen extends Component<Props, State> {
   }
 
   async componentDidMount() {
-    const userService = new UserService();
-    const profile = await userService.getProfile();
+    const profile = await this.userService.getProfile();
 
     if (await shouldAskForRating()) {
       this.setState({ askForRating: true });

--- a/src/features/assessment/DescribeSymptomsScreen.tsx
+++ b/src/features/assessment/DescribeSymptomsScreen.tsx
@@ -14,12 +14,14 @@ import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/compon
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { ValidationError } from '@covid/components/ValidationError';
 import { AssessmentInfosRequest } from '@covid/core/assessment/dto/AssessmentInfosRequest';
-import UserService from '@covid/core/user/UserService';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
 import { cleanFloatVal } from '@covid/core/utils/number';
 import AssessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 import i18n from '@covid/locale/i18n';
 import { assessmentService } from '@covid/Services';
 import YesNoField from '@covid/components/YesNoField';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -97,6 +99,9 @@ const initialState: State = {
 };
 
 export default class DescribeSymptomsScreen extends Component<SymptomProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: SymptomProps) {
     super(props);
     this.state = initialState;
@@ -250,9 +255,7 @@ export default class DescribeSymptomsScreen extends Component<SymptomProps, Stat
     ];
 
     const getInitialFormValues = (): DescribeSymptomsData => {
-      const userService = new UserService();
-      const features = userService.getConfig();
-
+      const features = this.userService.getConfig();
       return {
         ...initialFormValues,
         temperatureUnit: features.defaultTemperatureUnit,

--- a/src/features/assessment/LevelOfIsolationScreen.tsx
+++ b/src/features/assessment/LevelOfIsolationScreen.tsx
@@ -14,7 +14,7 @@ import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/compon
 import { ValidationError } from '@covid/components/ValidationError';
 import { AssessmentInfosRequest } from '@covid/core/assessment/dto/AssessmentInfosRequest';
 import { PatientStateType } from '@covid/core/patient/PatientState';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { cleanIntegerVal } from '@covid/core/utils/number';
 import AssessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
@@ -22,6 +22,8 @@ import i18n from '@covid/locale/i18n';
 import { assessmentService } from '@covid/Services';
 import { colors, fontStyles } from '@theme';
 import { FaceMaskData, FaceMaskQuestion, TypeOfMaskValues } from '@covid/features/assessment/fields/FaceMaskQuestion';
+import { Services } from '@covid/provider/services.types';
+import { lazyInject } from '@covid/provider/services';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -55,6 +57,9 @@ const initialState: State = {
 };
 
 export default class LevelOfIsolationScreen extends Component<LocationProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: LocationProps) {
     super(props);
     this.state = initialState;
@@ -116,14 +121,13 @@ export default class LevelOfIsolationScreen extends Component<LocationProps, Sta
   });
 
   private updatePatientsLastAskedDate(currentPatient: PatientStateType) {
-    const userService = new UserService();
     const patientId = currentPatient.patientId;
     const timeNow = moment().toDate();
     const infos = {
       last_asked_level_of_isolation: timeNow,
     } as Partial<PatientInfosRequest>;
 
-    return userService
+    return this.userService
       .updatePatient(patientId, infos)
       .then(() => (currentPatient.shouldAskLevelOfIsolation = false))
       .catch(() => {

--- a/src/features/assessment/ProfileBackDateScreen.tsx
+++ b/src/features/assessment/ProfileBackDateScreen.tsx
@@ -9,10 +9,12 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
 import { ValidationError } from '@covid/components/ValidationError';
-import UserService, { isUSCountry } from '@covid/core/user/UserService';
+import { isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import AssessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 import { AtopyData, AtopyQuestions } from '@covid/features/patient/fields/AtopyQuestions';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 import i18n from '@covid/locale/i18n';
 
 import { ScreenParamList } from '../ScreenParamList';
@@ -69,7 +71,9 @@ const initialState: State = {
 };
 
 export default class ProfileBackDateScreen extends Component<BackDateProps, State> {
-  userService = new UserService();
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   features = this.userService.getConfig();
 
   constructor(props: BackDateProps) {
@@ -141,8 +145,7 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
   });
 
   async componentDidMount() {
-    const userService = new UserService();
-    const features = userService.getConfig();
+    const features = this.userService.getConfig();
     const { currentPatient } = AssessmentCoordinator.assessmentData;
     this.setState({
       needBloodPressureAnswer: !currentPatient.hasBloodPressureAnswer,
@@ -159,11 +162,9 @@ export default class ProfileBackDateScreen extends Component<BackDateProps, Stat
   handleProfileUpdate(formData: BackfillData) {
     const { currentPatient } = AssessmentCoordinator.assessmentData;
     const patientId = currentPatient.patientId;
-
-    const userService = new UserService();
     const infos = this.createPatientInfos(formData);
 
-    userService
+    this.userService
       .updatePatient(patientId, infos)
       .then((response) => {
         if (formData.race) currentPatient.hasRaceEthnicityAnswer = true;

--- a/src/features/assessment/fields/LifestyleQuestion.tsx
+++ b/src/features/assessment/fields/LifestyleQuestion.tsx
@@ -6,9 +6,11 @@ import i18n from '@covid/locale/i18n';
 import { FieldWrapper } from '@covid/components/Screen';
 import DropdownField from '@covid/components/DropdownField';
 import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
-import { userService } from '@covid/Services';
 import { cleanFloatVal } from '@covid/core/utils/number';
 import { WeightData, WeightQuestion } from '@covid/features/patient/fields/WeightQuestion';
+import { container } from '@covid/provider/services';
+import { ICoreService } from '@covid/core/user/UserService';
+import { Services } from '@covid/provider/services.types';
 
 export interface LifestyleData {
   weightChange: string;
@@ -133,8 +135,7 @@ export const LifestyleQuestion: FormikLifestyleQuestionInputFC<Props, LifestyleD
 };
 
 LifestyleQuestion.initialFormValues = (): LifestyleData => {
-  const features = userService.getConfig();
-
+  const features = container.get<ICoreService>(Services.User).getConfig();
   return {
     weightChange: '',
     dietChange: '',

--- a/src/features/multi-profile/ArchiveReasonScreen.tsx
+++ b/src/features/multi-profile/ArchiveReasonScreen.tsx
@@ -6,8 +6,10 @@ import { HeaderText, RegularText, SecondaryText } from '@covid/components/Text';
 import Screen, { FieldWrapper, Header } from '@covid/components/Screen';
 import { BigButton } from '@covid/components/BigButton';
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
 import Navigator from '@covid/features/AppCoordinator';
+import { useInjection } from '@covid/provider/services.hooks';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -17,6 +19,7 @@ type RenderProps = {
 };
 
 export const ArchiveReasonScreen: React.FC<RenderProps> = (props) => {
+  const userService = useInjection<ICoreService>(Services.User);
   const reasons = [
     {
       text: i18n.t('archive-reason.choice-duplicate-account'),
@@ -50,7 +53,6 @@ export const ArchiveReasonScreen: React.FC<RenderProps> = (props) => {
       archived_reason: reason,
     };
 
-    const userService = new UserService();
     userService.updatePatient(props.route.params.profileId, infos).then((response) => {
       Navigator.gotoScreen('SelectProfile');
     });

--- a/src/features/multi-profile/ConsentForOtherScreen.tsx
+++ b/src/features/multi-profile/ConsentForOtherScreen.tsx
@@ -8,10 +8,12 @@ import { LoadingModal } from '@covid/components/Loading';
 import Screen, { Header } from '@covid/components/Screen';
 import { BrandedButton, ClickableText, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
 import { ApiErrorState, initialErrorState } from '@covid/core/api/ApiServiceErrors';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import i18n from '@covid/locale/i18n';
-import { offlineService, userService } from '@covid/Services';
+import { offlineService } from '@covid/Services';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import Navigator from '../AppCoordinator';
 import { ConsentType, ScreenParamList } from '../ScreenParamList';
@@ -33,6 +35,9 @@ const initialState: ConsentState = {
 };
 
 export default class ConsentForOtherScreen extends Component<RenderProps, ConsentState> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: RenderProps) {
     super(props);
     this.state = initialState;
@@ -68,8 +73,7 @@ export default class ConsentForOtherScreen extends Component<RenderProps, Consen
   consentLabel = this.isAdultConsent() ? i18n.t('adult-consent-confirm') : i18n.t('child-consent-confirm');
 
   async startAssessment(patientId: string) {
-    const userService = new UserService();
-    const currentPatient = await userService.getCurrentPatient(patientId);
+    const currentPatient = await this.userService.getCurrentPatient(patientId);
     Navigator.resetToProfileStartAssessment(currentPatient);
   }
 
@@ -83,7 +87,7 @@ export default class ConsentForOtherScreen extends Component<RenderProps, Consen
       reported_by_another: true,
     } as Partial<PatientInfosRequest>;
 
-    const response = await userService.createPatient(newPatient);
+    const response = await this.userService.createPatient(newPatient);
     return response.data.id;
   }
 

--- a/src/features/multi-profile/ReportForOtherScreen.tsx
+++ b/src/features/multi-profile/ReportForOtherScreen.tsx
@@ -8,7 +8,7 @@ import { profilesIcon } from '@assets';
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
 import { AssessmentCoordinator } from '@covid/core/assessment/AssessmentCoordinator';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import {
   BrandedButton,
   ClickableText,
@@ -18,6 +18,8 @@ import {
   SecondaryText,
 } from '@covid/components/Text';
 import { Header } from '@covid/components/Screen';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -27,9 +29,11 @@ type RenderProps = {
 };
 
 export default class ReportForOtherScreen extends Component<RenderProps, object> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   handleSkip = async () => {
-    const userService = new UserService();
-    await userService.recordAskedToReportForOther();
+    await this.userService.recordAskedToReportForOther();
     this.props.navigation.navigate(AssessmentCoordinator.getThankYouScreen());
   };
 

--- a/src/features/multi-profile/SelectProfileScreen.tsx
+++ b/src/features/multi-profile/SelectProfileScreen.tsx
@@ -10,11 +10,14 @@ import { Header } from '@covid/components/Screen';
 import { HeaderText, SecondaryText } from '@covid/components/Text';
 import { ApiErrorState, initialErrorState } from '@covid/core/api/ApiServiceErrors';
 import i18n from '@covid/locale/i18n';
-import { offlineService, userService } from '@covid/Services';
+import { offlineService } from '@covid/Services';
 import { DrawerToggle } from '@covid/components/DrawerToggle';
 import { ProfileCard } from '@covid/components/ProfileCard';
 import { NewProfileCard } from '@covid/components/NewProfileCard';
 import { DEFAULT_PROFILE } from '@covid/utils/avatar';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
+import { ICoreService } from '@covid/core/user/UserService';
 
 import { ScreenParamList } from '../ScreenParamList';
 import Navigator from '../AppCoordinator';
@@ -50,6 +53,9 @@ const initialState = {
 };
 
 export default class SelectProfileScreen extends Component<RenderProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: RenderProps) {
     super(props);
     this.state = initialState;
@@ -74,7 +80,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
   async listProfiles() {
     this.setState({ status: i18n.t('errors.status-loading'), error: null });
     try {
-      const response = await userService.listPatients();
+      const response = await this.userService.listPatients();
       response &&
         this.setState({
           profiles: response.data,
@@ -87,7 +93,7 @@ export default class SelectProfileScreen extends Component<RenderProps, State> {
 
   async profileSelected(profileId: string, index: number) {
     try {
-      const currentPatient = await userService.getCurrentPatient(profileId);
+      const currentPatient = await this.userService.getCurrentPatient(profileId);
       this.setState({ isApiError: false });
       await Navigator.profileSelected(index === 0, currentPatient);
     } catch (error) {

--- a/src/features/password-reset/ResetPassword/index.tsx
+++ b/src/features/password-reset/ResetPassword/index.tsx
@@ -6,7 +6,9 @@ import { Keyboard, KeyboardAvoidingView, Platform, TouchableWithoutFeedback } fr
 import * as Yup from 'yup';
 
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../../ScreenParamList';
 
@@ -32,6 +34,9 @@ interface ResetPasswordData {
 }
 
 export class ResetPasswordScreen extends Component<PropsType, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: PropsType) {
     super(props);
     this.state = initialState;
@@ -42,8 +47,7 @@ export class ResetPasswordScreen extends Component<PropsType, State> {
   private handleClick(formData: ResetPasswordData) {
     if (this.state.enableSubmit) {
       this.setState({ enableSubmit: false }); // Stop resubmissions
-      const userService = new UserService(); // todo get global var
-      userService
+      this.userService
         .resetPassword(formData.email)
         .then(() => this.props.navigation.navigate('ResetPasswordConfirm'))
         .catch((err: AxiosError) => {

--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -12,13 +12,14 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
 import { ValidationError } from '@covid/components/ValidationError';
-import { isUSCountry } from '@covid/core/user/UserService';
+import { isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { cleanFloatVal, cleanIntegerVal } from '@covid/core/utils/number';
 import i18n from '@covid/locale/i18n';
-import { userService } from '@covid/Services';
 import patientCoordinator from '@covid/core/patient/PatientCoordinator';
 import YesNoField from '@covid/components/YesNoField';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -83,13 +84,16 @@ const initialState: State = {
 };
 
 export default class AboutYouScreen extends Component<AboutYouProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: AboutYouProps) {
     super(props);
     this.state = initialState;
   }
 
   async componentDidMount() {
-    const features = userService.getConfig();
+    const features = this.userService.getConfig();
 
     this.setState({
       showRaceQuestion: features.showRaceQuestion,
@@ -105,7 +109,7 @@ export default class AboutYouScreen extends Component<AboutYouProps, State> {
       const patientId = currentPatient.patientId;
       var infos = this.createPatientInfos(formData);
 
-      userService
+      this.userService
         .updatePatient(patientId, infos)
         .then(() => {
           currentPatient.hasRaceEthnicityAnswer = formData.race.length > 0;

--- a/src/features/patient/PreviousExposure.tsx
+++ b/src/features/patient/PreviousExposure.tsx
@@ -13,12 +13,14 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
 import { ValidationError } from '@covid/components/ValidationError';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import i18n from '@covid/locale/i18n';
 import { stripAndRound } from '@covid/utils/helpers';
 import patientCoordinator from '@covid/core/patient/PatientCoordinator';
 import YesNoField from '@covid/components/YesNoField';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -76,6 +78,9 @@ const initialState: State = {
 };
 
 export default class PreviousExposureScreen extends Component<HealthProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: HealthProps) {
     super(props);
     this.state = initialState;
@@ -108,11 +113,9 @@ export default class PreviousExposureScreen extends Component<HealthProps, State
   handleUpdateHealth(formData: YourHealthData) {
     const currentPatient = patientCoordinator.patientData.currentPatient;
     const patientId = currentPatient.patientId;
-
-    const userService = new UserService();
     const infos = this.createPatientInfos(formData);
 
-    userService
+    this.userService
       .updatePatient(patientId, infos)
       .then((response) => {
         patientCoordinator.gotoNextScreen(this.props.route.name);

--- a/src/features/patient/YourHealthScreen.tsx
+++ b/src/features/patient/YourHealthScreen.tsx
@@ -11,13 +11,15 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
 import { ValidationError } from '@covid/components/ValidationError';
-import UserService, { isUSCountry } from '@covid/core/user/UserService';
+import { isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { AtopyData, AtopyQuestions } from '@covid/features/patient/fields/AtopyQuestions';
 import i18n from '@covid/locale/i18n';
 import { stripAndRound } from '@covid/utils/helpers';
 import patientCoordinator from '@covid/core/patient/PatientCoordinator';
 import YesNoField from '@covid/components/YesNoField';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -100,11 +102,13 @@ const initialState: State = {
 const maleOptions = ['', 'male', 'pfnts'];
 
 export default class YourHealthScreen extends Component<HealthProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: HealthProps) {
     super(props);
     const currentPatient = patientCoordinator.patientData.currentPatient;
-    const userService = new UserService();
-    const features = userService.getConfig();
+    const features = this.userService.getConfig();
     this.state = {
       ...initialState,
       showPregnancyQuestion: features.showPregnancyQuestion && currentPatient.isFemale,
@@ -182,11 +186,9 @@ export default class YourHealthScreen extends Component<HealthProps, State> {
   handleUpdateHealth(formData: YourHealthData) {
     const currentPatient = patientCoordinator.patientData.currentPatient;
     const patientId = currentPatient.patientId;
-
-    const userService = new UserService();
     var infos = this.createPatientInfos(formData);
 
-    userService
+    this.userService
       .updatePatient(patientId, infos)
       .then((response) => {
         currentPatient.hasCompletedPatientDetails = true;

--- a/src/features/patient/YourStudyScreen.tsx
+++ b/src/features/patient/YourStudyScreen.tsx
@@ -13,10 +13,12 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
 import { ValidationError } from '@covid/components/ValidationError';
-import UserService, { isGBCountry, isUSCountry } from '@covid/core/user/UserService';
+import UserService, { isGBCountry, isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import i18n from '@covid/locale/i18n';
 import patientCoordinator from '@covid/core/patient/PatientCoordinator';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -210,6 +212,9 @@ const AllCohorts: CohortDefinition[] = [
 ];
 
 export default class YourStudyScreen extends Component<YourStudyProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   registerSchema = Yup.object().shape({
     clinicalStudyNames: Yup.string(),
     clinicalStudyContact: Yup.string(),
@@ -245,10 +250,9 @@ export default class YourStudyScreen extends Component<YourStudyProps, State> {
   handleSubmit(formData: YourStudyData) {
     const currentPatient = patientCoordinator.patientData.currentPatient;
     const patientId = currentPatient.patientId;
-    const userService = new UserService();
     const infos = this.createPatientInfos(formData);
 
-    userService
+    this.userService
       .updatePatient(patientId, infos)
       .then((response) => {
         patientCoordinator.gotoNextScreen(this.props.route.name);

--- a/src/features/patient/YourWorkScreen.tsx
+++ b/src/features/patient/YourWorkScreen.tsx
@@ -12,7 +12,7 @@ import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
 import { ValidationError } from '@covid/components/ValidationError';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import i18n from '@covid/locale/i18n';
 import patientCoordinator from '@covid/core/patient/PatientCoordinator';
 import {
@@ -25,6 +25,8 @@ import {
   PatientInfosRequest,
 } from '@covid/core/user/dto/UserAPIContracts';
 import YesNoField from '@covid/components/YesNoField';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -75,6 +77,9 @@ const initialState: State = {
 };
 
 export default class YourWorkScreen extends Component<YourWorkProps, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   constructor(props: YourWorkProps) {
     super(props);
     this.state = initialState;
@@ -89,10 +94,9 @@ export default class YourWorkScreen extends Component<YourWorkProps, State> {
   handleUpdateWork(formData: YourWorkData) {
     const currentPatient = patientCoordinator.patientData.currentPatient;
     const patientId = currentPatient.patientId;
-    const userService = new UserService();
     const infos = this.createPatientInfos(formData);
 
-    userService
+    this.userService
       .updatePatient(patientId, infos)
       .then((response) => {
         currentPatient.isHealthWorker =

--- a/src/features/patient/fields/HeightQuestion.tsx
+++ b/src/features/patient/fields/HeightQuestion.tsx
@@ -6,10 +6,11 @@ import DropdownField from '@covid/components/DropdownField';
 import { FieldWrapper } from '@covid/components/Screen';
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { ValidationError } from '@covid/components/ValidationError';
-import { isUSCountry } from '@covid/core/user/UserService';
+import { isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import i18n from '@covid/locale/i18n';
-import { userService } from '@covid/Services';
 import { RegularText } from '@covid/components/Text';
+import { container } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 export interface HeightData {
   height: string;
@@ -111,7 +112,7 @@ export const HeightQuestion: FCWithStatic<Props> = ({ formikProps }) => {
 };
 
 HeightQuestion.initialFormValues = () => {
-  const features = userService.getConfig();
+  const features = container.get<ICoreService>(Services.User).getConfig();
   return {
     height: '',
     feet: '',

--- a/src/features/patient/fields/WeightQuestion.tsx
+++ b/src/features/patient/fields/WeightQuestion.tsx
@@ -6,10 +6,11 @@ import DropdownField from '@covid/components/DropdownField';
 import { FieldWrapper } from '@covid/components/Screen';
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { ValidationError } from '@covid/components/ValidationError';
-import { isUSCountry } from '@covid/core/user/UserService';
+import { isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import i18n from '@covid/locale/i18n';
-import { userService } from '@covid/Services';
 import { RegularText } from '@covid/components/Text';
+import { container } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 export interface WeightData {
   weight: string;
@@ -109,7 +110,7 @@ export const WeightQuestion: FCWithStatic<Props> = ({ formikProps, label }) => {
 };
 
 WeightQuestion.initialFormValues = () => {
-  const features = userService.getConfig();
+  const features = container.get<ICoreService>(Services.User).getConfig();
   return {
     weight: '',
     stones: '',

--- a/src/features/register/ConsentScreen/ConsentScreen.tsx
+++ b/src/features/register/ConsentScreen/ConsentScreen.tsx
@@ -4,8 +4,10 @@ import React, { FC, useState, useCallback } from 'react';
 import { View } from 'react-native';
 
 import i18n from '@covid/locale/i18n';
-import UserService, { isGBCountry, isSECountry, isUSCountry } from '@covid/core/user/UserService';
+import { isGBCountry, isSECountry, isUSCountry, ICoreService } from '@covid/core/user/UserService';
 import { BrandedButton } from '@covid/components/Text';
+import { useInjection } from '@covid/provider/services.hooks';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../../ScreenParamList';
 import {
@@ -27,9 +29,8 @@ type PropsType = {
   route: RouteProp<ScreenParamList, 'Consent'>;
 };
 
-const userService = new UserService();
-
 const ConsentScreen: FC<PropsType> = (props) => {
+  const userService = useInjection<ICoreService>(Services.User);
   const [agreed, setAgreed] = useState(false);
 
   const handleAgreeClicked = useCallback(async () => {

--- a/src/features/register/CountryIpModal/CountryIpModal.tsx
+++ b/src/features/register/CountryIpModal/CountryIpModal.tsx
@@ -10,8 +10,10 @@ import { isAndroid } from '@covid/components/Screen';
 import { RegularText } from '@covid/components/Text';
 import { ITest } from '@covid/components/types';
 import { AsyncStorageService } from '@covid/core/AsyncStorageService';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import i18n from '@covid/locale/i18n';
+import { useInjection } from '@covid/provider/services.hooks';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../../ScreenParamList';
 
@@ -35,9 +37,8 @@ type Item = {
   value: CountryCode;
 };
 
-const userService = new UserService();
-
 const CountryIpModal: FC<PropsType> = ({ navigation, isModalVisible, closeModal }) => {
+  const userService = useInjection<ICoreService>(Services.User);
   const [countrySelected, setCountrySelected] = useState('');
 
   const selectCountry = useCallback(

--- a/src/features/register/OptionalInfoScreen.tsx
+++ b/src/features/register/OptionalInfoScreen.tsx
@@ -3,7 +3,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import Constants from 'expo-constants';
 import { Formik } from 'formik';
 import { Form } from 'native-base';
-import React, { Component } from 'react';
+import React, { Component, lazy } from 'react';
 import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import * as Yup from 'yup';
 
@@ -14,7 +14,10 @@ import { ApiErrorState, initialErrorState } from '@covid/core/api/ApiServiceErro
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { BrandedButton, ErrorText, HeaderText, RegularText } from '@covid/components/Text';
 import { LoadingModal } from '@covid/components/Loading';
-import { userService, offlineService, pushNotificationService } from '@covid/Services';
+import { offlineService, pushNotificationService } from '@covid/Services';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
+import { ICoreService } from '@covid/core/user/UserService';
 
 import Navigator from '../AppCoordinator';
 import { ScreenParamList } from '../ScreenParamList';
@@ -39,6 +42,9 @@ interface OptionalInfoData {
 }
 
 export class OptionalInfoScreen extends Component<PropsType, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   private phoneComponent: any;
 
   constructor(props: PropsType) {
@@ -47,7 +53,7 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
   }
 
   private async gotoNextScreen(patientId: string) {
-    const currentPatient = await userService.getCurrentPatient(patientId);
+    const currentPatient = await this.userService.getCurrentPatient(patientId);
     this.setState({ isApiError: false });
     Navigator.gotoNextScreen(this.props.route.name, { currentPatient });
   }
@@ -66,7 +72,7 @@ export class OptionalInfoScreen extends Component<PropsType, State> {
         ...(formData.name && { name: formData.name }),
         ...(formData.phone && { phone_number: formData.phone }),
       } as Partial<PiiRequest>;
-      await userService.updatePii(piiDoc);
+      await this.userService.updatePii(piiDoc);
     }
   }
 

--- a/src/features/register/RegisterScreen.tsx
+++ b/src/features/register/RegisterScreen.tsx
@@ -9,11 +9,13 @@ import * as Yup from 'yup';
 
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import Analytics, { events } from '@covid/core/Analytics';
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import { BrandedButton, ClickableText, ErrorText, HeaderLightText, RegularText } from '@covid/components/Text';
 import { Field, FieldError } from '@covid/components/Forms';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import Navigator from '../AppCoordinator';
 import { ScreenParamList } from '../ScreenParamList';
@@ -46,6 +48,9 @@ const initialRegistrationValues = {
 };
 
 export class RegisterScreen extends Component<PropsType, State> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   private passwordComponent: any;
 
   constructor(props: PropsType) {
@@ -62,8 +67,7 @@ export class RegisterScreen extends Component<PropsType, State> {
   private handleCreateAccount(formData: RegistrationData) {
     if (this.state.enableSubmit) {
       this.setState({ enableSubmit: false }); // Stop resubmissions
-      const userService = new UserService(); // todo get gloval var
-      userService
+      this.userService
         .register(formData.email, formData.password)
         .then((response) => {
           const isTester = response.data.user.is_tester;

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -15,9 +15,12 @@ import AnalyticsService from '@covid/core/Analytics';
 import { ApiErrorState, initialErrorState } from '@covid/core/api/ApiServiceErrors';
 import { cleanIntegerVal } from '@covid/core/utils/number';
 import i18n from '@covid/locale/i18n';
-import { contentService, offlineService, pushNotificationService, userService } from '@covid/Services';
+import { contentService, offlineService, pushNotificationService } from '@covid/Services';
 import { DrawerToggle } from '@covid/components/DrawerToggle';
 import { ScreenContent } from '@covid/core/content/ScreenContentContracts';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
+import { ICoreService } from '@covid/core/user/UserService';
 
 import Navigator, { NavigationType } from '../AppCoordinator';
 import { ScreenParamList } from '../ScreenParamList';
@@ -43,13 +46,16 @@ const initialState = {
 };
 
 export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScreenState> {
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   state: WelcomeRepeatScreenState = initialState;
 
   async componentDidMount() {
     Navigator.resetNavigation((this.props.navigation as unknown) as NavigationType);
     const userCount = await contentService.getUserCount();
     this.setState({ userCount: cleanIntegerVal(userCount as string) });
-    const feature = userService.getConfig();
+    const feature = this.userService.getConfig();
     this.setState({ showPartnerLogos: feature.showPartnerLogos });
     AnalyticsService.identify();
     await pushNotificationService.refreshPushToken();

--- a/src/features/register/gb/ValidationStudyConsentScreen.tsx
+++ b/src/features/register/gb/ValidationStudyConsentScreen.tsx
@@ -10,9 +10,9 @@ import { CheckboxItem, CheckboxList } from '@covid/components/Checkbox';
 import { Header } from '@covid/components/Screen';
 import { BrandedButton, ClickableText, HeaderText, RegularBoldText, RegularText } from '@covid/components/Text';
 import Analytics, { events } from '@covid/core/Analytics';
-import UserService from '@covid/core/user/UserService';
-import AssessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
-import i18n from '@covid/locale/i18n';
+import { ICoreService } from '@covid/core/user/UserService';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import Navigator from '../../AppCoordinator';
 import { ScreenParamList } from '../../ScreenParamList';
@@ -30,7 +30,8 @@ interface TermsState {
 }
 
 export default class ValidationStudyConsentScreen extends Component<PropsType, TermsState> {
-  private userService = new UserService();
+  @lazyInject(Services.User)
+  private userService: ICoreService;
 
   constructor(props: PropsType) {
     super(props);

--- a/src/features/register/gb/ValidationStudyIntroScreen.tsx
+++ b/src/features/register/gb/ValidationStudyIntroScreen.tsx
@@ -2,15 +2,16 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { Component } from 'react';
 import { Image, ScrollView, StyleSheet, TouchableOpacity, View, ImageBackground } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { icon, studyIntro } from '@assets';
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import Analytics, { events } from '@covid/core/Analytics';
 import { BrandedButton, HeaderText, RegularText } from '@covid/components/Text';
 import { Header } from '@covid/components/Screen';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import Navigator from '../../AppCoordinator';
 import { ScreenParamList } from '../../ScreenParamList';
@@ -21,7 +22,9 @@ type Props = {
 };
 
 export default class ValidationStudyIntroScreen extends Component<Props, object> {
-  userService = new UserService();
+  @lazyInject(Services.User)
+  private userService: ICoreService;
+
   render() {
     return (
       <View style={styles.backgroundContainer}>

--- a/src/features/register/us/NursesConsentUS.tsx
+++ b/src/features/register/us/NursesConsentUS.tsx
@@ -5,9 +5,11 @@ import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import UserService from '@covid/core/user/UserService';
+import { ICoreService } from '@covid/core/user/UserService';
 import { BrandedButton, ClickableText, RegularBoldText, RegularText } from '@covid/components/Text';
 import { CheckboxItem, CheckboxList } from '@covid/components/Checkbox';
+import { lazyInject } from '@covid/provider/services';
+import { Services } from '@covid/provider/services.types';
 
 import { ScreenParamList } from '../../ScreenParamList';
 import { NursesConsentVersionUS, privacyPolicyVersionUS } from '../constants';
@@ -23,7 +25,8 @@ interface TermsState {
 }
 
 export class NursesConsentUSScreen extends Component<PropsType, TermsState> {
-  private userService = new UserService();
+  @lazyInject(Services.User)
+  private userService: ICoreService;
 
   constructor(props: PropsType) {
     super(props);


### PR DESCRIPTION
# Description

This PR addresses 2 issues:
- Old references of `UserService`
- Excessive fetching of user profile / email

Solutions:
- Inject `UserService` everywhere (removed old references of `UserService`)
- Added new property `hasUser` to `UserService` which is used in `useEffect` to prevent excessive fetching (`hasUser` is default to `false`)


`hasUser` Is updated when:
- `loadUser` is called. Should be on `UserService` init
- `logout` is called in `UserService` (sets to `false`)
- `handleLoginOrRegisterResponse` (sets to `true`)

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`
