### PR TITLE
Update styling for COVID Test calendar

### DIFF
--- a/src/components/CalendarPicker.tsx
+++ b/src/components/CalendarPicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import CalendarPicker, { CalendarPickerProps } from 'react-native-calendar-picker';
 
 import { colors } from '@theme';
@@ -8,16 +8,18 @@ import { isUSCountry } from '@covid/core/user/UserService';
 import { screenWidth } from './Screen';
 
 const ZoeCalendarPicker = (props: CalendarPickerProps) => (
-  <CalendarPicker
-    {...props}
-    startFromMonday={!isUSCountry()}
-    selectedDayStyle={styles.selectedDay}
-    selectedDayTextColor={colors.white}
-    selectedRangeStyle={styles.selectedRange}
-    todayTextStyle={styles.today}
-    todayBackgroundColor="transparent"
-    scaleFactor={screenWidth + 30}
-  />
+  <View style={styles.calendarView}>
+    <CalendarPicker
+      {...props}
+      startFromMonday={!isUSCountry()}
+      selectedDayStyle={styles.selectedDay}
+      selectedDayTextColor={colors.white}
+      selectedRangeStyle={styles.selectedRange}
+      todayTextStyle={styles.today}
+      todayBackgroundColor="transparent"
+      width={screenWidth - 16}
+    />
+  </View>
 );
 
 const styles = StyleSheet.create({
@@ -30,6 +32,12 @@ const styles = StyleSheet.create({
   today: {
     color: colors.purple,
     fontWeight: '700',
+  },
+  calendarView: {
+    padding: 10,
+    backgroundColor: colors.backgroundTertiary,
+    borderRadius: 8,
+    alignItems: 'center',
   },
 });
 

--- a/src/features/assessment/fields/CovidTestDateQuestion.tsx
+++ b/src/features/assessment/fields/CovidTestDateQuestion.tsx
@@ -156,7 +156,6 @@ const styles = StyleSheet.create({
     ...fontStyles.bodyReg,
     color: colors.black,
     alignSelf: 'center',
-    // paddingHorizontal: 40,
     paddingBottom: 10,
   },
 });

--- a/src/features/assessment/fields/CovidTestDateQuestion.tsx
+++ b/src/features/assessment/fields/CovidTestDateQuestion.tsx
@@ -1,7 +1,7 @@
 import { FormikProps } from 'formik';
 import React, { useState } from 'react';
 import * as Yup from 'yup';
-import { Item, Label, Text } from 'native-base';
+import { Item, Label, Text, View } from 'native-base';
 import moment, { Moment } from 'moment';
 import { StyleSheet } from 'react-native';
 
@@ -85,7 +85,7 @@ export const CovidTestDateQuestion: CovidTestDateQuestion<Props, CovidTestDateDa
       />
 
       {formikProps.values.knowsDateOfTest === 'yes' && (
-        <FieldWrapper style={{ paddingRight: 30 }}>
+        <View style={styles.field}>
           <Item stackedLabel>
             <Label style={styles.labelStyle}>{i18n.t('covid-test.question-date-test-occurred')}</Label>
             {state.showDatePicker ? (
@@ -101,16 +101,16 @@ export const CovidTestDateQuestion: CovidTestDateQuestion<Props, CovidTestDateDa
                 {formikProps.values.dateTakenSpecific ? (
                   moment(formikProps.values.dateTakenSpecific).format('MMMM D, YYYY')
                 ) : (
-                  <RegularText>{i18n.t('covid-test.required-date')}</RegularText>
+                  <Text>{i18n.t('covid-test.required-date')}</Text>
                 )}
               </ClickableText>
             )}
           </Item>
-        </FieldWrapper>
+        </View>
       )}
 
       {formikProps.values.knowsDateOfTest === 'no' && (
-        <FieldWrapper style={{ paddingRight: 30 }}>
+        <View style={styles.field}>
           <Item stackedLabel>
             <Label style={styles.labelStyle}>{i18n.t('covid-test.question-date-test-occurred-guess')}</Label>
 
@@ -137,7 +137,7 @@ export const CovidTestDateQuestion: CovidTestDateQuestion<Props, CovidTestDateDa
               </ClickableText>
             )}
           </Item>
-        </FieldWrapper>
+        </View>
       )}
     </FieldWrapper>
   );
@@ -145,14 +145,18 @@ export const CovidTestDateQuestion: CovidTestDateQuestion<Props, CovidTestDateDa
 
 const styles = StyleSheet.create({
   labelStyle: {
-    marginBottom: 30,
+    marginVertical: 16,
+  },
+
+  field: {
+    marginHorizontal: 16,
   },
 
   fieldText: {
     ...fontStyles.bodyReg,
     color: colors.black,
     alignSelf: 'center',
-    paddingHorizontal: 40,
+    // paddingHorizontal: 40,
     paddingBottom: 10,
   },
 });


### PR DESCRIPTION
# Description

Updates the styling for the calendar to prevent it from spilling out of the central view on some devices.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="290" alt="Screenshot 2020-06-30 at 19 17 04" src="https://user-images.githubusercontent.com/52913482/86162553-e090b800-bb06-11ea-88b5-9e0a6c94a5f1.png">
