### PR TITLE
Fixes selection of mechanism other

### DIFF
--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -35,6 +35,23 @@ export enum PatientInteractions {
   NO = 'no',
 }
 
+export enum CovidTestMechanismOptions {
+  NOSE_SWAB = 'nose_swab', // Deprecated
+  THROAT_SWAB = 'throat_swab', // Deprecated
+  NOSE_OR_THROAT_SWAB = 'nose_throat_swab',
+  SPIT_TUBE = 'spit_tube',
+  BLOOD_SAMPLE = 'blood_sample', // Deprecated
+  BLOOD_FINGER_PRICK = 'blood_sample_finger_prick',
+  BLOOD_NEEDLE_DRAW = 'blood_sample_needle_draw',
+  OTHER = 'other',
+}
+
+export enum CovidTestTrainedWorkerOptions {
+  TRAINED = 'trained',
+  UNTRAINED = 'untrained',
+  UNSURE = 'unsure',
+}
+
 export type LoginOrRegisterResponse = {
   key: string; // auth token
   user: UserResponse;

--- a/src/features/assessment/fields/CovidTestMechanismQuesion.tsx
+++ b/src/features/assessment/fields/CovidTestMechanismQuesion.tsx
@@ -1,15 +1,14 @@
 import { FormikProps } from 'formik';
 import React from 'react';
 import * as Yup from 'yup';
-import { ImageSourcePropType } from 'react-native';
 
 import i18n from '@covid/locale/i18n';
-import { FieldWrapper } from '@covid/components/Screen';
 import DropdownField from '@covid/components/DropdownField';
 import { LifestyleRequest } from '@covid/core/assessment/dto/LifestyleRequest';
 import { GenericTextField } from '@covid/components/GenericTextField';
 import { CovidTest } from '@covid/core/user/dto/CovidTestContracts';
 import { fingerPrick, noseSwab, otherTest, spit, syringe } from '@assets';
+import { CovidTestMechanismOptions, CovidTestTrainedWorkerOptions } from '@covid/core/user/dto/UserAPIContracts';
 
 export interface CovidTestMechanismData {
   mechanism: string;
@@ -32,27 +31,33 @@ export const CovidTestMechanismQuestion: CovidTestMechanismQuestion<Props, Covid
   const { formikProps, test } = props;
 
   const mechanismItems = [
-    { label: i18n.t('covid-test.picker-nose-throat-swab'), value: 'nose_throat_swab' },
-    ...(test?.mechanism === 'nose_swab' ? [{ label: i18n.t('covid-test.picker-nose-swab'), value: 'nose_swab' }] : []),
-    ...(test?.mechanism === 'throat_swab'
-      ? [{ label: i18n.t('covid-test.picker-throat-swab'), value: 'throat_swab' }]
+    { label: i18n.t('covid-test.picker-nose-throat-swab'), value: CovidTestMechanismOptions.NOSE_OR_THROAT_SWAB },
+    ...(test?.mechanism === CovidTestMechanismOptions.NOSE_SWAB
+      ? [{ label: i18n.t('covid-test.picker-nose-swab'), value: CovidTestMechanismOptions.NOSE_SWAB }]
       : []),
-    { label: i18n.t('covid-test.picker-saliva-sample'), value: 'spit_tube' },
+    ...(test?.mechanism === CovidTestMechanismOptions.THROAT_SWAB
+      ? [{ label: i18n.t('covid-test.picker-throat-swab'), value: CovidTestMechanismOptions.THROAT_SWAB }]
+      : []),
+    { label: i18n.t('covid-test.picker-saliva-sample'), value: CovidTestMechanismOptions.SPIT_TUBE },
     ...(test?.mechanism === 'blood_sample'
-      ? [{ label: i18n.t('covid-test.picker-blood-sample'), value: 'blood_sample' }]
+      ? [{ label: i18n.t('covid-test.picker-blood-sample'), value: CovidTestMechanismOptions.BLOOD_SAMPLE }]
       : []),
-    { label: i18n.t('covid-test.picker-finger-prick'), value: 'blood_sample_finger_prick' },
-    { label: i18n.t('covid-test.picker-blood-draw'), value: 'blood_sample_needle_draw' },
-    { label: i18n.t('covid-test.picker-other'), value: 'other' },
+    { label: i18n.t('covid-test.picker-finger-prick'), value: CovidTestMechanismOptions.BLOOD_FINGER_PRICK },
+    { label: i18n.t('covid-test.picker-blood-draw'), value: CovidTestMechanismOptions.BLOOD_NEEDLE_DRAW },
+    { label: i18n.t('covid-test.picker-other'), value: CovidTestMechanismOptions.OTHER },
   ];
 
   const trainedWorkerItems = [
-    { label: i18n.t('picker-yes'), value: 'trained' },
-    { label: i18n.t('picker-no'), value: 'untrained' },
-    { label: i18n.t('picker-unsure'), value: 'unsure' },
+    { label: i18n.t('picker-yes'), value: CovidTestTrainedWorkerOptions.TRAINED },
+    { label: i18n.t('picker-no'), value: CovidTestTrainedWorkerOptions.UNTRAINED },
+    { label: i18n.t('picker-unsure'), value: CovidTestTrainedWorkerOptions.UNSURE },
   ];
 
-  const noIcons = ['nose_swab', 'throat_swab', 'blood_sample'];
+  const noIcons: string[] = [
+    CovidTestMechanismOptions.NOSE_SWAB,
+    CovidTestMechanismOptions.THROAT_SWAB,
+    CovidTestMechanismOptions.BLOOD_SAMPLE,
+  ];
   let mechanismItemIcons = undefined;
   if (!test || (test && !noIcons.includes(test.mechanism))) {
     mechanismItemIcons = [noseSwab, spit, fingerPrick, syringe, otherTest];
@@ -91,22 +96,11 @@ export const CovidTestMechanismQuestion: CovidTestMechanismQuestion<Props, Covid
 };
 
 CovidTestMechanismQuestion.initialFormValues = (test?: CovidTest): CovidTestMechanismData => {
-  const valid_options = [
-    'nose_throat_swab',
-    'nose_swab',
-    'throat_swab',
-    'spit_tube',
-    'blood_sample',
-    'blood_sample_finger_prick',
-    'blood_sample_needle_draw',
-    'other',
-  ];
-
   let mechanism = '';
   let mechanismSpecify = '';
 
   if (test?.id) {
-    if (valid_options.includes(test.mechanism)) {
+    if (Object.values(CovidTestMechanismOptions).includes(test.mechanism as CovidTestMechanismOptions)) {
       mechanism = test.mechanism;
     } else {
       mechanism = 'other';
@@ -132,7 +126,7 @@ CovidTestMechanismQuestion.schema = () => {
     mechanismSpecify: Yup.string(),
     trainedWorker: Yup.string().when('mechanism', {
       is: (mechanism) => {
-        return mechanism === 'nose_throat_swab';
+        return mechanism === CovidTestMechanismOptions.NOSE_OR_THROAT_SWAB;
       },
       then: Yup.string().required(i18n.t('please-select-option')),
     }),

--- a/src/features/assessment/fields/CovidTestMechanismQuesion.tsx
+++ b/src/features/assessment/fields/CovidTestMechanismQuesion.tsx
@@ -91,9 +91,32 @@ export const CovidTestMechanismQuestion: CovidTestMechanismQuestion<Props, Covid
 };
 
 CovidTestMechanismQuestion.initialFormValues = (test?: CovidTest): CovidTestMechanismData => {
+  const valid_options = [
+    'nose_throat_swab',
+    'nose_swab',
+    'throat_swab',
+    'spit_tube',
+    'blood_sample',
+    'blood_sample_finger_prick',
+    'blood_sample_needle_draw',
+    'other',
+  ];
+
+  let mechanism = '';
+  let mechanismSpecify = '';
+
+  if (test?.id) {
+    if (valid_options.includes(test.mechanism)) {
+      mechanism = test.mechanism;
+    } else {
+      mechanism = 'other';
+      mechanismSpecify = test.mechanism;
+    }
+  }
+
   return {
-    mechanism: test?.mechanism ? test.mechanism : '',
-    mechanismSpecify: '',
+    mechanism,
+    mechanismSpecify,
     trainedWorker: test?.trained_worker ? test.trained_worker : '',
   };
 };


### PR DESCRIPTION
# Description

Where the Covid Test mechanism dropdown is set to "other" and then the user specifies free text, this free text is stored in the same field as the dropdown options (which should have been a typed enum). 

This then breaks, when you goto edit the Covid Test...

This PR fixes that by checking the mechanism value is one of the valid values for the dropdown. 


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Screenshot 2020-07-02 at 10 52 00](https://user-images.githubusercontent.com/7824212/86344661-7127df00-bc52-11ea-8096-9f7f2f664f64.png)


## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
