### PR TITLE
Fix bug not waiting to retrieve patient

### DIFF
--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -63,8 +63,8 @@ export class SplashScreen extends Component<Props, SplashState> {
     }
   }
 
-  initAppState() {
-    appCoordinator.init(this.props.navigation as NavigationType);
+  async initAppState() {
+    await appCoordinator.init(this.props.navigation as NavigationType);
     appCoordinator.gotoNextScreen(this.props.route.name);
   }
 


### PR DESCRIPTION
# Description

When refactoring the navigation + splash screen I introduced a bug by not awaiting an async call to fetch the logged in patient ID. This would then navigate the user to the welcome1 screen.