### PR TITLE
Fix splash screen issue.

### DIFF
--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -407,7 +407,7 @@ export default class UserService extends ApiClientBase implements ICoreService {
   public async getProfile(): Promise<UserResponse> {
     const localUser = await AsyncStorageService.GetStoredData();
     if (!localUser) {
-      this.logout();
+      await this.logout();
       throw Error("User not found. Can't fetch profile");
     }
 

--- a/src/features/SplashScreen.tsx
+++ b/src/features/SplashScreen.tsx
@@ -64,8 +64,12 @@ export class SplashScreen extends Component<Props, SplashState> {
   }
 
   async initAppState() {
-    await appCoordinator.init(this.props.navigation as NavigationType);
-    appCoordinator.gotoNextScreen(this.props.route.name);
+    try {
+      await appCoordinator.init(this.props.navigation as NavigationType);
+      appCoordinator.gotoNextScreen(this.props.route.name);
+    } catch (error) {
+      appCoordinator.gotoNextScreen(this.props.route.name);
+    }
   }
 
   private reloadAppState = async () => {


### PR DESCRIPTION
# Description

Fix splash screen issue. 
Call to `await appCoordinator.init(this.props.navigation as NavigationType)` can throw an error and so you can get stuck on the SplashScreen. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
