### PR TITLE
Wire Diet Study Screens with a DietStudyCoordinator

### DIFF
--- a/src/Services.ts
+++ b/src/Services.ts
@@ -11,6 +11,7 @@ import { AssessmentApiClient } from './core/assessment/AssessmentApiClient';
 import AssessmentService from './core/assessment/AssessmentService';
 import ReduxAssessmentState from './core/assessment/AssessmentState';
 import ExpoPushTokenEnvironment from './core/push-notifications/expo';
+import { DietStudyApiClient } from '@covid/core/diet-study/DietStudyApiClient';
 
 const apiClient = new ApiClient();
 const localStorageService = new LocalStorageService();
@@ -31,3 +32,4 @@ export const pushNotificationService = new PushNotificationService(
 const assessmentState = new ReduxAssessmentState();
 const assessmentApiClient = new AssessmentApiClient(apiClient);
 export const assessmentService = new AssessmentService(assessmentApiClient, assessmentState);
+export const dietStudyApiClient = new DietStudyApiClient(apiClient);

--- a/src/Services.ts
+++ b/src/Services.ts
@@ -6,12 +6,12 @@ import PushNotificationService, {
 } from '@covid/core/push-notifications/PushNotificationService';
 import ContentService from '@covid/core/content/ContentService';
 import { ContentApiClient } from '@covid/core/content/ContentApiClient';
+import { DietStudyApiClient } from '@covid/core/diet-study/DietStudyApiClient';
 
 import { AssessmentApiClient } from './core/assessment/AssessmentApiClient';
 import AssessmentService from './core/assessment/AssessmentService';
 import ReduxAssessmentState from './core/assessment/AssessmentState';
 import ExpoPushTokenEnvironment from './core/push-notifications/expo';
-import { DietStudyApiClient } from '@covid/core/diet-study/DietStudyApiClient';
 
 const apiClient = new ApiClient();
 const localStorageService = new LocalStorageService();

--- a/src/core/diet-study/DietStudyApiClient.ts
+++ b/src/core/diet-study/DietStudyApiClient.ts
@@ -16,17 +16,17 @@ export class DietStudyApiClient implements IDietStudyRemoteClient {
     this.apiClient = apiClient;
   }
 
-  updateDietStudy(studyId: string, payload: DietStudyRequest): Promise<DietStudyResponse> {
+  updateDietStudy(studyId: string, payload: Partial<DietStudyRequest>): Promise<DietStudyResponse> {
     const url = `${API_URL}${studyId}/`;
-    return this.apiClient.patch<DietStudyRequest, DietStudyResponse>(url, payload);
+    return this.apiClient.patch<DietStudyRequest, DietStudyResponse>(url, payload as DietStudyRequest);
   }
 
-  addDietStudy(patientId: string, payload: DietStudyRequest): Promise<DietStudyResponse> {
+  addDietStudy(patientId: string, payload: Partial<DietStudyRequest>): Promise<DietStudyResponse> {
     payload = {
       ...payload,
       patient: patientId,
       version: appConfig.dietStudyVersion,
     };
-    return this.apiClient.post<DietStudyRequest, DietStudyResponse>(API_URL, payload);
+    return this.apiClient.post<DietStudyRequest, DietStudyResponse>(API_URL, payload as DietStudyRequest);
   }
 }

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -1,0 +1,68 @@
+import { StackNavigationProp } from '@react-navigation/stack';
+
+import { PatientStateType } from '@covid/core/patient/PatientState';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
+import { ScreenParamList } from '@covid/features/ScreenParamList';
+import { AppCoordinator } from '@covid/features/AppCoordinator';
+
+type ScreenName = keyof ScreenParamList;
+type ScreenFlow = {
+  [key in ScreenName]: () => void;
+};
+
+export type NavigationType = StackNavigationProp<ScreenParamList, keyof ScreenParamList>;
+
+export type DietStudyData = {
+  recentDietStudyId?: string;
+  febDietStudyId?: string;
+  currentPatient: PatientStateType;
+};
+
+export class DietStudyCoordinator {
+  appCoordinator: AppCoordinator;
+  navigation: NavigationType;
+  userService: ICoreService;
+  dietStudyData: DietStudyData;
+
+  screenFlow: ScreenFlow = {
+    DietStudyAboutYou: () => {
+      this.navigation.navigate('DietStudyYourLifestyle', { dietStudyData: this.dietStudyData });
+    },
+    DietStudyYourLifestyle: () => {
+      this.navigation.navigate('DietStudyTypicalDiet', { dietStudyData: this.dietStudyData });
+    },
+    DietStudyTypicalDiet: () => {
+      this.navigation.navigate('DietStudyThankYou', { dietStudyData: this.dietStudyData });
+    },
+    DietStudyThankYou: () => {
+      this.appCoordinator.startAssessmentFlow(this.dietStudyData.currentPatient);
+    },
+  } as ScreenFlow;
+
+  init = (
+    appCoordinator: AppCoordinator,
+    navigation: NavigationType,
+    dietStudyData: DietStudyData,
+    userService: ICoreService
+  ) => {
+    this.appCoordinator = appCoordinator;
+    this.navigation = navigation;
+    this.dietStudyData = dietStudyData;
+    this.userService = userService;
+  };
+
+  startDietStudy = () => {
+    this.navigation.navigate('DietStudyAboutYou', { dietStudyData: this.dietStudyData });
+  };
+
+  gotoNextScreen = (screenName: ScreenName) => {
+    if (this.screenFlow[screenName]) {
+      this.screenFlow[screenName]();
+    } else {
+      console.error('[ROUTE] no next route found for:', screenName);
+    }
+  };
+}
+
+const dietStudyCoordinator = new DietStudyCoordinator();
+export default dietStudyCoordinator;

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -10,6 +10,7 @@ import patientCoordinator from '@covid/core/patient/PatientCoordinator';
 import { Services } from '@covid/provider/services.types';
 import { lazyInject } from '@covid/provider/services';
 import { IContentService } from '@covid/core/content/ContentService';
+import dietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
 
 import { ScreenParamList } from './ScreenParamList';
 
@@ -130,6 +131,11 @@ export class AppCoordinator {
     assessmentCoordinator.startAssessment();
   }
 
+  startDietStudyFlow(currentPatient: PatientStateType) {
+    dietStudyCoordinator.init(this, this.navigation, { currentPatient }, this.userService);
+    dietStudyCoordinator.startDietStudy();
+  }
+
   gotoNextScreen = (screenName: ScreenName) => {
     if (this.screenFlow[screenName]) {
       this.screenFlow[screenName]();
@@ -156,6 +162,10 @@ export class AppCoordinator {
   async setPatientId(patientId: string) {
     this.patientId = patientId;
     this.currentPatient = await this.userService.getCurrentPatient(this.patientId!);
+  }
+
+  goToDietStart() {
+    this.startDietStudyFlow(this.currentPatient);
   }
 
   goToUKValidationStudy() {

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -13,6 +13,7 @@ import PushNotificationService from '@covid/core/push-notifications/PushNotifica
 import { useInjection } from '@covid/provider/services.hooks';
 import { Services } from '@covid/provider/services.types';
 import { NumberIndicator } from '@covid/components/Stats/NumberIndicator';
+import appCoordinator, { AppCoordinator } from '@covid/features/AppCoordinator';
 
 type MenuItemProps = {
   label: string;
@@ -110,6 +111,12 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
       : props.navigation.navigate('PrivacyPolicyUS', { viewOnly: true });
   }
 
+  function openDietStudy() {
+    console.log('1');
+    appCoordinator.goToDietStart();
+    // props.navigation.navigate('DietStudyAboutYou'); // TODO - Wire Navigations
+  }
+
   function showResearchUpdates() {
     Analytics.track(events.CLICK_DRAWER_MENU_ITEM, {
       name: DrawerMenuItem.RESEARCH_UPDATE,
@@ -147,7 +154,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
           label={i18n.t('diet-study.drawer-menu-item')}
           indicator={2}
           onPress={() => {
-            props.navigation.navigate('DietStudyAboutYou'); // TODO - Wire Navigations
+            openDietStudy();
           }}
         />
         <MenuItem

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -2,6 +2,7 @@ import { CovidTest } from '@covid/core/user/dto/CovidTestContracts';
 import { AssessmentData } from '@covid/core/assessment/AssessmentCoordinator';
 import { Profile } from '@covid/features/multi-profile/SelectProfileScreen';
 import { PatientData } from '@covid/core/patient/PatientCoordinator';
+import { DietStudyData } from '@covid/core/diet-study/DietStudyCoordinator';
 
 export enum ConsentType {
   Adult = 'adult',
@@ -65,11 +66,11 @@ export type ScreenParamList = {
   VaccineRegistryInfo: { assessmentData: AssessmentData };
 
   // DietStudy
-  DietStudyAboutYou: { assessmentData: AssessmentData };
   DietStudyIntro: { assessmentData: AssessmentData };
-  DietStudyThankYou: { assessmentData: AssessmentData };
-  DietStudyTypicalDiet: { assessmentData: AssessmentData };
-  DietStudyYourLifestyle: { assessmentData: AssessmentData };
+  DietStudyAboutYou: { dietStudyData: DietStudyData };
+  DietStudyThankYou: { dietStudyData: DietStudyData };
+  DietStudyTypicalDiet: { dietStudyData: DietStudyData };
+  DietStudyYourLifestyle: { dietStudyData: DietStudyData };
 
   // Completion screens
   ThankYou: undefined;

--- a/src/features/diet-study/DietStudyAboutYouScreen.tsx
+++ b/src/features/diet-study/DietStudyAboutYouScreen.tsx
@@ -50,7 +50,14 @@ export default class DietStudyAboutYouScreen extends Component<Props, State> {
     console.log(infos);
 
     try {
-      await dietStudyApiClient.addDietStudy(this.props.route.params.dietStudyData.currentPatient.patientId, infos);
+      const response = await dietStudyApiClient.addDietStudy(
+        this.props.route.params.dietStudyData.currentPatient.patientId,
+        infos
+      );
+
+      // Set StudyID from server response
+      dietStudyCoordinator.dietStudyData.recentDietStudyId = response.id;
+
       this.setState({ submitting: false });
       dietStudyCoordinator.gotoNextScreen(this.props.route.name);
     } catch (error) {

--- a/src/features/diet-study/DietStudyTypicalDietScreen.tsx
+++ b/src/features/diet-study/DietStudyTypicalDietScreen.tsx
@@ -2,50 +2,101 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { Component } from 'react';
 import { StyleSheet } from 'react-native';
+import * as Yup from 'yup';
+import { Formik } from 'formik';
+import { Form } from 'native-base';
 
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
-import { HeaderText } from '@covid/components/Text';
-import AssessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
-import { assessmentService } from '@covid/Services';
+import { BrandedButton, ErrorText, HeaderText } from '@covid/components/Text';
+import { dietStudyApiClient } from '@covid/Services';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
+import { DietStudyRequest } from '@covid/core/diet-study/dto/DietStudyRequest';
+import dietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
+import i18n from '@covid/locale/i18n';
+import { ValidationError } from '@covid/components/ValidationError';
+
+interface FormData {}
 
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'DietStudyTypicalDiet'>;
   route: RouteProp<ScreenParamList, 'DietStudyTypicalDiet'>;
 };
 
-export default class DietStudyTypicalDietScreen extends Component<Props> {
+type State = {
+  errorMessage: string;
+  submitting: boolean;
+};
+
+const initialState: State = {
+  errorMessage: '',
+  submitting: false,
+};
+
+export default class DietStudyTypicalDietScreen extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    AssessmentCoordinator.resetNavigation(props.navigation);
+    this.state = initialState;
   }
 
-  private async updateAssessment(status: string, isComplete = false) {
-    const { assessmentId } = AssessmentCoordinator.assessmentData;
-    const assessment = {
-      location: status,
-    };
+  async submitDietStudy(infos: Partial<DietStudyRequest>) {
+    console.log(infos);
 
-    if (isComplete) {
-      await assessmentService.completeAssessment(assessmentId!, assessment);
-    } else {
-      await assessmentService.saveAssessment(assessmentId!, assessment);
+    try {
+      await dietStudyApiClient.addDietStudy(this.props.route.params.dietStudyData.currentPatient.patientId, infos);
+      this.setState({ submitting: false });
+      dietStudyCoordinator.gotoNextScreen(this.props.route.name);
+    } catch (error) {
+      this.setState({ errorMessage: i18n.t('something-went-wrong') });
+      throw error;
     }
   }
 
+  private async updateDietStudy(formData: FormData) {
+    if (this.state.submitting) return;
+    this.setState({ submitting: true });
+
+    const infos = {
+      ...{},
+    } as Partial<DietStudyRequest>;
+
+    await this.submitDietStudy(infos);
+  }
+
   render() {
-    const currentPatient = AssessmentCoordinator.assessmentData.currentPatient;
+    const registerSchema = Yup.object().shape({});
 
     return (
-      <Screen profile={currentPatient.profile} navigation={this.props.navigation}>
+      <Screen navigation={this.props.navigation}>
         <Header>
-          <HeaderText>{}</HeaderText>
+          <HeaderText>{i18n.t('diet-study.typical-diet.title')}</HeaderText>
         </Header>
 
         <ProgressBlock>
           <ProgressStatus step={3} maxSteps={3} />
         </ProgressBlock>
+
+        <Formik
+          initialValues={{}}
+          validationSchema={registerSchema}
+          onSubmit={(values: FormData) => {
+            return this.updateDietStudy(values);
+          }}>
+          {(props) => {
+            return (
+              <Form>
+                <ErrorText>{this.state.errorMessage}</ErrorText>
+                {!!Object.keys(props.errors).length && props.submitCount > 0 && (
+                  <ValidationError error={i18n.t('validation-error-text')} />
+                )}
+
+                <BrandedButton onPress={props.handleSubmit} hideLoading={!props.isSubmitting}>
+                  {i18n.t('diet-study.next-section')}
+                </BrandedButton>
+              </Form>
+            );
+          }}
+        </Formik>
       </Screen>
     );
   }

--- a/src/features/diet-study/fields/EatingWindowQuestions.tsx
+++ b/src/features/diet-study/fields/EatingWindowQuestions.tsx
@@ -55,8 +55,8 @@ export const EatingWindowQuestions: EatingWindowQuestions<Props, EatingWindowDat
   ];
 
   const meridianIndicatorItems = [
-    { label: 'a.m.', value: 'am' },
-    { label: 'p.m.', value: 'pm' },
+    { label: 'a.m.', value: 'AM' },
+    { label: 'p.m.', value: 'PM' },
   ];
 
   return (
@@ -130,10 +130,10 @@ EatingWindowQuestions.initialFormValues = (): EatingWindowData => {
   return {
     startHour: '08',
     startMinute: '00',
-    startMeridianIndicator: 'am',
+    startMeridianIndicator: 'AM',
     endHour: '09',
     endMinute: '00',
-    endMeridianIndicator: 'pm',
+    endMeridianIndicator: 'PM',
   };
 };
 
@@ -142,8 +142,14 @@ EatingWindowQuestions.schema = () => {
 };
 
 EatingWindowQuestions.createDTO = (formData: EatingWindowData): Partial<DietStudyRequest> => {
+  function convertTo24(hours: string) {
+    const n = (parseInt(hours, 10) + 12) % 24;
+    return n.toString();
+  }
+
   function toTime(hours: string, mins: string, meridianIndicator: string): string {
-    return `${hours}:${mins} ${meridianIndicator}`;
+    const hours24 = meridianIndicator === 'PM' ? convertTo24(hours) : hours;
+    return `${hours24}:${mins}`;
   }
 
   return {


### PR DESCRIPTION
# Description

- Creates a basic dietStudyCoordinator.
- Wires up the DrawerMenu to the first 2 question screens and submit data to the survery. 

TODO:
 - We need to figure out a way of knowing if you're on the first pass (possibly set `display_name = June`) or if we are on the second pass? 

- Fixes problem with 24 hours times expected on the server

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
