### PR TITLE
Disable Fastlane CI Step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ jobs:
     steps:
       - build
       - publish_to_expo
-      - deploy_ios
-      - deploy_android
+      # - deploy_ios
+      # - deploy_android
   legacy_deploy:
     executor: node
     working_directory: ~/covid-react


### PR DESCRIPTION
Disables the build + publish to App Center. Unnecessarily bloats the release process, given that no one is using App Center in the team.