### PR TITLE
bug: set default patient profile before starting diet study

### DIFF
--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -47,8 +47,21 @@ export class DietStudyCoordinator {
     this.userService = userService;
   };
 
-  startDietStudy = () => {
-    NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
+  startIntro = () => {
+    NavigatorService.navigate('DietStudyIntro', this.dietStudyParam);
+  };
+
+  startDietStudy = async () => {
+    // Set default patient to first patient profile,
+    // user can navigate here from drawer menu without picking a profile
+
+    // TODO: Tell user they don't have a profile yet? (Is that a possbility?)
+    try {
+      const profile = await this.userService.myPatientProfile();
+      const currentPatient = await this.userService.getPatientState(profile!.id);
+      this.dietStudyData = { currentPatient };
+      NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
+    } catch (_) {}
   };
 
   gotoNextScreen = (screenName: ScreenName) => {

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -6,6 +6,7 @@ import i18n from '@covid/locale/i18n';
 import { AvatarName } from '@covid/utils/avatar';
 import { getDaysAgo } from '@covid/utils/datetime';
 import appConfig from '@covid/appConfig';
+import { Profile } from '@covid/features/multi-profile/SelectProfileScreen';
 
 import { AsyncStorageService } from '../AsyncStorageService';
 import { ConfigType, getCountryConfig } from '../Config';
@@ -66,6 +67,7 @@ export interface IConsentService {
 }
 
 export interface IPatientService {
+  myPatientProfile(): Promise<Profile | null>;
   listPatients(): Promise<any>;
   createPatient(infos: Partial<PatientInfosRequest>): Promise<any>;
   updatePatient(patientId: string, infos: Partial<PatientInfosRequest>): Promise<any>;
@@ -246,9 +248,20 @@ export default class UserService extends ApiClientBase implements ICoreService {
     return this.client.patch(`/consent/`, payload);
   }
 
+  public async myPatientProfile(): Promise<Profile | null> {
+    try {
+      const data = (await this.client.get(`/patient_list/`)).data as Profile[];
+      console.log(data);
+      return !!data && data.length > 0 ? data[0] : null;
+    } catch (error) {
+      handleServiceError(error);
+    }
+    return null;
+  }
+
   public async listPatients() {
     try {
-      const response = await this.client.get(`/patient_list/`);
+      const { response } = await this.client.get(`/patient_list/`);
       return response;
     } catch (error) {
       handleServiceError(error);


### PR DESCRIPTION
# Description

Make API to fetch and set first patient profile when user selected Diet Study from Drawer menu

TODO: Show user there is no profiles?

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`
