### PR TITLE
feat: show diet study intro if needed, after profile is selected

### DIFF
--- a/src/core/AsyncStorageService.ts
+++ b/src/core/AsyncStorageService.ts
@@ -10,6 +10,7 @@ const USER_COUNT = 'userCount';
 const USER_COUNTRY = 'userCountry';
 const CONSENT_SIGNED = 'consentSigned';
 const PUSH_TOKEN = 'pushToken';
+const SKIP_DIET_STUDY = 'skipDietStudy';
 
 const USER_PROFILE = 'userProfile';
 const ASKED_COUNTRY = 'askedCountry';
@@ -183,5 +184,23 @@ export class AsyncStorageService {
     } catch (err) {
       return null;
     }
+  }
+
+  // Diet Study Consent
+
+  static async getSkipDietStudy(): Promise<boolean | null> {
+    try {
+      await AsyncStorage.removeItem(SKIP_DIET_STUDY);
+      const value = await AsyncStorage.getItem(SKIP_DIET_STUDY);
+      return value !== null ? value === 'true' : null;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  static async setSkipDietStudy(skip: boolean) {
+    try {
+      await AsyncStorage.setItem(SKIP_DIET_STUDY, JSON.stringify(skip));
+    } catch (err) {}
   }
 }

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -51,7 +51,6 @@ export class DietStudyCoordinator {
 
   startDietStudy = async () => {
     const shouldSkip = await AsyncStorageService.getSkipDietStudy();
-    console.log('hi', shouldSkip);
     // If skip is null, user has not answered.
     // If skip is false, user is opted in .
     if (!shouldSkip) {

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -5,6 +5,7 @@ import { AppCoordinator } from '@covid/features/AppCoordinator';
 import NavigatorService from '@covid/NavigatorService';
 
 import { AsyncStorageService } from '../AsyncStorageService';
+
 import { IDietStudyRemoteClient } from './DietStudyApiClient';
 
 type ScreenName = keyof ScreenParamList;

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -47,6 +47,10 @@ export class DietStudyCoordinator {
     this.userService = userService;
   };
 
+  startIntro = () => {
+    NavigatorService.navigate('DietStudyIntro', this.dietStudyParam);
+  };
+
   startDietStudy = () => {
     NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
   };

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -4,6 +4,8 @@ import { ScreenParamList } from '@covid/features/ScreenParamList';
 import { AppCoordinator } from '@covid/features/AppCoordinator';
 import NavigatorService from '@covid/NavigatorService';
 
+import { AsyncStorageService } from '../AsyncStorageService';
+
 type ScreenName = keyof ScreenParamList;
 type ScreenFlow = {
   [key in ScreenName]: () => void;
@@ -47,21 +49,15 @@ export class DietStudyCoordinator {
     this.userService = userService;
   };
 
-  startIntro = () => {
-    NavigatorService.navigate('DietStudyIntro', this.dietStudyParam);
-  };
-
   startDietStudy = async () => {
-    // Set default patient to first patient profile,
-    // user can navigate here from drawer menu without picking a profile
-
-    // TODO: Tell user they don't have a profile yet? (Is that a possbility?)
-    try {
-      const profile = await this.userService.myPatientProfile();
-      const currentPatient = await this.userService.getPatientState(profile!.id);
-      this.dietStudyData = { currentPatient };
-      NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
-    } catch (_) {}
+    const shouldSkip = await AsyncStorageService.getSkipDietStudy();
+    console.log('hi', shouldSkip);
+    // If skip is null, user has not answered.
+    // If skip is false, user is opted in .
+    if (!shouldSkip) {
+      return NavigatorService.navigate('DietStudyIntro', this.dietStudyParam);
+    }
+    NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
   };
 
   gotoNextScreen = (screenName: ScreenName) => {

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -143,9 +143,8 @@ export class AppCoordinator {
     this.patientId = currentPatient.patientId;
     if (isGBCountry() && mainProfile && (await this.userService.shouldAskForValidationStudy(false))) {
       this.goToUKValidationStudy();
-    } else if (await this.shouldShowDietStudyIntro(currentPatient)) {
-      dietStudyCoordinator.init(this, { currentPatient }, this.userService);
-      return dietStudyCoordinator.startIntro();
+    } else if (await this.shouldShowDietStudy(currentPatient)) {
+      this.startDietStudyFlow(currentPatient);
     } else {
       this.startAssessmentFlow(currentPatient);
     }
@@ -184,7 +183,7 @@ export class AppCoordinator {
     NavigatorService.navigate('CreateProfile', { avatarName });
   }
 
-  private async shouldShowDietStudyIntro(currentPatient: PatientStateType): Promise<boolean> {
+  private async shouldShowDietStudy(currentPatient: PatientStateType): Promise<boolean> {
     const skipDietStudy = await AsyncStorageService.getSkipDietStudy();
     return !skipDietStudy && currentPatient.profile.name === 'Me';
   }

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -12,6 +12,7 @@ import { lazyInject } from '@covid/provider/services';
 import { IContentService } from '@covid/core/content/ContentService';
 import dietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
 import NavigatorService from '@covid/NavigatorService';
+import { AsyncStorageService } from '@covid/core/AsyncStorageService';
 
 import { ScreenParamList } from './ScreenParamList';
 
@@ -142,6 +143,9 @@ export class AppCoordinator {
     this.patientId = currentPatient.patientId;
     if (isGBCountry() && mainProfile && (await this.userService.shouldAskForValidationStudy(false))) {
       this.goToUKValidationStudy();
+    } else if (await this.shouldShowDietStudyIntro(currentPatient)) {
+      dietStudyCoordinator.init(this, { currentPatient }, this.userService);
+      return dietStudyCoordinator.startIntro();
     } else {
       this.startAssessmentFlow(currentPatient);
     }
@@ -178,6 +182,11 @@ export class AppCoordinator {
 
   goToCreateProfile(avatarName: string) {
     NavigatorService.navigate('CreateProfile', { avatarName });
+  }
+
+  private async shouldShowDietStudyIntro(currentPatient: PatientStateType): Promise<boolean> {
+    const skipDietStudy = await AsyncStorageService.getSkipDietStudy();
+    return !skipDietStudy && currentPatient.profile.name === 'Me';
   }
 }
 

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -13,7 +13,7 @@ import PushNotificationService from '@covid/core/push-notifications/PushNotifica
 import { useInjection } from '@covid/provider/services.hooks';
 import { Services } from '@covid/provider/services.types';
 import { NumberIndicator } from '@covid/components/Stats/NumberIndicator';
-import appCoordinator, { AppCoordinator } from '@covid/features/AppCoordinator';
+import appCoordinator from '@covid/features/AppCoordinator';
 
 type MenuItemProps = {
   label: string;
@@ -59,7 +59,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   useEffect(() => {
     if (userEmail !== '') return;
     fetchEmail();
-  }, [userService.hasUser]);
+  }, [userService.hasUser, setUserEmail]);
 
   function showDeleteAlert() {
     Alert.alert(
@@ -112,9 +112,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
   }
 
   function openDietStudy() {
-    console.log('1');
     appCoordinator.goToDietStart();
-    // props.navigation.navigate('DietStudyAboutYou'); // TODO - Wire Navigations
   }
 
   function showResearchUpdates() {

--- a/src/features/diet-study/DietStudyIntroScreen.tsx
+++ b/src/features/diet-study/DietStudyIntroScreen.tsx
@@ -8,6 +8,8 @@ import { ScreenParamList } from '@covid/features/ScreenParamList';
 import { TextInfoScreen } from '@covid/components/Screens/TextInfoScreen';
 import i18n from '@covid/locale/i18n';
 import Analytics, { events } from '@covid/core/Analytics';
+import DietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
+import { AsyncStorageService } from '@covid/core/AsyncStorageService';
 
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'DietStudyIntro'>;
@@ -15,18 +17,22 @@ type Props = {
 };
 
 const DietStudyIntroScreen: React.FC<Props> = ({ route, navigation }) => {
-  const currentPatient = AssessmentCoordinator.assessmentData.currentPatient;
+  const { currentPatient } = DietStudyCoordinator.dietStudyParam.dietStudyData;
 
   const accept = () => {
     Analytics.track(events.ACCEPT_DIET_STUDY);
+    DietStudyCoordinator.startDietStudy();
   };
 
   const defer = () => {
     Analytics.track(events.DEFER_DIET_STUDY);
+    navigation.pop();
   };
 
-  const skip = () => {
+  const skip = async () => {
+    await AsyncStorageService.setSkipDietStudy(true);
     Analytics.track(events.DECLINE_DIET_STUDY);
+    navigation.pop();
   };
 
   return (
@@ -39,7 +45,7 @@ const DietStudyIntroScreen: React.FC<Props> = ({ route, navigation }) => {
       primaryButtonLabel={i18n.t('diet-study.intro.cta-yes')}
       secondaryButtonLabel={i18n.t('diet-study.intro.cta-no-later')}
       primaryButtonAction={accept}
-      secondaryButtonAction={skip}
+      secondaryButtonAction={defer}
       bottomView={<StickyBottomButton label={i18n.t('diet-study.intro.cta-no-never')} onPress={skip} />}
     />
   );

--- a/src/features/diet-study/DietStudyIntroScreen.tsx
+++ b/src/features/diet-study/DietStudyIntroScreen.tsx
@@ -19,7 +19,8 @@ type Props = {
 const DietStudyIntroScreen: React.FC<Props> = ({ route, navigation }) => {
   const { currentPatient } = DietStudyCoordinator.dietStudyParam.dietStudyData;
 
-  const accept = () => {
+  const accept = async () => {
+    await AsyncStorageService.setSkipDietStudy(false);
     Analytics.track(events.ACCEPT_DIET_STUDY);
     DietStudyCoordinator.startDietStudy();
   };


### PR DESCRIPTION
# Description

Store diet study skip option in local storage.

TODO: Decide on API call to store value in patient profile?

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`
