### PR TITLE
feat: made diet study api injectable. uses to check has user complete…

### DIFF
--- a/src/Services.ts
+++ b/src/Services.ts
@@ -6,7 +6,6 @@ import PushNotificationService, {
 } from '@covid/core/push-notifications/PushNotificationService';
 import ContentService from '@covid/core/content/ContentService';
 import { ContentApiClient } from '@covid/core/content/ContentApiClient';
-import { DietStudyApiClient } from '@covid/core/diet-study/DietStudyApiClient';
 
 import { AssessmentApiClient } from './core/assessment/AssessmentApiClient';
 import AssessmentService from './core/assessment/AssessmentService';
@@ -32,4 +31,3 @@ export const pushNotificationService = new PushNotificationService(
 const assessmentState = new ReduxAssessmentState();
 const assessmentApiClient = new AssessmentApiClient(apiClient);
 export const assessmentService = new AssessmentService(assessmentApiClient, assessmentState);
-export const dietStudyApiClient = new DietStudyApiClient(apiClient);

--- a/src/core/diet-study/DietStudyApiClient.ts
+++ b/src/core/diet-study/DietStudyApiClient.ts
@@ -1,19 +1,25 @@
+import { injectable, inject } from 'inversify';
+
 import appConfig from '@covid/appConfig';
 import { IApiClient } from '@covid/core/api/ApiClient';
 import { DietStudyRequest } from '@covid/core/diet-study/dto/DietStudyRequest';
 import { DietStudyResponse } from '@covid/core/diet-study/dto/DietStudyResponse';
+import { Services } from '@covid/provider/services.types';
 
 const API_URL = '/diet_study/';
 
 export interface IDietStudyRemoteClient {
+  getDietStudies(): Promise<DietStudyResponse[]>;
   addDietStudy(patientId: string, payload: DietStudyRequest): Promise<DietStudyResponse>;
-  updateDietStudy(studyId: string, payload: DietStudyRequest): Promise<DietStudyResponse>;
+  updateDietStudy(studyId: string, payload: Partial<DietStudyRequest>): Promise<DietStudyResponse>;
 }
 
+@injectable()
 export class DietStudyApiClient implements IDietStudyRemoteClient {
-  apiClient: IApiClient;
-  constructor(apiClient: IApiClient) {
-    this.apiClient = apiClient;
+  constructor(@inject(Services.Api) private apiClient: IApiClient) {}
+
+  getDietStudies(): Promise<DietStudyResponse[]> {
+    return this.apiClient.get<DietStudyResponse[]>(API_URL);
   }
 
   updateDietStudy(studyId: string, payload: Partial<DietStudyRequest>): Promise<DietStudyResponse> {

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -10,6 +10,7 @@ import patientCoordinator from '@covid/core/patient/PatientCoordinator';
 import { Services } from '@covid/provider/services.types';
 import { lazyInject } from '@covid/provider/services';
 import { IContentService } from '@covid/core/content/ContentService';
+import { IDietStudyRemoteClient } from '@covid/core/diet-study/DietStudyApiClient';
 import dietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
 import NavigatorService from '@covid/NavigatorService';
 
@@ -35,6 +36,8 @@ export class AppCoordinator {
   userService: ICoreService;
   @lazyInject(Services.Content)
   contentService: IContentService;
+  @lazyInject(Services.DietStudy)
+  dietStudyService: IDietStudyRemoteClient;
   patientId: string | null = null;
   currentPatient: PatientStateType;
 
@@ -120,7 +123,7 @@ export class AppCoordinator {
   }
 
   startDietStudyFlow(currentPatient: PatientStateType) {
-    dietStudyCoordinator.init(this, { currentPatient }, this.userService);
+    dietStudyCoordinator.init(this, { currentPatient }, this.userService, this.dietStudyService);
     dietStudyCoordinator.startDietStudy();
   }
 

--- a/src/provider/services.ts
+++ b/src/provider/services.ts
@@ -1,10 +1,11 @@
 import { Container } from 'inversify';
 import getDecorators from 'inversify-inject-decorators';
 
-import ApiClient, { IApiClient } from '../core/api/ApiClient';
-import { IContentApiClient, ContentApiClient } from '../core/content/ContentApiClient';
-import ContentService, { IContentService } from '../core/content/ContentService';
-import UserService, { ICoreService } from '../core/user/UserService';
+import ApiClient, { IApiClient } from '@covid/core/api/ApiClient';
+import { IContentApiClient, ContentApiClient } from '@covid/core/content/ContentApiClient';
+import ContentService, { IContentService } from '@covid/core/content/ContentService';
+import UserService, { ICoreService } from '@covid/core/user/UserService';
+import { IDietStudyRemoteClient, DietStudyApiClient } from '@covid/core/diet-study/DietStudyApiClient';
 
 import { Services } from './services.types';
 
@@ -17,5 +18,7 @@ container.bind<ICoreService>(Services.User).to(UserService).inSingletonScope();
 container.bind<IContentApiClient>(Services.ContentApi).to(ContentApiClient).inSingletonScope();
 
 container.bind<IContentService>(Services.Content).to(ContentService).inSingletonScope();
+
+container.bind<IDietStudyRemoteClient>(Services.DietStudy).to(DietStudyApiClient).inSingletonScope();
 
 export const { lazyInject } = getDecorators(container);

--- a/src/provider/services.types.ts
+++ b/src/provider/services.types.ts
@@ -3,4 +3,5 @@ export const Services = {
   ContentApi: Symbol('ContentApi'),
   Content: Symbol('Content'),
   User: Symbol('User'),
+  DietStudy: Symbol('DietStudy'),
 };


### PR DESCRIPTION
## Description

Show thank you page when user has provided diet study answers for more than 2 time period. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

Need a better way to track progress.
- How do we know how many time period of data user need to provide?
- How do we track state of each study? (Currently we Create new database entry on the 1st page of the questions, and perform update for the 2nd and 3rd page)
