### PR TITLE
add Sign In button to Welcome 1 screen

### DIFF
--- a/src/features/register/Welcome1Screen.tsx
+++ b/src/features/register/Welcome1Screen.tsx
@@ -4,7 +4,7 @@ import { Image, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-nat
 
 import { gbMap, svMap, usMap } from '@assets';
 import { ContributionCounter } from '@covid/components/ContributionCounter';
-import { BrandedButton, RegularText } from '@covid/components/Text';
+import { BrandedButton, RegularText, ClickableText } from '@covid/components/Text';
 import { isGBCountry, isSECountry } from '@covid/core/user/UserService';
 import { cleanIntegerVal } from '@covid/utils/number';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
@@ -46,6 +46,8 @@ const Welcome1Screen: React.FC<PropsType> = ({ navigation }) => {
 
   const getFlagIcon = useCallback(getLocaleFlagIcon, [getLocaleFlagIcon]);
 
+  const onLoginPress = useCallback(() => navigation.navigate('Login'), [navigation.navigate]);
+
   const onSelectCountryPress = useCallback(() => navigation.navigate('CountrySelect', { patientId: null }), [
     navigation.navigate,
   ]);
@@ -57,6 +59,9 @@ const Welcome1Screen: React.FC<PropsType> = ({ navigation }) => {
       <ScrollView contentContainerStyle={styles.scrollView}>
         <Image testID="map" style={styles.mapImage} source={getMapImage()} />
 
+        <ClickableText testID="login" style={styles.login} onPress={onLoginPress}>
+          {i18n.t('welcome.sign-in')}
+        </ClickableText>
         <TouchableOpacity testID="selectCountry" style={styles.countryFlag} onPress={onSelectCountryPress}>
           <Image testID="flag" style={styles.flagIcon} source={getFlagIcon()} />
         </TouchableOpacity>
@@ -106,7 +111,14 @@ const styles = StyleSheet.create({
   countryFlag: {
     position: 'absolute',
     top: 56,
-    end: 32,
+    end: 24,
+  },
+  login: {
+    position: 'absolute',
+    top: 60,
+    end: 56,
+    color: colors.white,
+    marginHorizontal: 16,
   },
   covidContainer: {
     paddingHorizontal: 14,


### PR DESCRIPTION
# Description

Adds Sign In button to 1st screen as well as second

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/52913482/87518497-4426f380-c678-11ea-82b7-6ab79ed9a173.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`
