### PR TITLE
fix: show diet study nav for uk user only

### DIFF
--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -148,12 +148,14 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
             <Image style={styles.closeIcon} source={closeIcon} />
           </TouchableOpacity>
         </View>
-        <MenuItem
-          label={i18n.t('diet-study.drawer-menu-item')}
-          onPress={() => {
-            openDietStudy();
-          }}
-        />
+        {isGBCountry() && (
+          <MenuItem
+            label={i18n.t('diet-study.drawer-menu-item')}
+            onPress={() => {
+              openDietStudy();
+            }}
+          />
+        )}
         <MenuItem
           label={i18n.t('research-updates')}
           onPress={() => {


### PR DESCRIPTION
# Description

Only show drawer item for UK user

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`
