### PR TITLE
Fix/diet study tidy up

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1195,7 +1195,9 @@
       "noticed-a-change": "Have you noticed a change in your diet since February 2020, before the COVID-19 lockdown began?"
     },
 
-    "complete-cta": "Complete pre-lockdown",
+
+    "complete-pre-cta": "Complete pre-lockdown",
+    "complete-cta": "Complete",
 
     "next-box": {
       "title": "Thank you",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1115,7 +1115,8 @@
       "omega3": "Fish or omega 3 oils and capsules",
       "garlic": "Garlic supplement",
       "other": "Other",
-      "pfnts": "Prefer not to say"
+      "pfnts": "Prefer not to say",
+      "specify": "Please specify the other supplements"
     },
 
     "first-calories-label": "After waking (typically in the morning), what time do you usually first eat or drink anything other than water/black coffee and plain tea?",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1008,6 +1008,8 @@
   "diet-study": {
     "drawer-menu-item": "My study",
 
+    "required": "This is required",
+
     "intro": {
       "title": "COVID & Diet",
       "description-1": "We would like to ask you some one-off Diet and Lifestyle Questions to help researchers understand how diet can impact the likelihood and severity of getting COVID.",
@@ -1020,13 +1022,16 @@
     "next-section": "Next section",
 
     "about-you": {
-      "title": "A bit about you"
+      "title": "A bit about you",
+      "thank-you": "Thank you",
+      "answer-same-set-questions": "Now, please answer the same set of questions, but this time for February 2020, before the COVID pandemid spread."
     },
 
     "weight-label": "Your weight",
     "weight-unsure-label": "I don't know my weight",
     "was-pregnant-label": "I am/was pregnant",
     "hours-of-sleep-label": "About how many hours sleep do you get in every 24 hours (please include naps)",
+    "hours-of-sleep-placeholder": "Hours",
     "shift-work-label": "Do you work shifts outside the regular daytime hours of approximately 07.00 a.m. and 06.00 p.m.?",
     "food-security": {
       "label": "Which of the following statements best describes the food eaten in your household in the last week?",
@@ -1117,7 +1122,9 @@
     "last-calories-label": "What is the latest time of the day that you usually eat or drink anything other than water/black coffee and plain tea?",
     "eats-breakfast-label": "Do you typically consume breakfast?",
     "main-meals-label": "How many 'main' meals do you typically eat in a day (a main meal is lunch or dinner)",
+    "main-meals-placeholder": "Main meals",
     "snacks-label": "How frequently do you typically consume snacks in a day (a snack is any food consumed outside of breakfast, lunch or dinner)",
+    "snacks-placeholder": "Snacks",
     "diet": {
       "label": "Which of the below options best describes you over the four weeks (you can select more than one option)?",
       "mixed": "Mixed diet (including meat, fish or seafood)",
@@ -1181,8 +1188,11 @@
       "fast_food-2": "",
 
       "portions_of_fruit-label": "On average, how many portions of FRUIT do you eat a day? (excluding 100% fruit juice. Examples include a handful of grapes, an orange, a handful of dried fruits)",
-      "glasses_of_juice-label": "On average, how many glasses of 100% fruit or vegetable juice do you drink a day? (a standard glass is 8 ml)",
+      "portions_of_fruit-placeholder": "Portions",
+      "glasses_of_juice-label": "On average, how many glasses of 100% fruit or vegetable juice do you drink a day? (a standard glass is 240 ml)",
+      "glasses_of_juice-placeholder": "Glasses",
       "portions_of_veg-label": "On average, how many portions of VEGETABLES do you eat a day? (Examples include: 3 heaped tablespoons of carrots, a side salad, 2 spears of broccoli)",
+      "portions_of_veg-placeholder": "Portions",
 
       "milk-label": "What milk do you usually use or drink, such as in hot & cold drinks or on cereal?",
       "milk-whole": "Whole / full-fat milk",
@@ -1195,6 +1205,9 @@
       "noticed-a-change": "Have you noticed a change in your diet since February 2020, before the COVID-19 lockdown began?"
     },
 
+    "diet-changed": {
+      "not-sure": "Not sure"
+    },
 
     "complete-pre-cta": "Complete pre-lockdown",
     "complete-cta": "Complete",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1037,7 +1037,9 @@
     "next-section": "",
 
     "about-you": {
-      "title": ""
+      "title": "",
+      "thank-you": "",
+      "answer-same-set-questions": ""
     },
 
     "weight-label": "",
@@ -1198,8 +1200,11 @@
       "fast_food-2": "",
 
       "portions_of_fruit-label": "",
+      "portions_of_fruit-placeholder": "",
       "glasses_of_juice-label": "",
+      "glasses_of_juice-placeholder": "",
       "portions_of_veg-label": "",
+      "portions_of_veg-placeholder": "",
 
       "milk-label": "",
       "milk-whole": "",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1024,6 +1024,11 @@
 
   "diet-study": {
     "drawer-menu-item": "",
+    "required": "",
+
+    "diet-changed": {
+      "not-sure": ""
+    },
 
     "intro": {
       "title": "COVID & Diet",
@@ -1046,6 +1051,7 @@
     "weight-unsure-label": "",
     "was-pregnant-label": "",
     "hours-of-sleep-label": "",
+    "hours-of-sleep-placeholder": "",
     "shift-work-label": "",
     "food-security": {
       "label": "",
@@ -1136,8 +1142,13 @@
     "first-calories-label": "",
     "last-calories-label": "",
     "eats-breakfast-label": "",
+
     "main-meals-label": "",
+    "main-meals-placeholder": "",
+
     "snacks-label": "",
+    "snacks-placeholder": "",
+
     "diet": {
       "label": "",
       "mixed": "",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1129,7 +1129,8 @@
       "omega3": "",
       "garlic": "",
       "other": "",
-      "pfnts": ""
+      "pfnts": "",
+      "specify": ""
     },
 
     "first-calories-label": "",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1212,6 +1212,7 @@
       "noticed-a-change": ""
     },
 
+    "complete-pre-cta": "",
     "complete-cta": "",
 
     "next-box": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1209,6 +1209,8 @@
       "noticed-a-change": ""
     },
 
+
+    "complete-pre-cta": "",
     "complete-cta": "",
 
     "next-box": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1022,6 +1022,8 @@
   "diet-study": {
     "drawer-menu-item": "",
 
+    "required": "",
+
     "intro": {
       "title": "COVID & Diet",
       "description-1": "",
@@ -1134,7 +1136,9 @@
     "last-calories-label": "",
     "eats-breakfast-label": "",
     "main-meals-label": "",
+    "main-meals-placeholder": "",
     "snacks-label": "",
+    "snacks-placeholder": "",
     "diet": {
       "label": "",
       "mixed": "",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1129,7 +1129,8 @@
       "omega3": "",
       "garlic": "",
       "other": "",
-      "pfnts": ""
+      "pfnts": "",
+      "specify": ""
     },
 
     "first-calories-label": "",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1034,13 +1034,16 @@
     "next-section": "",
 
     "about-you": {
-      "title": ""
+      "title": "",
+      "thank-you": "",
+      "answer-same-set-questions": ""
     },
 
     "weight-label": "",
     "weight-unsure-label": "",
     "was-pregnant-label": "",
     "hours-of-sleep-label": "",
+    "hours-of-sleep-placeholder": "",
     "shift-work-label": "",
     "food-security": {
       "label": "",
@@ -1195,8 +1198,11 @@
       "fast_food-2": "",
 
       "portions_of_fruit-label": "",
+      "portions_of_fruit-placeholder": "",
       "glasses_of_juice-label": "",
+      "glasses_of_juice-placeholder": "",
       "portions_of_veg-label": "",
+      "portions_of_veg-placeholder": "",
 
       "milk-label": "",
       "milk-whole": "",
@@ -1209,6 +1215,9 @@
       "noticed-a-change": ""
     },
 
+    "diet-changed": {
+      "not-sure": ""
+    },
 
     "complete-pre-cta": "",
     "complete-cta": "",

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -84,7 +84,8 @@ export class DietStudyCoordinator {
     switch (response) {
       case DietStudyConsent.ACCEPTED: {
         Analytics.track(events.ACCEPT_DIET_STUDY);
-        NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
+        this.startDietStudy();
+        // NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
         break;
       }
       case DietStudyConsent.SKIP: {
@@ -103,7 +104,8 @@ export class DietStudyCoordinator {
   startDietStudy = async () => {
     // Check has user already completed diet studies
     const studies = await this.dietStudyService.getDietStudies();
-    if (studies.length > 1) {
+    const recentStudies = studies.filter((item) => item.display_name === CURRENT_DIET_STUDY_TIME_PERIOD);
+    if (recentStudies.length > 0) {
       NavigatorService.navigate('DietStudyThankYou', this.dietStudyParam);
     } else {
       NavigatorService.navigate('DietStudyIntro', this.dietStudyParam);

--- a/src/core/diet-study/dto/DietStudyResponse.ts
+++ b/src/core/diet-study/dto/DietStudyResponse.ts
@@ -1,3 +1,4 @@
 export type DietStudyResponse = {
   id: string;
+  display_name: string;
 };

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -14,7 +14,6 @@ import { useInjection } from '@covid/provider/services.hooks';
 import { Services } from '@covid/provider/services.types';
 import { NumberIndicator } from '@covid/components/Stats/NumberIndicator';
 import appCoordinator from '@covid/features/AppCoordinator';
-import dietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
 
 type MenuItemProps = {
   label: string;
@@ -62,14 +61,6 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
     if (userEmail !== '') return;
     fetchEmail();
   }, [userService.hasUser, setUserEmail]);
-
-  useEffect(() => {
-    const check = async () => {
-      const shouldShow = await appCoordinator.shouldShowDietStudy(appCoordinator.currentPatient);
-      setShowDietStudy(isGBCountry() && shouldShow);
-    };
-    check();
-  }, [appCoordinator.currentPatient]);
 
   function showDeleteAlert() {
     Alert.alert(

--- a/src/features/DrawerMenu.tsx
+++ b/src/features/DrawerMenu.tsx
@@ -14,6 +14,7 @@ import { useInjection } from '@covid/provider/services.hooks';
 import { Services } from '@covid/provider/services.types';
 import { NumberIndicator } from '@covid/components/Stats/NumberIndicator';
 import appCoordinator from '@covid/features/AppCoordinator';
+import dietStudyCoordinator from '@covid/core/diet-study/DietStudyCoordinator';
 
 type MenuItemProps = {
   label: string;
@@ -46,6 +47,7 @@ enum DrawerMenuItem {
 export function DrawerMenu(props: DrawerContentComponentProps) {
   const userService = useInjection<IUserService>(Services.User);
   const [userEmail, setUserEmail] = useState<string>('');
+  const [showDietStudy, setShowDietStudy] = useState<boolean>(isGBCountry());
 
   const fetchEmail = async () => {
     try {
@@ -60,6 +62,14 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
     if (userEmail !== '') return;
     fetchEmail();
   }, [userService.hasUser, setUserEmail]);
+
+  useEffect(() => {
+    const check = async () => {
+      const shouldShow = await appCoordinator.shouldShowDietStudy(appCoordinator.currentPatient);
+      setShowDietStudy(isGBCountry() && shouldShow);
+    };
+    check();
+  }, [appCoordinator.currentPatient]);
 
   function showDeleteAlert() {
     Alert.alert(
@@ -148,7 +158,7 @@ export function DrawerMenu(props: DrawerContentComponentProps) {
             <Image style={styles.closeIcon} source={closeIcon} />
           </TouchableOpacity>
         </View>
-        {isGBCountry() && (
+        {showDietStudy && (
           <MenuItem
             label={i18n.t('diet-study.drawer-menu-item')}
             onPress={() => {

--- a/src/features/diet-study/DietStudyAboutYouScreen.tsx
+++ b/src/features/diet-study/DietStudyAboutYouScreen.tsx
@@ -34,17 +34,17 @@ type Props = {
 const ThankYouSection: React.FC = () => {
   return (
     <View style={styles.thankyou}>
-      <RegularBoldText>Thank you</RegularBoldText>
+      <RegularBoldText>{i18n.t('diet-study.about-you.thank-you')}</RegularBoldText>
       <View style={{ height: 4 }} />
       <RegularText style={{ textAlign: 'center' }}>
-        Now, please answer the same set of questions, but this time for February 2020, before the COVID pandemic spread.
+        {i18n.t('diet-study.about-you.answer-same-set-questions')}
       </RegularText>
     </View>
   );
 };
 const DietStudyAboutYouScreen: React.FC<Props> = ({ route, navigation }) => {
-  const { timePeriod } = route.params.dietStudyData;
-  const { profile, isFemale } = route.params.dietStudyData.currentPatient;
+  const { timePeriod, currentPatient } = route.params.dietStudyData;
+  const { profile, isFemale } = currentPatient;
 
   const form = useDietStudyFormSubmit(route.name);
 
@@ -57,11 +57,10 @@ const DietStudyAboutYouScreen: React.FC<Props> = ({ route, navigation }) => {
     .concat(FoodSecurityQuestion.schema());
 
   const updateDietStudy = async (formData: FormData) => {
-    console.log(`Update diet study: ${form.submitting}`);
     if (form.submitting) return;
     let infos = {
-      display_name: route.params.dietStudyData.timePeriod,
-      patient: route.params.dietStudyData.currentPatient.patientId,
+      display_name: timePeriod,
+      patient: currentPatient.patientId,
       ...ExtraWeightQuestions.createDTO(formData),
       ...HoursSleepQuestion.createDTO(formData),
       ...ShiftWorkQuestion.createDTO(formData),

--- a/src/features/diet-study/DietStudyTypicalDietScreen.tsx
+++ b/src/features/diet-study/DietStudyTypicalDietScreen.tsx
@@ -14,14 +14,10 @@ import { DietStudyRequest } from '@covid/core/diet-study/dto/DietStudyRequest';
 import i18n from '@covid/locale/i18n';
 import { ValidationError } from '@covid/components/ValidationError';
 import { colors } from '@theme';
-import NavigatorService from '@covid/NavigatorService';
 import dietStudyCoordinator, {
-  DietStudyData,
   PREVIOUS_DIET_STUDY_TIME_PERIOD,
   CURRENT_DIET_STUDY_TIME_PERIOD,
 } from '@covid/core/diet-study/DietStudyCoordinator';
-
-import appCoordinator from '../AppCoordinator';
 
 import { MilkTypeQuestion, MilkTypesData } from './fields/MilkTypeQuestion';
 import { FruitNVegConsumptionData, FruitNVegConsumptionQuestions } from './fields/FruitNVegConsumptionQuestions';
@@ -60,12 +56,14 @@ const DietStudyTypicalDietScreen: React.FC<Props> = ({ route, navigation }) => {
       ...DietChangedQuestion.createDTO(formData),
     } as Partial<DietStudyRequest>;
 
-    if (!!recentDietStudyId && formData.hasDietChanged === DietChangedOption.YES) {
+    if (!!recentDietStudyId && formData.has_diet_changed === DietChangedOption.YES) {
       dietStudyCoordinator.dietStudyParam.dietStudyData.timePeriod = PREVIOUS_DIET_STUDY_TIME_PERIOD;
     }
 
     await form.submitDietStudy(infos);
   };
+
+  const completeCtaLabel = (formikProps: FormikProps<FormData>) => formikProps.values.has_diet_changed === DietChangedOption.YES ? i18n.t('diet-study.complete-pre-cta') : i18n.t('diet-study.complete-cta');
 
   return (
     <Screen profile={profile} navigation={navigation} style={styles.screen}>
@@ -94,9 +92,7 @@ const DietStudyTypicalDietScreen: React.FC<Props> = ({ route, navigation }) => {
               <View style={[styles.divider, styles.padded]} />
 
               <FoodFreqQuestion formikProps={props as FormikProps<FoodFreqData>} />
-
               <FruitNVegConsumptionQuestions formikProps={props as FormikProps<FruitNVegConsumptionData>} />
-
               <MilkTypeQuestion formikProps={props as FormikProps<MilkTypesData>} />
 
               {timePeriod === CURRENT_DIET_STUDY_TIME_PERIOD && (
@@ -112,7 +108,7 @@ const DietStudyTypicalDietScreen: React.FC<Props> = ({ route, navigation }) => {
               <View style={{ height: 72 }} />
 
               <BrandedButton onPress={props.handleSubmit} hideLoading={!props.isSubmitting}>
-                {i18n.t('diet-study.complete-cta')}
+                {completeCtaLabel(props)}
               </BrandedButton>
             </Form>
           );

--- a/src/features/diet-study/DietStudyTypicalDietScreen.tsx
+++ b/src/features/diet-study/DietStudyTypicalDietScreen.tsx
@@ -63,7 +63,10 @@ const DietStudyTypicalDietScreen: React.FC<Props> = ({ route, navigation }) => {
     await form.submitDietStudy(infos);
   };
 
-  const completeCtaLabel = (formikProps: FormikProps<FormData>) => formikProps.values.has_diet_changed === DietChangedOption.YES ? i18n.t('diet-study.complete-pre-cta') : i18n.t('diet-study.complete-cta');
+  const completeCtaLabel = (formikProps: FormikProps<FormData>) =>
+    formikProps.values.has_diet_changed === DietChangedOption.YES
+      ? i18n.t('diet-study.complete-pre-cta')
+      : i18n.t('diet-study.complete-cta');
 
   return (
     <Screen profile={profile} navigation={navigation} style={styles.screen}>

--- a/src/features/diet-study/fields/DietChangedQuestion.tsx
+++ b/src/features/diet-study/fields/DietChangedQuestion.tsx
@@ -9,7 +9,7 @@ import { FormQuestion } from '@covid/components/Inputs/FormQuestion.interface';
 import ButtonsGroup from '@covid/components/Inputs/ButtonsGroup';
 
 export interface DietChangedData {
-  hasDietChanged: DietChangedOption | '';
+  has_diet_changed: DietChangedOption | '';
 }
 
 export enum DietChangedOption {
@@ -36,25 +36,25 @@ export const DietChangedQuestion: FormQuestion<Props, DietChangedData, CovidTest
           value: DietChangedOption.YES,
         },
         {
-          label: 'Not sure',
+          label: i18n.t('diet-study.diet-changed.not-sure'),
           value: DietChangedOption.NOT_SURE,
         },
       ]}
       onValueChange={(value: DietChangedOption) => {
-        props.formikProps.setFieldValue('hasDietChanged', value);
+        props.formikProps.setFieldValue('has_diet_changed', value);
       }}
       selectedValue=""
-      error={props.formikProps.touched.hasDietChanged && props.formikProps.errors.hasDietChanged}
+      error={props.formikProps.touched.has_diet_changed && props.formikProps.errors.has_diet_changed}
       {...props}
     />
   );
 };
 
-DietChangedQuestion.initialFormValues = (): DietChangedData => ({ hasDietChanged: '' });
+DietChangedQuestion.initialFormValues = (): DietChangedData => ({ has_diet_changed: '' });
 
 DietChangedQuestion.schema = () =>
   Yup.object().shape({
-    hasDietChanged: Yup.string().required(),
+    has_diet_changed: Yup.string().required(i18n.t('diet-study.required')),
   });
 
 DietChangedQuestion.createDTO = (_): Partial<DietStudyRequest> => ({});

--- a/src/features/diet-study/fields/EatingHabitQuestions.tsx
+++ b/src/features/diet-study/fields/EatingHabitQuestions.tsx
@@ -43,7 +43,7 @@ export const EatingHabitQuestions: EatingHabitQuestions<Props, EatingHabitData> 
       <FieldLabel>{i18n.t('diet-study.main-meals-label')}</FieldLabel>
       <FieldWrapper style={{ padding: 16 }}>
         <ValidatedTextInput
-          placeholder=""
+          placeholder={i18n.t('diet-study.main-meals-placeholder')}
           value={formikProps.values.mainMeals}
           onChangeText={formikProps.handleChange('mainMeals')}
           onBlur={formikProps.handleBlur('mainMeals')}
@@ -57,7 +57,7 @@ export const EatingHabitQuestions: EatingHabitQuestions<Props, EatingHabitData> 
       <FieldLabel>{i18n.t('diet-study.snacks-label')}</FieldLabel>
       <FieldWrapper style={{ padding: 16 }}>
         <ValidatedTextInput
-          placeholder=""
+          placeholder={i18n.t('diet-study.snacks-placeholder')}
           value={formikProps.values.snacks}
           onChangeText={formikProps.handleChange('snacks')}
           onBlur={formikProps.handleBlur('snacks')}

--- a/src/features/diet-study/fields/FoodFreqQuestion.tsx
+++ b/src/features/diet-study/fields/FoodFreqQuestion.tsx
@@ -83,7 +83,7 @@ FoodFreqQuestion.initialFormValues = (): FoodFreqData => ({
 });
 
 FoodFreqQuestion.schema = () => {
-  const validation = Yup.string().required();
+  const validation = Yup.string().required(i18n.t('diet-study.required'));
   return Yup.object().shape({
     ffq_fruit: validation,
     ffq_fruit_juice: validation,

--- a/src/features/diet-study/fields/FruitNVegConsumptionQuestions.tsx
+++ b/src/features/diet-study/fields/FruitNVegConsumptionQuestions.tsx
@@ -23,26 +23,19 @@ interface Props {
   formikProps: FormikProps<FruitNVegConsumptionData>;
 }
 
-interface CheckBoxData {
-  label: string;
-  value: string;
-}
-
 interface InputProps {
   label: string;
-  items: CheckBoxData[];
-  selectedValue?: any;
+  placeholder: string;
   fieldKey: Keys;
-  error?: any;
   formikProps: FormikProps<FruitNVegConsumptionData>;
 }
 
-const Input: React.FC<InputProps> = ({ label, items, selectedValue, fieldKey, error, formikProps }) => (
+const Input: React.FC<InputProps> = ({ label, placeholder, fieldKey, formikProps }) => (
   <FieldWrapper style={styles.fieldWrapper}>
     <RegularText>{label}</RegularText>
     <View style={{}}>
       <ValidatedTextInput
-        placeholder=""
+        placeholder={placeholder}
         value={formikProps.values[fieldKey] ? `${formikProps.values[fieldKey]}` : ''}
         onChangeText={formikProps.handleChange(fieldKey)}
         onBlur={formikProps.handleBlur(fieldKey)}
@@ -60,12 +53,9 @@ export const FruitNVegConsumptionQuestions: FormQuestion<Props, FruitNVegConsump
 ) => {
   const { formikProps } = props;
 
-  const items = [{ label: 'Empty', value: '1' }];
-
   const input = (key: keyof FruitNVegConsumptionData): InputProps => ({
     label: i18n.t(`diet-study.typical-diet.${key}-label`),
-    items,
-    selectedValue: formikProps.values[key],
+    placeholder: i18n.t(`diet-study.typical-diet.${key}-placeholder`),
     fieldKey: key,
     formikProps,
   });
@@ -76,7 +66,7 @@ export const FruitNVegConsumptionQuestions: FormQuestion<Props, FruitNVegConsump
     <>
       {inputs().map((input) => {
         const key = input.fieldKey as Keys;
-        return <Input key={key} error={formikProps.touched[key] && formikProps.errors[key]} {...input} />;
+        return <Input key={key} {...input} />;
       })}
     </>
   );

--- a/src/features/diet-study/fields/HoursSleepQuestion.tsx
+++ b/src/features/diet-study/fields/HoursSleepQuestion.tsx
@@ -31,7 +31,7 @@ export const HoursSleepQuestion: HoursSleepQuestion<Props, HoursSleepData> = (pr
       <FieldLabel>{i18n.t('diet-study.hours-of-sleep-label')}</FieldLabel>
       <FieldWrapper style={{ padding: 16 }}>
         <ValidatedTextInput
-          placeholder=""
+          placeholder={i18n.t('diet-study.hours-of-sleep-placeholder')}
           value={formikProps.values.hoursSleep}
           onChangeText={formikProps.handleChange('hoursSleep')}
           onBlur={formikProps.handleBlur('hoursSleep')}

--- a/src/features/diet-study/fields/SupplementQuestions.tsx
+++ b/src/features/diet-study/fields/SupplementQuestions.tsx
@@ -11,10 +11,12 @@ import { FieldLabel } from '@covid/components/Text';
 import { FieldWrapper } from '@covid/components/Screen';
 import YesNoField from '@covid/components/YesNoField';
 import { CheckboxItem, CheckboxList } from '@covid/components/Checkbox';
+import { GenericTextField } from '@covid/components/GenericTextField';
 
 export interface SupplementData {
   takesSupplements: string;
   supplements: string[];
+  supplements_other: string;
 }
 
 interface Props {
@@ -91,6 +93,14 @@ export const SupplementQuestions: SupplementQuestions<Props, SupplementData> = (
           </Item>
         </View>
       )}
+
+      {formikProps.values.supplements.includes('supplements_other') && (
+        <GenericTextField
+          formikProps={formikProps}
+          label={i18n.t('diet-study.supplements.specify')}
+          name="supplements_other"
+        />
+      )}
     </>
   );
 };
@@ -99,6 +109,7 @@ SupplementQuestions.initialFormValues = (): SupplementData => {
   return {
     takesSupplements: '',
     supplements: [] as string[],
+    supplements_other: '',
   };
 };
 
@@ -122,10 +133,13 @@ SupplementQuestions.createDTO = (formData: SupplementData): Partial<DietStudyReq
       supplements_omega3: false,
       supplements_garlic: false,
       supplements_pfnts: false,
-      supplements_other: false,
+      supplements_other: formData.supplements,
     } as any;
 
     formData.supplements.forEach((item: string) => {
+      if (item === 'supplements_other') {
+        return;
+      }
       supplements[item] = true;
     });
 


### PR DESCRIPTION
# Description

- Added placeholders for numeric inputs
- Added optionally rendered generic textfield for `supplement_other` when user selected `other` as the option for supplements question
- Added validation text for Food Frequency & Has diet changed questions
- Dynamic CTA for typical diet screen 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [x] I have run `npm run test:i18n`
