### PR TITLE
Feature/auto calc recent diet time period

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1008,6 +1008,7 @@
   "diet-study": {
     "drawer-menu-item": "My study",
     "answer-for-feb": "Answer for February",
+    "answer-for-last-4-weeks": "Answer for last 4 weeks",
 
     "required": "This is required",
 

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1025,6 +1025,7 @@
   "diet-study": {
     "drawer-menu-item": "",
     "answer-for-feb": "",
+    "answer-for-last-4-weeks": "",
     "required": "",
 
     "diet-changed": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1022,6 +1022,7 @@
   "diet-study": {
     "drawer-menu-item": "",
     "answer-for-feb": "",
+    "answer-for-last-4-weeks": "",
     "required": "",
 
     "intro": {

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -18,12 +18,15 @@ type ScreenFlow = {
 };
 type DietStudyParam = { dietStudyData: DietStudyData };
 
-export const CURRENT_DIET_STUDY_TIME_PERIOD = 'July 2020';
+export const CURRENT_DIET_STUDY_TIME_PERIOD = 'Recent';
 export const PREVIOUS_DIET_STUDY_TIME_PERIOD = 'Feb 2020';
 
 export const getScreenHeaderOptions = (time?: string): Partial<ScreenProps> => {
   if (time === CURRENT_DIET_STUDY_TIME_PERIOD) {
-    return { calloutType: CallOutType.Simple };
+    return {
+      calloutType: CallOutType.Tag,
+      calloutTitle: i18n.t('diet-study.answer-for-last-4-weeks'),
+    };
   } else {
     return {
       calloutType: CallOutType.Tag,
@@ -39,7 +42,7 @@ export enum DietStudyConsent {
 }
 
 export type DietStudyData = {
-  timePeriod?: string;
+  timePeriod: string;
   recentDietStudyId?: string;
   febDietStudyId?: string;
   currentPatient: PatientStateType;
@@ -115,6 +118,9 @@ export class DietStudyCoordinator {
   }
 
   startDietStudy = async () => {
+    NavigatorService.navigate('DietStudyTypicalDiet', this.dietStudyParam);
+    return;
+
     // Check has user already completed diet studies
     const studies = await this.dietStudyService.getDietStudies();
     const recentStudies = studies.filter((item) => item.display_name === CURRENT_DIET_STUDY_TIME_PERIOD);

--- a/src/features/diet-study/DietStudyAboutYouScreen.tsx
+++ b/src/features/diet-study/DietStudyAboutYouScreen.tsx
@@ -23,7 +23,9 @@ import { colors } from '@theme';
 import dietStudyCoordinator, {
   PREVIOUS_DIET_STUDY_TIME_PERIOD,
   getScreenHeaderOptions,
+  CURRENT_DIET_STUDY_TIME_PERIOD,
 } from '@covid/core/diet-study/DietStudyCoordinator';
+import { currentDietStudyTimePeriod } from '@covid/utils/datetime';
 
 import { useDietStudyFormSubmit } from './DietStudyFormSubmit.hooks';
 
@@ -59,10 +61,14 @@ const DietStudyAboutYouScreen: React.FC<Props> = ({ route, navigation }) => {
     .concat(ShiftWorkQuestion.schema())
     .concat(FoodSecurityQuestion.schema());
 
+  const getTimePeriod = (time?: string): string => {
+    return time === CURRENT_DIET_STUDY_TIME_PERIOD ? currentDietStudyTimePeriod() : PREVIOUS_DIET_STUDY_TIME_PERIOD;
+  };
+
   const updateDietStudy = async (formData: FormData) => {
     if (form.submitting) return;
     let infos = {
-      display_name: timePeriod,
+      display_name: getTimePeriod(timePeriod),
       patient: currentPatient.patientId,
       ...ExtraWeightQuestions.createDTO(formData),
       ...HoursSleepQuestion.createDTO(formData),

--- a/src/features/diet-study/DietStudyFormSubmit.hooks.tsx
+++ b/src/features/diet-study/DietStudyFormSubmit.hooks.tsx
@@ -41,10 +41,7 @@ export const useDietStudyFormSubmit = (next: keyof ScreenParamList): DietStudyFo
     }
   };
 
-  const submitDietStudy = async (
-    infos: DietStudyRequest | Partial<DietStudyRequest>,
-    isCompelete: boolean
-  ): Promise<DietStudyResponse> => {
+  const submitDietStudy = async (infos: DietStudyRequest | Partial<DietStudyRequest>): Promise<DietStudyResponse> => {
     try {
       const studyId = getStudyId();
       let response: DietStudyResponse;

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -24,3 +24,5 @@ export const aWeekAgo = () => {
 export const isDateBefore = (date: DateTypes, compDate: DateTypes): boolean => {
   return moment(date).isBefore(compDate);
 };
+
+export const currentDietStudyTimePeriod = (): string => moment(new Date()).format('MMMM YYYY');

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -25,4 +25,4 @@ export const isDateBefore = (date: DateTypes, compDate: DateTypes): boolean => {
   return moment(date).isBefore(compDate);
 };
 
-export const currentDietStudyTimePeriod = (): string => moment(new Date()).format('MMMM YYYY');
+export const currentDietStudyTimePeriod = (): string => moment(new Date()).format('MMM YYYY');


### PR DESCRIPTION
# Description

Rather than having `July 2020` hardcoded, the time period we send to backend `display_name` is now a dynamic value, calculated on the fly. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`
