### PR TITLE
Diet Study Flow Fixes

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1034,7 +1034,7 @@
     "was-pregnant-label": "I am/was pregnant",
     "hours-of-sleep-weekday-label": "How long did you usually sleep for on week nights (Sunday to Thursday)?",
     "hours-of-sleep-weekend-label": "How long did you usually sleep for on weekend nights (Friday to Saturday)?",
-    "hours-of-sleep-placeholder": "Hours",
+    "hours-of-sleep-placeholder": "Hours per night",
     "shift-work-label": "Do you work shifts outside the regular daytime hours of approximately 07.00 a.m. and 06.00 p.m.?",
     "food-security": {
       "label": "Which of the following statements best describes the food eaten in your household in the last week?",
@@ -1126,9 +1126,9 @@
     "last-calories-label": "What is the latest time of the day that you usually eat or drink anything (including snacks) other than water/black coffee and plain tea?",
     "eats-breakfast-label": "Do you typically eat breakfast?",
     "main-meals-label": "How many 'main' meals do you typically eat in a day (a main meal is lunch or dinner)?",
-    "main-meals-placeholder": "Main meals",
+    "main-meals-placeholder": "Meals per day",
     "snacks-label": "How frequently do you typically eat snacks in a day (a snack is any food eaten outside of breakfast, lunch or dinner)?",
-    "snacks-placeholder": "Snacks",
+    "snacks-placeholder": "Snacks per day",
     "lost-control": "Do you worry you have lost control over how much you eat?",
     "diet": {
       "label": "Which of the below options best describes you over the four weeks (you can select more than one option)?",
@@ -1193,11 +1193,11 @@
       "fast_food-2": "",
 
       "portions_of_fruit-label": "On average, how many portions of FRUIT do you eat a day? (excluding 100% fruit juice. Examples include a handful of grapes, an orange, a handful of dried fruits)",
-      "portions_of_fruit-placeholder": "Portions",
+      "portions_of_fruit-placeholder": "Portions per day",
       "glasses_of_juice-label": "On average, how many glasses of 100% fruit or vegetable juice do you drink a day? (a standard glass is 240 ml)",
-      "glasses_of_juice-placeholder": "Glasses",
+      "glasses_of_juice-placeholder": "Glasses per day",
       "portions_of_veg-label": "On average, how many portions of VEGETABLES do you eat a day? (Examples include: 3 heaped tablespoons of carrots, a side salad, 2 spears of broccoli)",
-      "portions_of_veg-placeholder": "Portions",
+      "portions_of_veg-placeholder": "Portions per day",
 
       "milk-label": "What milk do you usually use or drink, such as in hot & cold drinks or on cereal?",
       "milk-whole": "Whole / full-fat milk",

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -71,7 +71,8 @@ export class DietStudyCoordinator {
       const { timePeriod } = this.dietStudyParam.dietStudyData;
 
       if (timePeriod === PREVIOUS_DIET_STUDY_TIME_PERIOD) {
-        NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam); // Goes back to screen currently on stack
+        NavigatorService.reset([{ name: 'WelcomeRepeat' }]);
+        NavigatorService.navigate('DietStudyAboutYou', this.dietStudyParam);
       } else {
         NavigatorService.reset([{ name: 'WelcomeRepeat' }]);
         NavigatorService.navigate('DietStudyThankYou', this.dietStudyParam);

--- a/src/features/diet-study/DietStudyFormSubmit.hooks.tsx
+++ b/src/features/diet-study/DietStudyFormSubmit.hooks.tsx
@@ -41,10 +41,7 @@ export const useDietStudyFormSubmit = (next: keyof ScreenParamList): DietStudyFo
     }
   };
 
-  const submitDietStudy = async (
-    infos: DietStudyRequest | Partial<DietStudyRequest>,
-    isCompelete: boolean
-  ): Promise<DietStudyResponse> => {
+  const submitDietStudy = async (infos: DietStudyRequest | Partial<DietStudyRequest>): Promise<DietStudyResponse> => {
     try {
       const studyId = getStudyId();
       let response: DietStudyResponse;

--- a/src/features/diet-study/DietStudyTypicalDietScreen.tsx
+++ b/src/features/diet-study/DietStudyTypicalDietScreen.tsx
@@ -57,11 +57,11 @@ const DietStudyTypicalDietScreen: React.FC<Props> = ({ route, navigation }) => {
       ...DietChangedQuestion.createDTO(formData),
     } as Partial<DietStudyRequest>;
 
+    await form.submitDietStudy(infos);
+
     if (!!recentDietStudyId && formData.has_diet_changed === DietChangedOption.YES) {
       dietStudyCoordinator.dietStudyParam.dietStudyData.timePeriod = PREVIOUS_DIET_STUDY_TIME_PERIOD;
     }
-
-    await form.submitDietStudy(infos);
 
     // Important: We need to keep this here for Coordinator to
     // go to the thank you page after 2nd round is completed.


### PR DESCRIPTION
# Description

[1] Update placeholder text for clarity

[2] Reset navigation before starting second pass. This fixes a problem when finishing the first pass of the Diet Study, and when you start the second pass the form is pre-populated and scrolled to the bottom. The navigate action takes you "back"  to the previously populated screen as it's in the navigation stack history. 

[3] Fix missing patch at the end of the third screen, by calling `await form.submitDietStudy(infos)` before the block the changes the `timePeriod`

[4] Remove unused param `isComplete` on submitDietStudy function.


## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device
