### PR TITLE
Fix submit supplements

### DIFF
--- a/src/features/diet-study/fields/SupplementQuestions.tsx
+++ b/src/features/diet-study/fields/SupplementQuestions.tsx
@@ -133,7 +133,7 @@ SupplementQuestions.createDTO = (formData: SupplementData): Partial<DietStudyReq
       supplements_omega3: false,
       supplements_garlic: false,
       supplements_pfnts: false,
-      supplements_other: formData.supplements,
+      supplements_other: formData.supplements_other,
     } as any;
 
     formData.supplements.forEach((item: string) => {


### PR DESCRIPTION
# Description

Fixes the CreateDTO for supplements question which was setting the supplements_other tag to be an array object. 

![Screenshot 2020-07-26 at 23 00 37](https://user-images.githubusercontent.com/7824212/88490485-e9549c80-cf93-11ea-9655-0933c72432d2.png)


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
