### PR TITLE
Rename async storage key and variable

### DIFF
--- a/src/core/AsyncStorageService.ts
+++ b/src/core/AsyncStorageService.ts
@@ -12,7 +12,7 @@ const USER_COUNT = 'userCount';
 const USER_COUNTRY = 'userCountry';
 const CONSENT_SIGNED = 'consentSigned';
 const PUSH_TOKEN = 'pushToken';
-const SKIP_DIET_STUDY = 'skipDietStudy';
+const DIET_STUDY_CONSENT = 'dietStudyConsent';
 
 const USER_PROFILE = 'userProfile';
 const ASKED_COUNTRY = 'askedCountry';
@@ -50,7 +50,7 @@ export class AsyncStorageService {
     try {
       await AsyncStorage.removeItem(AUTH_TOKEN);
       await AsyncStorage.removeItem(USER_ID);
-      await AsyncStorage.removeItem(SKIP_DIET_STUDY);
+      await AsyncStorage.removeItem(DIET_STUDY_CONSENT);
     } catch (err) {
       // Swallow for now
       // todo: find a way to report the crash and an alternative
@@ -192,7 +192,7 @@ export class AsyncStorageService {
   // Diet Study Consent
   static async getDietStudyConsent(): Promise<DietStudyConsent | null> {
     try {
-      const value = await AsyncStorage.getItem(SKIP_DIET_STUDY);
+      const value = await AsyncStorage.getItem(DIET_STUDY_CONSENT);
       return value as DietStudyConsent | null;
     } catch (err) {
       return null;
@@ -201,7 +201,7 @@ export class AsyncStorageService {
 
   static async setDietStudyConsent(consent: DietStudyConsent) {
     try {
-      return await AsyncStorage.setItem(SKIP_DIET_STUDY, consent);
+      return await AsyncStorage.setItem(DIET_STUDY_CONSENT, consent);
     } catch (err) {}
   }
 }


### PR DESCRIPTION
# Description

Rename async storage key and variable name used for Diet Storage consent. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
