### PR TITLE
Resume Diet Study from the Drawer Menu

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1015,7 +1015,7 @@
   },
 
   "diet-study": {
-    "drawer-menu-item": "My study",
+    "drawer-menu-item": "Diet Study",
     "answer-for-feb": "Answer for month of Feb",
     "answer-for-last-4-weeks": "Answer for last 4 weeks",
 

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1015,7 +1015,7 @@
   },
 
   "diet-study": {
-    "drawer-menu-item": "Diet Study",
+    "drawer-menu-item": "Diet study",
     "answer-for-feb": "Answer for month of Feb",
     "answer-for-last-4-weeks": "Answer for last 4 weeks",
 
@@ -1295,6 +1295,6 @@
     "callout-title": "VACCINE",
     "callout-text": "Would you like to join our COVID-19 vaccine registry?",
     "callout-link-text": "I am interested",
-    "menu-item": "Join the vaccine registry"
+    "menu-item": "Join vaccine registry"
   }
 }

--- a/src/core/diet-study/DietStudyCoordinator.ts
+++ b/src/core/diet-study/DietStudyCoordinator.ts
@@ -141,11 +141,16 @@ export class DietStudyCoordinator {
   startDietStudy = async () => {
     // Check has user already completed diet studies
     const studies = await this.dietStudyService.getDietStudies();
-    const recentStudies = studies.filter((item) => item.display_name === LAST_4_WEEKS && item.is_complete);
-    if (recentStudies.length > 0) {
-      NavigatorService.navigate('DietStudyThankYou', this.dietStudyParam);
-    } else {
+    const completedDietStudies = studies.filter((item) => item.is_complete);
+
+    if (completedDietStudies.length === 0) {
+      // Start from the beginning
       NavigatorService.navigate('DietStudyIntro', this.dietStudyParam);
+    } else if (completedDietStudies.length === 1) {
+      // Start from PreLockdown
+      NavigatorService.navigate('DietStudyThankYouBreak', this.dietStudyParam);
+    } else {
+      NavigatorService.navigate('DietStudyThankYou', this.dietStudyParam);
     }
   };
 
@@ -156,13 +161,6 @@ export class DietStudyCoordinator {
       console.error('[ROUTE] no next route found for:', screenName);
     }
   };
-
-  async showProfiles() {
-    return this.userService.getConfig().enableMultiplePatients && (await this.userService.hasMultipleProfiles());
-  }
-  async listPatients() {
-    return this.userService.listPatients();
-  }
 }
 
 const dietStudyCoordinator = new DietStudyCoordinator();

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -55,6 +55,7 @@ export interface IUserService {
   shouldShowDietStudy(): Promise<boolean>;
   setVaccineRegistryResponse(response: boolean): void;
   setDietStudyResponse(response: boolean): void;
+  getStudyStatus(): Promise<AskForStudies>;
 }
 
 export interface IProfileService {
@@ -572,6 +573,23 @@ export default class UserService extends ApiClientBase implements ICoreService {
 
     const response = await this.client.get<AskForStudies>(url);
     return response.data.should_ask_diet_study;
+  }
+
+  getDefaultStudyResponse(): AskForStudies {
+    return {
+      should_ask_uk_validation_study: false,
+      should_ask_uk_vaccine_register: false,
+      should_ask_diet_study: false,
+    } as AskForStudies;
+  }
+
+  async getStudyStatus(): Promise<AskForStudies> {
+    // Currently all existing studies are UK only so short-circuit and save a call the server.
+    if (!isGBCountry()) return Promise.resolve(this.getDefaultStudyResponse());
+
+    const url = `/study_consent/status/?home_screen=true`;
+    const response = await this.client.get<AskForStudies>(url);
+    return response.data;
   }
 
   setValidationStudyResponse(response: boolean, anonymizedData?: boolean, reContacted?: boolean) {

--- a/src/features/menu/DrawerMenu.tsx
+++ b/src/features/menu/DrawerMenu.tsx
@@ -1,20 +1,18 @@
 import { DrawerContentComponentProps } from '@react-navigation/drawer';
 import Constants from 'expo-constants';
-import React, { useState, useEffect } from 'react';
-import { Image, StyleSheet, TouchableOpacity, View, SafeAreaView } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { Image, SafeAreaView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import { closeIcon } from '@assets';
 import i18n from '@covid/locale/i18n';
 import { IUserService } from '@covid/core/user/UserService';
-import Analytics, { events } from '@covid/core/Analytics';
 import { CaptionText } from '@covid/components/Text';
-import PushNotificationService from '@covid/core/push-notifications/PushNotificationService';
 import { useInjection } from '@covid/provider/services.hooks';
 import { Services } from '@covid/provider/services.types';
 import appCoordinator from '@covid/features/AppCoordinator';
-import { MyStudyIcon, VaccineRegistryIcon, ShareIcon, EditProfilesIcon } from '@assets/icons/navigation';
-import { MenuItem, DrawerMenuItem } from '@covid/features/menu/DrawerMenuItem';
+import { MyStudyIcon, ShareIcon, VaccineRegistryIcon } from '@assets/icons/navigation';
+import { MenuItem } from '@covid/features/menu/DrawerMenuItem';
 import { useLogout } from '@covid/features/menu/Logout.hooks';
 import { LinksSection } from '@covid/features/menu/LinksSection';
 
@@ -32,12 +30,12 @@ export const DrawerMenu: React.FC<DrawerContentComponentProps> = (props) => {
   useEffect(() => {
     if (userEmail !== '') return;
     fetchEmail();
-    fetchShouldShowVaccine();
-    fetchShouldShowDietStudy();
+    fetchStudyStatus();
   }, [userService.hasUser, setUserEmail]);
 
   const fetchEmail = async () => {
     try {
+      // TODO - Save a server hit and stash this in async storage
       const profile = await userService.getProfile();
       setUserEmail(profile?.username ?? '');
     } catch (_) {
@@ -45,20 +43,13 @@ export const DrawerMenu: React.FC<DrawerContentComponentProps> = (props) => {
     }
   };
 
-  const fetchShouldShowVaccine = async () => {
+  const fetchStudyStatus = async () => {
     try {
-      const shouldAskForVaccineRegistry = await userService.shouldAskForVaccineRegistry();
-      setShowVaccineRegistry(shouldAskForVaccineRegistry);
+      const data = await userService.getStudyStatus();
+      setShowVaccineRegistry(data.should_ask_uk_vaccine_register);
+      setShowDietStudy(data.should_ask_diet_study);
     } catch (_) {
       setShowVaccineRegistry(false);
-    }
-  };
-
-  const fetchShouldShowDietStudy = async () => {
-    try {
-      const showDietStudy = await appCoordinator.shouldShowStudiesMenu();
-      setShowDietStudy(showDietStudy);
-    } catch (_) {
       setShowDietStudy(false);
     }
   };


### PR DESCRIPTION
# Description

Allow users to return to the Diet Study from the Drawer Menu. The Icon is only shown for UK users who are in the rollout percentage. 

If they don't have any complete records, they'll start from the begining of the flow. 
If they've completed July 2020, then they'll start from the Welcome Break / Sarah Page
If they've completed both flows

In a follow up PR: 
- add a badge icon if they have incomplete studies. 
- Potentially add a CTA somewhere. 

 
## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

## UK 
![Screenshot 2020-08-05 at 12 21 48](https://user-images.githubusercontent.com/7824212/89407200-424fcd80-d716-11ea-9c3f-822b7bb85b1f.png)

## US
![Screenshot 2020-08-05 at 12 11 20](https://user-images.githubusercontent.com/7824212/89406775-99a16e00-d715-11ea-8b4b-6558a68fe965.png)

## Sweden
![Screenshot 2020-08-05 at 12 11 39](https://user-images.githubusercontent.com/7824212/89406782-9a3a0480-d715-11ea-94b7-34b8fa7360a3.png)


## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
