### PR TITLE
cap length of dropdown

### DIFF
--- a/src/components/DropdownField.tsx
+++ b/src/components/DropdownField.tsx
@@ -135,7 +135,8 @@ export const DropdownField: React.FC<DropdownFieldProps> = ({
         dropdownStyle={{
           ...styles.dropdownStyle,
           width: dropdownWidth,
-          height: (options?.length ?? 1) * DROPDOWN_ROW_HEIGHT,
+          height:
+            (options?.length ?? 1) * DROPDOWN_ROW_HEIGHT > 225 ? 225 : (options?.length ?? 1) * DROPDOWN_ROW_HEIGHT,
         }}
         options={options.map((item: PickerItemProps) => item.label)}
         defaultIndex={defaultIndex}
@@ -200,6 +201,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.backgroundTertiary,
     height: 'auto',
     minHeight: 48,
+    maxHeight: 96,
     borderRadius: 8,
     minWidth: 70,
   },

--- a/src/components/DropdownField.tsx
+++ b/src/components/DropdownField.tsx
@@ -201,7 +201,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.backgroundTertiary,
     height: 'auto',
     minHeight: 48,
-    maxHeight: 96,
     borderRadius: 8,
     minWidth: 70,
   },

--- a/src/features/diet-study/fields/EatingWindowQuestions.tsx
+++ b/src/features/diet-study/fields/EatingWindowQuestions.tsx
@@ -55,8 +55,8 @@ export const EatingWindowQuestions: EatingWindowQuestions<Props, EatingWindowDat
   ];
 
   const meridianIndicatorItems = [
-    { label: 'a.m.', value: 'AM' },
-    { label: 'p.m.', value: 'PM' },
+    { label: 'am', value: 'AM' },
+    { label: 'pm', value: 'PM' },
   ];
 
   return (


### PR DESCRIPTION
# Description

Caps the length of the dropdown to prevent it spilling out smaller screens and causing difficulty.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_
![image](https://user-images.githubusercontent.com/52913482/89638121-2f1e3880-d8a3-11ea-8491-12b49921b3c8.png)
