### PR TITLE
feat: limit input & added caption / validation on other text field

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1236,7 +1236,9 @@
 
     "other-info": {
       "label": "Is there any other information about your diet & lifestyle you would like to share?",
-      "placeholder": "Optional"
+      "placeholder": "Optional",
+      "text-limit": "Ensure this field has no more than {{count}} characters.",
+      "text-limit-caption": "Max {{count}} characters"
     },
 
     "diet-changed": {

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1264,7 +1264,9 @@
 
     "other-info": {
       "label": "",
-      "placeholder": ""
+      "placeholder": "",
+      "text-limit": "",
+      "text-limit-caption": ""
     },
 
     "continue-cta": "",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1255,7 +1255,9 @@
 
     "other-info": {
       "label": "",
-      "placeholder": ""
+      "placeholder": "",
+      "text-limit": "",
+      "text-limit-caption": ""
     },
 
     "diet-changed": {

--- a/src/components/GenericTextField.tsx
+++ b/src/components/GenericTextField.tsx
@@ -1,7 +1,6 @@
 import { FormikProps } from 'formik';
 import React from 'react';
 import { KeyboardTypeOptions, StyleSheet, StyleProp, ViewStyle } from 'react-native';
-import { text } from 'body-parser';
 
 import { FieldWrapper } from './Screen';
 import { ValidatedTextInput } from './ValidatedTextInput';

--- a/src/components/GenericTextField.tsx
+++ b/src/components/GenericTextField.tsx
@@ -1,6 +1,7 @@
 import { FormikProps } from 'formik';
 import React from 'react';
 import { KeyboardTypeOptions, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { text } from 'body-parser';
 
 import { FieldWrapper } from './Screen';
 import { ValidatedTextInput } from './ValidatedTextInput';

--- a/src/features/diet-study/fields/OtherInfoQuestion.tsx
+++ b/src/features/diet-study/fields/OtherInfoQuestion.tsx
@@ -7,6 +7,7 @@ import i18n from '@covid/locale/i18n';
 import { CovidTest } from '@covid/core/user/dto/CovidTestContracts';
 import { DietStudyRequest } from '@covid/core/diet-study/dto/DietStudyRequest';
 import { GenericTextField } from '@covid/components/GenericTextField';
+import { CaptionText } from '@covid/components/Text';
 
 export interface OtherInfoData {
   other_info: string;
@@ -15,6 +16,8 @@ export interface OtherInfoData {
 interface Props {
   formikProps: FormikProps<OtherInfoData>;
 }
+
+const CHAR_LIMIT = 1000;
 
 export interface OtherInfoQuestion<P, Data> extends React.FC<P> {
   initialFormValues: () => Data;
@@ -25,16 +28,22 @@ export interface OtherInfoQuestion<P, Data> extends React.FC<P> {
 export const OtherInfoQuestion: OtherInfoQuestion<Props, OtherInfoData> = (props: Props) => {
   const { formikProps } = props;
   return (
-    <GenericTextField
-      formikProps={formikProps}
-      label={i18n.t('diet-study.other-info.label')}
-      name="other_info"
-      inputProps={{
-        multiline: true,
-        numberOfLines: 5,
-      }}
-      wrapperStyle={styles.input}
-    />
+    <>
+      <GenericTextField
+        formikProps={formikProps}
+        label={i18n.t('diet-study.other-info.label')}
+        name="other_info"
+        inputProps={{
+          multiline: true,
+          numberOfLines: 5,
+          maxLength: CHAR_LIMIT,
+        }}
+        wrapperStyle={styles.input}
+      />
+      <CaptionText style={styles.limit}>
+        {i18n.t('diet-study.other-info.text-limit-caption', { count: CHAR_LIMIT })}
+      </CaptionText>
+    </>
   );
 };
 
@@ -42,7 +51,9 @@ OtherInfoQuestion.initialFormValues = (): OtherInfoData => ({ other_info: '' });
 
 OtherInfoQuestion.schema = () =>
   Yup.object().shape({
-    other_info: Yup.string().required(i18n.t('diet-study.required')),
+    other_info: Yup.string()
+      .required(i18n.t('diet-study.required'))
+      .max(CHAR_LIMIT, i18n.t('diet-study.other-info.text-limit', { count: CHAR_LIMIT })),
   });
 
 OtherInfoQuestion.createDTO = (formData: OtherInfoData): Partial<DietStudyRequest> => {
@@ -55,5 +66,8 @@ const styles = StyleSheet.create({
   input: {
     marginVertical: 12,
     marginHorizontal: 16,
+  },
+  limit: {
+    paddingLeft: 16,
   },
 });


### PR DESCRIPTION
# Description

Added a limit to other info text field on diet study

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2020-08-07 at 11 52 09](https://user-images.githubusercontent.com/36766508/89638886-7d800700-d8a4-11ea-8538-452048efe150.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
