### PR TITLE
Drive Welcome Repeat screen from server response

### DIFF
--- a/src/core/content/ContentService.ts
+++ b/src/core/content/ContentService.ts
@@ -1,7 +1,7 @@
 import { injectable, inject } from 'inversify';
 
 import { AsyncStorageService, PersonalisedLocalData, PERSONALISED_LOCAL_DATA } from '@covid/core/AsyncStorageService';
-import { AreaStatsResponse } from '@covid/core/user/dto/UserAPIContracts';
+import { AreaStatsResponse, StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
 import { handleServiceError } from '@covid/core/api/ApiServiceErrors';
 import UserService, { isSECountry, isUSCountry } from '@covid/core/user/UserService';
 import i18n from '@covid/locale/i18n';
@@ -17,7 +17,7 @@ export interface IContentService {
   getAskedToRateStatus(): Promise<string | null>;
   setAskedToRateStatus(status: string): void;
   getUserCount(): Promise<string | null>;
-  getStartupInfo(): void;
+  getStartupInfo(): Promise<StartupInfo | null>;
   getAreaStats(patientId: string): Promise<AreaStatsResponse>;
 }
 
@@ -82,9 +82,12 @@ export default class ContentService implements IContentService {
         await AsyncStorageService.setItem(JSON.stringify(camelizeKeys(data)), PERSONALISED_LOCAL_DATA);
         this.localData = data;
       }
+      return info;
     } catch (error) {
       handleServiceError(error);
     }
+
+    return null;
   }
 
   public async getAskedToRateStatus() {

--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -272,6 +272,7 @@ export type AreaStatsResponse = {
 export type StartupInfo = {
   users_count: number;
   ip_country: string;
+  show_new_dashboard: boolean;
   local_data: {
     map_url: string;
     name: string;

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -25,14 +25,6 @@ type ScreenFlow = {
   [key in ScreenName]: () => void;
 };
 
-// Various route parameters
-type PatientIdParamType = { patientId: string };
-type CurrentPatientParamType = { currentPatient: PatientStateType };
-type ConsentView = { viewOnly: boolean };
-type ProfileParamType = { profile: Profile };
-type ProfileIdType = { profileId: string };
-type RouteParamsType = PatientIdParamType | CurrentPatientParamType | ConsentView | ProfileParamType | ProfileIdType; //TODO Can be used for passing params to goToNextScreen
-
 export type NavigationType = StackNavigationProp<ScreenParamList, keyof ScreenParamList>;
 
 export class AppCoordinator {
@@ -45,7 +37,7 @@ export class AppCoordinator {
   patientId: string | null = null;
   currentPatient: PatientStateType;
 
-  homeScreenName: ScreenName = 'Dashboard';
+  homeScreenName: ScreenName = 'WelcomeRepeat';
 
   screenFlow: ScreenFlow = {
     Splash: () => {
@@ -86,6 +78,7 @@ export class AppCoordinator {
       }
     },
     Dashboard: () => {
+      // UK only so currently no need to check config.enableMultiplePatients
       NavigatorService.navigate('SelectProfile');
     },
     ArchiveReason: () => {
@@ -108,11 +101,12 @@ export class AppCoordinator {
   } as ScreenFlow;
 
   async init() {
-    await this.contentService.getStartupInfo();
+    const info = await this.contentService.getStartupInfo();
     this.patientId = await this.userService.getFirstPatientId();
     if (this.patientId) {
       this.currentPatient = await this.userService.getPatientState(this.patientId);
     }
+    this.homeScreenName = info?.show_new_dashboard ? 'Dashboard' : 'WelcomeRepeat';
   }
 
   getConfig(): ConfigType {


### PR DESCRIPTION
# Description

Use show_new_dashboard returned on startup_info to drive the behaviour of the HomeScreen. 
Thanks @snack-0verflow for laying the ground work for this!


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
