### PR TITLE
fix: load map differently. uses HTML string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-native-svg": "9.13.3",
     "react-native-view-shot": "3.0.2",
     "react-native-web": "~0.11.7",
-    "react-native-webview": "^10.4.0",
+    "react-native-webview": "7.4.3",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "redux": "^4.0.5",
@@ -75,7 +75,8 @@
     "uuid": "^8.0.0",
     "weak-key": "^1.0.2",
     "yup": "^0.28.3",
-    "react-native-webview": "7.4.3"
+    "expo-asset": "~8.0.0",
+    "expo-file-system": "~8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/features/EstimatedCasesScreen.tsx
+++ b/src/features/EstimatedCasesScreen.tsx
@@ -1,19 +1,28 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { StackNavigationProp } from '@react-navigation/stack';
 
+import { BackButton } from '@covid/components/PatientHeader';
+import { ScreenParamList } from '@covid/features/ScreenParamList';
+import { loadEstimatedCasesCartoMap } from '@covid/utils/files';
 import { colors } from '@theme';
-
-import { BackButton } from '../components/PatientHeader';
-
-import { ScreenParamList } from './ScreenParamList';
 
 interface Props {
   navigation: StackNavigationProp<ScreenParamList>;
 }
 
 export const EstimatedCasesScreen: React.FC<Props> = ({ navigation }) => {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setHtml(await loadEstimatedCasesCartoMap());
+      } catch (_) {}
+    })();
+  }, []);
+
   return (
     <View style={{ flex: 1, marginBottom: 0, backgroundColor: 'white' }}>
       <View
@@ -26,7 +35,7 @@ export const EstimatedCasesScreen: React.FC<Props> = ({ navigation }) => {
         }}>
         <BackButton navigation={navigation} />
       </View>
-      <WebView originWhitelist={['*']} source={require('@assets/carto/estimated-cases.html')} style={styles.webview} />
+      {html && <WebView originWhitelist={['*']} source={{ html }} style={styles.webview} />}
     </View>
   );
 };

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,24 @@
+import { Asset } from 'expo-asset';
+import * as FileSystem from 'expo-file-system';
+
+export const EstimatedCasesCartoMap = require('@assets/carto/estimated-cases.html');
+
+export const loadHTMLAsString = async (asset: number | string): Promise<string> => {
+  const file = Asset.fromModule(asset);
+  await file.downloadAsync();
+  if (!file.localUri) {
+    throw new Error('Local file uri not found for given asset');
+  }
+  return await FileSystem.readAsStringAsync(file.localUri);
+};
+
+//
+// This is required for Android. Because the following didn't work,
+// causes 'sources not defined.' on webview.
+// <Webview source{require('file.html')} />
+//
+// With this we can use html in Webview, like the following example
+// <Webview source{{ html: loadEstimatedCasesCartoMap() }} />
+// (Not the best example as this method is async).
+
+export const loadEstimatedCasesCartoMap = async (): Promise<string> => loadHTMLAsString(EstimatedCasesCartoMap);


### PR DESCRIPTION
# Description

WebView has issue loading file through `require('file.html')` on Android.

## On what platform have you tested the change?

- [x] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [x] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2020-08-14 at 15 46 08](https://user-images.githubusercontent.com/36766508/90261805-62ce0500-de45-11ea-9af7-20e5ae87b650.png)
![Screenshot_1597416364](https://user-images.githubusercontent.com/36766508/90261806-63669b80-de45-11ea-8439-db16d3c962ee.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
