### PR TITLE
fix: add 'Dashboard' to nav stack when resetting

### DIFF
--- a/src/features/thank-you/ThankYouUKScreen.tsx
+++ b/src/features/thank-you/ThankYouUKScreen.tsx
@@ -133,7 +133,7 @@ export default class ThankYouUKScreen extends Component<RenderProps, State> {
                   onPress={() =>
                     this.props.navigation.reset({
                       index: 1,
-                      routes: [{ name: 'Dashboard' }, { name: 'SelectProfile' }],
+                      routes: [{ name: appCoordinator.homeScreenName }, { name: 'SelectProfile' }],
                     })
                   }
                   style={styles.ctaMultipleProfileText}>

--- a/src/features/thank-you/ThankYouUKScreen.tsx
+++ b/src/features/thank-you/ThankYouUKScreen.tsx
@@ -132,8 +132,8 @@ export default class ThankYouUKScreen extends Component<RenderProps, State> {
                 <ClickableText
                   onPress={() =>
                     this.props.navigation.reset({
-                      index: 0,
-                      routes: [{ name: 'SelectProfile' }],
+                      index: 1,
+                      routes: [{ name: 'Dashboard' }, { name: 'SelectProfile' }],
                     })
                   }
                   style={styles.ctaMultipleProfileText}>


### PR DESCRIPTION
# Description

Added `Dashboard` to nav stack while resetting, also set current nav index to `SelectProfile`

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
