### PR TITLE
fix: added arrow on empty state & made both maps clickable

### DIFF
--- a/src/components/Cards/EstimatedCasesMapCard.tsx
+++ b/src/components/Cards/EstimatedCasesMapCard.tsx
@@ -56,6 +56,11 @@ const EmptyView: React.FC<EmptyViewProps> = ({ onPress, ...props }) => {
     NavigatorService.navigate('EstimatedCases');
   };
 
+  const onArrowTapped = () => {
+    Analytics.track(events.ESTIMATED_CASES_MAP_CLICKED, { origin: MapEventOrigin.Arrow });
+    NavigatorService.navigate('EstimatedCases');
+  };
+
   useEffect(() => {
     Analytics.track(events.ESTIMATED_CASES_MAP_EMPTY_STATE_SHOWN);
     (async () => {
@@ -75,8 +80,13 @@ const EmptyView: React.FC<EmptyViewProps> = ({ onPress, ...props }) => {
         </View>
       )}
 
-      <View style={styles.headerContainer}>
-        <Header3Text style={styles.primaryLabel}>{primaryLabel}</Header3Text>
+      <View style={[styles.headerContainer, { width: '90%' }]}>
+        <Header3Text style={[styles.primaryLabel, { marginTop: 4 }]}>{primaryLabel}</Header3Text>
+        <View style={styles.emptyStateArrow}>
+          <TouchableOpacity style={[styles.backIcon, { marginBottom: 8 }]} onPress={onArrowTapped}>
+            <ChevronRight width={32} height={32} />
+          </TouchableOpacity>
+        </View>
         {showUpdatePostcode && <RegularText style={styles.secondaryLabel}>{secondaryLabel}</RegularText>}
       </View>
 
@@ -187,6 +197,7 @@ export const EstimatedCasesMapCard: React.FC<Props> = ({}) => {
           source={{ html }}
           style={styles.webview}
           onEvent={onMapEvent}
+          pointerEvents="none"
         />
       );
     }
@@ -204,6 +215,11 @@ export const EstimatedCasesMapCard: React.FC<Props> = ({}) => {
 
   const showMap = () => {
     Analytics.track(events.ESTIMATED_CASES_MAP_CLICKED, { origin: MapEventOrigin.Arrow });
+    NavigatorService.navigate('EstimatedCases');
+  };
+
+  const onMapTapped = () => {
+    Analytics.track(events.ESTIMATED_CASES_MAP_CLICKED, { origin: MapEventOrigin.Map });
     NavigatorService.navigate('EstimatedCases');
   };
 
@@ -227,8 +243,10 @@ export const EstimatedCasesMapCard: React.FC<Props> = ({}) => {
         <MutedText style={styles.secondaryLabel}>{i18n.t('covid-cases-map.current-estimates')}</MutedText>
       </View>
 
-      <View style={styles.mapContainer} pointerEvents="none">
-        {map()}
+      <View style={styles.mapContainer}>
+        <TouchableOpacity activeOpacity={0.6} onPress={onMapTapped}>
+          {map()}
+        </TouchableOpacity>
       </View>
 
       <View style={styles.statsContainer}>
@@ -360,5 +378,12 @@ const styles = StyleSheet.create({
 
   postcodeButton: {
     marginBottom: 20,
+  },
+
+  emptyStateArrow: {
+    position: 'absolute',
+    flexDirection: 'row',
+    alignItems: 'center',
+    right: 0,
   },
 });


### PR DESCRIPTION
# Description

- Added arrow to map card on empty state
- Made Map clickable / touchable, will navigate to full screen map

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Image from iOS (1)](https://user-images.githubusercontent.com/36766508/90384971-51217300-e07a-11ea-995d-744fd41fa37e.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
