### PR TITLE
Fix US Study Modal

### DIFF
--- a/src/components/USStudyInvite.tsx
+++ b/src/components/USStudyInvite.tsx
@@ -10,7 +10,7 @@ import Analytics, { events } from '@covid/core/Analytics';
 import { useInjection } from '@covid/provider/services.hooks';
 import { Services } from '@covid/provider/services.types';
 import { isUSCountry } from '@covid/core/localisation/LocalisationService';
-import { IConsentService } from '@covid/core/consent/ConsentService';
+import { IPatientService } from '@covid/core/patient/PatientService';
 
 import { BrandedButton } from './BrandedButton';
 
@@ -19,7 +19,7 @@ type StudyInviteProps = {
 };
 
 export const USStudyInvite: React.FC<StudyInviteProps> = (props: StudyInviteProps) => {
-  const consentService = useInjection<IConsentService>(Services.Consent);
+  const patientService = useInjection<IPatientService>(Services.Patient);
   const [modalVisible, setModalVisible] = useState(false);
   const { currentPatient } = props.assessmentData;
 
@@ -32,14 +32,14 @@ export const USStudyInvite: React.FC<StudyInviteProps> = (props: StudyInviteProp
   const handleAgree = () => {
     setModalVisible(false);
     Analytics.track(events.ACCEPT_STUDY_CONTACT);
-    consentService.setUSStudyInviteResponse(props.assessmentData.currentPatient.patientId, true);
+    patientService.setUSStudyInviteResponse(props.assessmentData.currentPatient.patientId, true);
     currentPatient.shouldShowUSStudyInvite = false;
   };
 
   const handleClose = () => {
     setModalVisible(false);
     Analytics.track(events.DECLINE_STUDY_CONTACT);
-    consentService.setUSStudyInviteResponse(props.assessmentData.currentPatient.patientId, false);
+    patientService.setUSStudyInviteResponse(props.assessmentData.currentPatient.patientId, false);
     currentPatient.shouldShowUSStudyInvite = false;
   };
 

--- a/src/core/Experiments.ts
+++ b/src/core/Experiments.ts
@@ -1,6 +1,7 @@
 import Analytics from '@covid/core/Analytics';
 import { container } from '@covid/provider/services';
 import { Services } from '@covid/provider/services.types';
+import { IUserService } from '@covid/core/user/UserService';
 
 export const experiments = {
   Experiment_001: 'Experiment_001', // Test alternative external callouts on UK Thank You Pags
@@ -27,6 +28,8 @@ function getVariant(hash: string, totalVariants: number): string {
 
 export async function startExperiment(experimentName: string, totalVariants: number): Promise<string | null> {
   const profile = await container.get<IUserService>(Services.User).getProfile();
+  if (!profile) return null;
+
   const variant = getVariant(profile.username, totalVariants);
   const payload: { [index: string]: string } = {};
   payload[experimentName] = variant;

--- a/src/core/patient/PatientService.ts
+++ b/src/core/patient/PatientService.ts
@@ -26,6 +26,7 @@ export interface IPatientService {
   updatePatientState(patientState: PatientStateType, patient: PatientInfosRequest): Promise<PatientStateType>;
   getCurrentPatient(patientId: string, patient?: PatientInfosRequest): Promise<PatientStateType>;
   shouldAskLevelOfIsolation(dateLastAsked: Date | null): boolean;
+  setUSStudyInviteResponse(patientId: string, response: boolean): void;
 }
 
 @injectable()
@@ -213,5 +214,9 @@ export class PatientService extends ApiClientBase implements IPatientService {
   public shouldAskLevelOfIsolation(dateLastAsked: Date | null): boolean {
     if (!dateLastAsked) return true;
     return getDaysAgo(dateLastAsked) >= FREQUENCY_TO_ASK_ISOLATION_QUESTION;
+  }
+
+  public setUSStudyInviteResponse(patientId: string, response: boolean) {
+    this.updatePatient(patientId, { contact_additional_studies: response });
   }
 }


### PR DESCRIPTION
# Description

Fixes a problem when dismissing a the US Study Invite Modal. (Only shown for new US users). 

This was a caused by a circular reference between between ConsentService and PatientService. 

The USStudyInvite "consent" is an anomoly - as the flag is on the patient model. So `setUSStudyInviteResponse` really does belong in the PatientService. 



## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

