### PR TITLE
Clean up Delete Data Endpoint & AsyncStorage

### DIFF
--- a/src/core/AsyncStorageService.ts
+++ b/src/core/AsyncStorageService.ts
@@ -2,7 +2,6 @@ import { AsyncStorage } from 'react-native';
 
 import { DietStudyConsent } from '@covid/core/diet-study/DietStudyCoordinator';
 
-import { UserResponse } from './user/dto/UserAPIContracts';
 import { AuthenticatedUser } from './user/UserService';
 
 const AUTH_TOKEN = 'authToken';
@@ -14,9 +13,7 @@ const CONSENT_SIGNED = 'consentSigned';
 const PUSH_TOKEN = 'pushToken';
 const DIET_STUDY_CONSENT = 'dietStudyConsent';
 
-const USER_PROFILE = 'userProfile';
 const ASKED_COUNTRY = 'askedCountry';
-
 const ASKED_TO_REPORT_FOR_OTHERS = 'askedToReportForOthers';
 
 export const PERSONALISED_LOCAL_DATA = 'personalisedLocalData';
@@ -93,30 +90,6 @@ export class AsyncStorageService {
     if (askedCountry == null) return false;
     else {
       return JSON.parse(askedCountry) as boolean;
-    }
-  }
-
-  static async saveProfile(profile: UserResponse | null) {
-    try {
-      await AsyncStorage.setItem(USER_PROFILE, JSON.stringify(profile));
-    } catch (err) {
-      // Swallow for now
-      // todo: find a way to report the crash and an alternative
-    }
-  }
-
-  static async getProfile() {
-    let userProfile: string | null = null;
-    try {
-      userProfile = await AsyncStorage.getItem(USER_PROFILE);
-    } catch (e) {
-      // Swallow for now
-      // todo: find a way to report the crash and an alternative
-    }
-
-    if (userProfile == null) return null;
-    else {
-      return JSON.parse(userProfile) as UserResponse;
     }
   }
 

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -85,7 +85,6 @@ export default class UserService extends ApiClientBase implements IUserService {
   private async deleteLocalUserData() {
     ApiClientBase.unsetToken();
     await AsyncStorageService.clearData();
-    await AsyncStorageService.saveProfile(null);
     await this.consentService.setConsentSigned('', '', '');
   }
 
@@ -100,7 +99,6 @@ export default class UserService extends ApiClientBase implements IUserService {
     const data = this.getData<LoginOrRegisterResponse>(response);
     const authToken = data.key;
     await this.storeTokenInAsyncStorage(authToken, data.user.pii);
-    await AsyncStorageService.saveProfile(data.user);
     this.client.defaults.headers['Authorization'] = 'Token ' + authToken;
     this.hasUser = true;
     return data;
@@ -162,7 +160,6 @@ export default class UserService extends ApiClientBase implements IUserService {
   public async getProfile(): Promise<UserResponse | null> {
     try {
       const { data: profile } = await this.client.get<UserResponse>(`/profile/`);
-      await AsyncStorageService.saveProfile(profile);
       return profile;
     } catch (error) {
       handleServiceError(error);

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -176,12 +176,6 @@ export default class UserService extends ApiClientBase implements IUserService {
   }
 
   async deleteRemoteUserData() {
-    const profile = await AsyncStorageService.getProfile();
-    const payload = {
-      username: profile?.username,
-    };
-    return this.client.delete(`/users/delete/`, {
-      data: payload,
-    });
+    return this.client.delete(`/users/delete/`);
   }
 }


### PR DESCRIPTION
# Description

- Backend PR is up to clean up the Delete user endpoint, which too the username as payload JSON, whereas it's implicit - you can only delete yourself as the authenticated user. 

- This results in a clean more RESTFul delete endpoint and it also allows us to remove the saveProfile and getProfile from AsyncStorage.


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device
