### PR TITLE
fix: move snapshot ref to another container

### DIFF
--- a/src/components/Cards/EstimatedCasesMapCard.tsx
+++ b/src/components/Cards/EstimatedCasesMapCard.tsx
@@ -235,35 +235,37 @@ export const EstimatedCasesMapCard: React.FC<Props> = () => {
   }
 
   return (
-    <View style={styles.root} ref={viewRef}>
-      <View style={styles.headerContainer}>
-        <Header3Text style={styles.primaryLabel}>
-          {i18n.t('covid-cases-map.covid-in-x', { location: displayLocation })}
-        </Header3Text>
-        <MutedText style={styles.secondaryLabel}>{i18n.t('covid-cases-map.current-estimates')}</MutedText>
-      </View>
+    <View style={styles.root}>
+      <View style={styles.snapshotContainer} ref={viewRef}>
+        <View style={styles.headerContainer}>
+          <Header3Text style={styles.primaryLabel}>
+            {i18n.t('covid-cases-map.covid-in-x', { location: displayLocation })}
+          </Header3Text>
+          <MutedText style={styles.secondaryLabel}>{i18n.t('covid-cases-map.current-estimates')}</MutedText>
+        </View>
 
-      <View style={styles.mapContainer}>
-        <TouchableOpacity activeOpacity={0.6} onPress={onMapTapped}>
-          {map()}
-        </TouchableOpacity>
-      </View>
+        <View style={styles.mapContainer}>
+          <TouchableOpacity activeOpacity={0.6} onPress={onMapTapped}>
+            {map()}
+          </TouchableOpacity>
+        </View>
 
-      <View style={styles.statsContainer}>
-        {!!activeCases && (
-          <View style={styles.statsRow}>
-            <Header0Text style={styles.stats}>{activeCases}</Header0Text>
-            <MutedText style={styles.statsLabel}>{i18n.t('covid-cases-map.active-cases-in-area')}</MutedText>
-          </View>
-        )}
-        {!activeCases && (
-          <View style={styles.statsRow}>
-            <MutedText style={styles.statsLabel}>{i18n.t('covid-cases-map.not-enough-contributors')}</MutedText>
-          </View>
-        )}
-        <TouchableOpacity style={styles.backIcon} onPress={showMap}>
-          <ChevronRight width={32} height={32} />
-        </TouchableOpacity>
+        <View style={styles.statsContainer}>
+          {!!activeCases && (
+            <View style={styles.statsRow}>
+              <Header0Text style={styles.stats}>{activeCases}</Header0Text>
+              <MutedText style={styles.statsLabel}>{i18n.t('covid-cases-map.active-cases-in-area')}</MutedText>
+            </View>
+          )}
+          {!activeCases && (
+            <View style={styles.statsRow}>
+              <MutedText style={styles.statsLabel}>{i18n.t('covid-cases-map.not-enough-contributors')}</MutedText>
+            </View>
+          )}
+          <TouchableOpacity style={styles.backIcon} onPress={showMap}>
+            <ChevronRight width={32} height={32} />
+          </TouchableOpacity>
+        </View>
       </View>
 
       <View style={styles.divider} />
@@ -392,5 +394,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     right: 0,
+  },
+
+  snapshotContainer: {
+    width: '100%',
   },
 });


### PR DESCRIPTION
# Description

- New container to use for snapshot container's ref (no more rounded corners in snapshot image)
- Share button no longer within the container for the shareable image

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
