### PR TITLE
Fix/Refresh homescreen data on Login

### DIFF
--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -136,7 +136,6 @@ export class AppCoordinator {
     let profile: UserResponse | null = null;
 
     await this.userService.loadUser();
-    const info = await this.contentService.getStartupInfo();
 
     if (this.userService.hasUser) {
       profile = await this.userService.getProfile();
@@ -153,14 +152,18 @@ export class AppCoordinator {
       store.dispatch(fetchUKMetrics());
     }
 
-    // Set main route depending on API / Country
-    this.homeScreenName = store.getState().content.startupInfo?.show_new_dashboard ? 'Dashboard' : 'WelcomeRepeat';
-    this.homeScreenName = isGBCountry() ? this.homeScreenName : 'WelcomeRepeat';
+    this.setHomeScreenName();
 
     // Track insights
     if (shouldShowCountryPicker) {
       Analytics.track(events.MISMATCH_COUNTRY_CODE, { current_country_code: LocalisationService.userCountry });
     }
+  }
+
+  setHomeScreenName(): void {
+    // Set main route depending on API / Country
+    this.homeScreenName = store.getState().content.startupInfo?.show_new_dashboard ? 'Dashboard' : 'WelcomeRepeat';
+    this.homeScreenName = isGBCountry() ? this.homeScreenName : 'WelcomeRepeat';
   }
 
   getConfig(): ConfigType {

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -147,16 +147,19 @@ export class AppCoordinator {
       shouldShowCountryPicker = profile!.country_code !== LocalisationService.userCountry;
     }
 
-    await store.dispatch(fetchStartUpInfo());
-    if (isGBCountry()) {
-      store.dispatch(fetchUKMetrics());
-    }
-
+    await this.fetchInitialData();
     this.setHomeScreenName();
 
     // Track insights
     if (shouldShowCountryPicker) {
       Analytics.track(events.MISMATCH_COUNTRY_CODE, { current_country_code: LocalisationService.userCountry });
+    }
+  }
+
+  async fetchInitialData(): Promise<void> {
+    await store.dispatch(fetchStartUpInfo());
+    if (isGBCountry()) {
+      await store.dispatch(fetchUKMetrics());
     }
   }
 

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -21,6 +21,8 @@ import { BrandedButton, ClickableText, HeaderLightText, RegularText } from '@cov
 import { Services } from '@covid/provider/services.types';
 import { lazyInject } from '@covid/provider/services';
 import appCoordinator from '@covid/features/AppCoordinator';
+import store from '@covid/core/state/store';
+import { fetchStartUpInfo } from '@covid/core/content/state/contentSlice';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -77,9 +79,15 @@ export class LoginScreen extends Component<PropsType, StateType> {
 
         // TODO: Support multiple users.
         const patientId = response.user.patients[0];
-        appCoordinator.setPatientId(patientId).then(() => {
-          appCoordinator.gotoNextScreen(this.props.route.name);
-        });
+        appCoordinator
+          .setPatientId(patientId)
+          .then(() => {
+            store.dispatch(fetchStartUpInfo());
+            appCoordinator.setHomeScreenName();
+          })
+          .then(() => {
+            appCoordinator.gotoNextScreen(this.props.route.name);
+          });
       })
       .catch((error) => {
         if (error.constructor === UserNotFoundException) {

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -21,8 +21,6 @@ import { BrandedButton, ClickableText, HeaderLightText, RegularText } from '@cov
 import { Services } from '@covid/provider/services.types';
 import { lazyInject } from '@covid/provider/services';
 import appCoordinator from '@covid/features/AppCoordinator';
-import store from '@covid/core/state/store';
-import { fetchStartUpInfo } from '@covid/core/content/state/contentSlice';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -81,10 +79,8 @@ export class LoginScreen extends Component<PropsType, StateType> {
         const patientId = response.user.patients[0];
         appCoordinator
           .setPatientId(patientId)
-          .then(() => {
-            store.dispatch(fetchStartUpInfo());
-            appCoordinator.setHomeScreenName();
-          })
+          .then(() => appCoordinator.fetchInitialData())
+          .then(() => appCoordinator.setHomeScreenName())
           .then(() => {
             appCoordinator.gotoNextScreen(this.props.route.name);
           });


### PR DESCRIPTION
# Description

Triggers a refetch of startupInfo on Login to ensure any returning users, or users who've logged out for any reason still see the dashboard.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device