### PR TITLE
feat: update 'edit profile' / 'create'

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -106,6 +106,7 @@
 
   "back-date-profile-title": "Some additional questions about you",
   "update-profile": "Update profile",
+  "create-profile": "Create",
 
   "title-about-work": "About your work",
 

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -106,6 +106,7 @@
 
   "back-date-profile-title": "Algunas preguntas adicionales sobre usted",
   "update-profile": "Actualizar perfil",
+  "create-profile": "Crear",
 
   "title-about-work": "Acerca de su trabajo",
 

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -557,6 +557,7 @@
 
   "back-date-profile-title": "Några fler frågor om dig",
   "update-profile": "Uppdatera profilen",
+  "create-profile": "Skapa",
 
   "covid-test-list": {
     "title": "Dina covid-19-tester",

--- a/src/components/NewProfileCard.tsx
+++ b/src/components/NewProfileCard.tsx
@@ -6,13 +6,16 @@ import { addProfile } from '@assets';
 import i18n from '@covid/locale/i18n';
 import { colors } from '@theme';
 
-import { RegularText } from './Text';
+import { RegularText, SecondaryText } from './Text';
 
 export const NewProfileCard: React.FC = () => {
   return (
     <Card style={styles.card} transparent>
       <Image source={addProfile} style={styles.addImage} resizeMode="contain" />
       <RegularText>{i18n.t('select-profile-button')}</RegularText>
+      <SecondaryText style={{ textAlign: 'center', fontSize: 12, color: colors.accent }}>
+        {i18n.t('create-profile')}
+      </SecondaryText>
       <View style={{ height: 14 }} />
     </Card>
   );

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -4,13 +4,12 @@ import { Card } from 'native-base';
 
 import { AvatarName, getAvatarByName } from '@covid/utils/avatar';
 import { getDaysAgo } from '@covid/utils/datetime';
-import InfoCircle from '@assets/icons/InfoCircle';
 import { GreenTick } from '@covid/components/GreenTick';
 import { colors } from '@theme';
 import { Profile } from '@covid/components/Collections/ProfileList';
-
-import { ClippedText } from './Text';
-import LastReported from './LastReported';
+import i18n from '@covid/locale/i18n';
+import { ClippedText, SecondaryText } from '@covid/components/Text';
+import LastReported from '@covid/components/LastReported';
 
 type Props = {
   profile: Profile;
@@ -24,29 +23,26 @@ export const ProfileCard: React.FC<Props> = (props) => {
 
   return (
     <Card style={styles.card} transparent>
-      <View style={styles.infoContainer}>
-        <TouchableOpacity onPress={props.onEditPressed}>
-          <InfoCircle />
-        </TouchableOpacity>
-      </View>
-
       <View style={styles.avatarContainer}>
         {hasReportedToday && <GreenTick />}
         <Image source={avatarImage} style={styles.avatar} resizeMode="contain" />
       </View>
       <ClippedText>{profile.name}</ClippedText>
       <LastReported timeAgo={profile.last_reported_at} />
+      <TouchableOpacity onPress={props.onEditPressed}>
+        <SecondaryText style={{ textAlign: 'center', fontSize: 12, color: colors.accent }}>
+          {i18n.t('nav-edit-profile')}
+        </SecondaryText>
+      </TouchableOpacity>
     </Card>
   );
 };
 
 const styles = StyleSheet.create({
-  infoContainer: {
-    alignSelf: 'flex-end',
-  },
   avatarContainer: {
     alignItems: 'center',
     width: 100,
+    marginTop: 20,
     marginBottom: 10,
   },
   avatar: {

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -2,6 +2,7 @@ export const colors = {
   brand: '#024364',
   lightBrand: '#5D879C',
   predict: '#082A5D',
+  accent: '#A0278F',
 
   primary: '#565A5C',
   secondary: '#888B8C',


### PR DESCRIPTION
# Description

- Remove the 'i' icon for edit profile
- Add touchable text "Edit profile"
- Add non-touchable text "Create"

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2020-09-08 at 18 42 44](https://user-images.githubusercontent.com/36766508/92510089-34a0d280-f203-11ea-96a2-867e2e3e058a.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
