### PR TITLE
update readme with total reset and multiple ios sims

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,24 +61,18 @@ npm install expo-cli --g
    git clone git@github.com:zoe/covid-tracker-react-native.git
    ```
 
-2. When you first start your application you should see the IP address in the console (located above the QR code). For example:
+2. Create a `.env` file and set the api end point - please note that `http://` is required otherwise API requests will fail.
+* Stage: https://zoe-covid19-stage.appspot.com/
+* Prod: https://api.covidradar.org/
 
    ```sh
-   exp://123.456.7.890:19000
-   ```
-
-   Copy the host part of the IP address only.
-
-3. Create a `.env` file - please note that `http://` is required otherwise API requests will fail.
-
-   ```sh
-   echo "API_URL=http://<ip_address_host_here>:3000" > .env
+   echo "API_URL=http://<api_url_here>:3000" > .env
    ```
 
    e.g.
 
    ```sh
-   echo "API_URL=http://123.456.7.890:3000" > .env
+   echo "API_URL=https://zoe-covid19-stage.appspot.com/" > .env
    ```
 
 4. Run the following command to create `AMPLITUDE_KEY` environment variable:
@@ -105,6 +99,7 @@ npm install expo-cli --g
    ```bash
    npm run mock-server
    ```
+   * note: Mock server is currently unavailble (using)
    
 ### Git Hooks
 
@@ -157,6 +152,14 @@ These are some known, common issues and their solutions:
 2. Unable to resolve module `deprecated-react-native-listview`
 
 - Solution: Running `rm -rf $TMPDIR/metro-cache` has been reported to solve the problem. 
+
+3. Sometimes when working with React Native a total reset is required to get things up and running again. There can be lots of reasons for this and some googling may be required, however, the following is a common approach that works for many instances:
+```bash
+watchman watch-del-all && rm package-lock.json && rm -rf node_modules && rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/haste-map-* && npm install
+```
+
+## Multiple iOS simulators
+[How to run multiple ios simulators with expo](https://stackoverflow.com/questions/53924934/can-i-run-my-expo-app-on-multiple-ios-simulators-at-once) 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,19 +61,36 @@ npm install expo-cli --g
    git clone git@github.com:zoe/covid-tracker-react-native.git
    ```
 
-2. Create a `.env` file and set the api end point - please note that `http://` is required otherwise API requests will fail.
-* Stage: https://zoe-covid19-stage.appspot.com/
-* Prod: https://api.covidradar.org/
+2. When you first start your application you should see the IP address in the console (located above the QR code). For example:
 
    ```sh
-   echo "API_URL=http://<api_url_here>:3000" > .env
+   exp://123.456.7.890:19000
+   ```
+
+3. Create a .env file - please note that http:// is required otherwise API requests will fail.
+
+   ```sh
+   echo "API_URL=http://<ip_address_host_here>:3000" > .env
    ```
 
    e.g.
 
    ```sh
-   echo "API_URL=https://zoe-covid19-stage.appspot.com/" > .env
+   echo "API_URL=http://123.456.7.890:3000" > .env
    ```
+
+   NOTE: if you change the .env file be sure to clear the metro cache to ensure your changes take place.
+
+   ```
+   rm -rf $TMPDIR/metro-*
+   ```
+
+   or
+
+   ```
+   expo clear-metro-cache
+   ```
+
 
 4. Run the following command to create `AMPLITUDE_KEY` environment variable:
 
@@ -154,8 +171,15 @@ These are some known, common issues and their solutions:
 - Solution: Running `rm -rf $TMPDIR/metro-cache` has been reported to solve the problem. 
 
 3. Sometimes when working with React Native a total reset is required to get things up and running again. There can be lots of reasons for this and some googling may be required, however, the following is a common approach that works for many instances:
+
 ```bash
 watchman watch-del-all && rm package-lock.json && rm -rf node_modules && rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/haste-map-* && npm install
+```
+
+or run
+
+```bash
+expo reset
 ```
 
 ## Multiple iOS simulators

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "ts-node": "ts-node",
     "mock-server": "ts-node ./mock-server/mockServer.ts --watch",
     "storybook": "start-storybook",
-    "clean": "git checkout develop && git pull && git fetch --all --prune && for branch in `git branch -vv | grep ': gone]' | awk '{print $1}'`; do git branch -D $branch; done"
+    "clean": "git checkout develop && git pull && git fetch --all --prune && for branch in `git branch -vv | grep ': gone]' | awk '{print $1}'`; do git branch -D $branch; done",
+    "reset": "watchman watch-del-all && rm package-lock.json && rm -rf node_modules && rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/haste-map-* && npm install",
+    "clear-metro-cache": "rm -rf $TMPDIR/metro-*"
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "2.1.0",


### PR DESCRIPTION
I've updated the readme to include a total reset command. A common clear cache command.

Added link to setting up multiple simulators for ios with expo
