### PR TITLE
Add bottom margin to screen

### DIFF
--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -130,6 +130,7 @@ const styles = StyleSheet.create({
   pageBlock: {
     flexGrow: 1,
     marginHorizontal: 16,
+    marginBottom: 16,
   },
 
   headerBlock: {


### PR DESCRIPTION
# Description

Adds a bottom margin to screen element to always have gap between bottom and any elements. This makes sure buttons don't sit on the bottom line of the screen.