### PR TITLE
Fixes passing of selected school via schoolCoordinator

### DIFF
--- a/src/features/school-network/JoinSchoolScreen.tsx
+++ b/src/features/school-network/JoinSchoolScreen.tsx
@@ -63,7 +63,7 @@ export const JoinSchoolScreen: React.FC<Props> = ({ route, navigation, ...props 
   }, []);
 
   const onSubmit = (schoolData: JoinSchoolData) => {
-    schoolNetworkCoordinator.selectedSchool = schools.filter((school) => (school.id = schoolData.schoolId))[0];
+    schoolNetworkCoordinator.selectedSchool = schools.filter((school) => school.id === schoolData.schoolId)[0];
     next();
   };
 


### PR DESCRIPTION
# Description

User reported bug: 
 - If you select the second school in the list and then goto the next screen to pick the group - the name of the first school appears in the title text. 



The filter was not using equality check. Missed in code review :( 
Needs a follow up PR to change how this works for long dropdown list - but this is the smallest PR for now. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Screenshot 2020-09-11 at 17 32 35](https://user-images.githubusercontent.com/7824212/92951335-17177700-f456-11ea-8774-b4b259508f71.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
