### PR TITLE
CHORE: Remove calls to backkend app_text API. 

### DIFF
--- a/src/core/content/ContentApiClient.ts
+++ b/src/core/content/ContentApiClient.ts
@@ -1,14 +1,12 @@
 import { injectable, inject } from 'inversify';
 
 import { AreaStatsResponse, StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
-import { AppScreenContent } from '@covid/core/content/ScreenContentContracts';
 import { Services } from '@covid/provider/services.types';
 import { IApiClient } from '@covid/core/api/ApiClient';
 
 export interface IContentApiClient {
   getAreaStats(patientId: string): Promise<AreaStatsResponse>;
   getStartupInfo(): Promise<StartupInfo>;
-  getScreenContent(countryCode: string, languageCode: string): Promise<AppScreenContent>;
 }
 
 @injectable()
@@ -22,11 +20,5 @@ export class ContentApiClient implements IContentApiClient {
 
   getStartupInfo(): Promise<StartupInfo> {
     return this.apiClient.get<StartupInfo>('/users/startup_info/');
-  }
-
-  getScreenContent(countryCode: string, languageCode: string): Promise<AppScreenContent> {
-    return this.apiClient.get<AppScreenContent>(
-      `/text/list/?country_code=${countryCode}&language_code=${languageCode}`
-    );
   }
 }

--- a/src/core/content/ContentService.ts
+++ b/src/core/content/ContentService.ts
@@ -13,7 +13,6 @@ import { IContentApiClient } from '@covid/core/content/ContentApiClient';
 export interface IContentService {
   localData?: PersonalisedLocalData;
   getUserCount(): Promise<string | null>;
-  getWelcomeRepeatContent(): Promise<ScreenContent>;
   getCalloutBoxDefault(): ScreenContent;
   getAskedToRateStatus(): Promise<string | null>;
   setAskedToRateStatus(status: string): void;
@@ -26,7 +25,6 @@ export interface IContentService {
 export default class ContentService implements IContentService {
   @inject(Services.ContentApi)
   private readonly apiClient: IContentApiClient;
-  private screenContent: AppScreenContent;
 
   localData: PersonalisedLocalData;
 
@@ -39,16 +37,6 @@ export default class ContentService implements IContentService {
       return 'https://covid.joinzoe.com/';
     }
   };
-
-  async getWelcomeRepeatContent() {
-    if (!this.screenContent) {
-      this.screenContent = await this.apiClient.getScreenContent(
-        LocalisationService.userCountry,
-        LocalisationService.getLocale()
-      );
-    }
-    return this.screenContent.WelcomeRepeat;
-  }
 
   getCalloutBoxDefault(): ScreenContent {
     return {

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -65,14 +65,12 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
   state: WelcomeRepeatScreenState = initialState;
 
   async componentDidMount() {
-    const content = await this.contentService.getWelcomeRepeatContent();
     const userCount = await this.contentService.getUserCount();
 
     AnalyticsService.identify();
     await pushNotificationService.refreshPushToken();
 
     this.setState({
-      calloutBoxContent: content,
       userCount: cleanIntegerVal(userCount as string),
     });
   }

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -71,6 +71,7 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
     await pushNotificationService.refreshPushToken();
 
     this.setState({
+      calloutBoxContent: this.contentService.getCalloutBoxDefault(),
       userCount: cleanIntegerVal(userCount as string),
     });
   }


### PR DESCRIPTION
# Description

This PR removes the call to the backend to get AppText, which is no longer used on the UK WelcomeRepeat screen. The original intention was to allow backend driven changes to the app text.  Only Sweden and US use this - and the "defaults" in the front end are still valid. This is likely to go away soon when the welcome screens get redesigned. 

The backend APIs will be deprecated and eventually removed. 

(Hashtag Kenneth was right)

## On what platform have you tested the change?

- [ ] Android - Emulator
- [x] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Screenshot 2020-09-17 at 09 39 18](https://user-images.githubusercontent.com/7824212/93446928-b3fc6900-f8c9-11ea-8c4c-b1ba8c29000f.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
