### PR TITLE
Fix login dashboard logic

### DIFF
--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -165,9 +165,7 @@ export class AppCoordinator extends Coordinator implements SelectProfile {
   }
 
   setHomeScreenName(): void {
-    // Set main route depending on API / Country
-    this.homeScreenName = store.getState().content.startupInfo?.show_new_dashboard ? 'Dashboard' : 'WelcomeRepeat';
-    this.homeScreenName = isGBCountry() ? this.homeScreenName : 'WelcomeRepeat';
+    this.homeScreenName = isGBCountry() ? 'Dashboard' : 'WelcomeRepeat';
   }
 
   getConfig(): ConfigType {


### PR DESCRIPTION
# Description

This builds on https://github.com/zoe/covid-tracker-react-native/pull/761 which fixes the new Dashboard screen vs the old WelcomeScreen for UK users during registration . 

For Login this issue still remains. Rather than force another server fetch on login, I'm just going to assume all UK users should see the new Dashboard screen. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
