### PR TITLE
Add feature flag lookup for US Diet Study

### DIFF
--- a/src/core/consent/ConsentService.ts
+++ b/src/core/consent/ConsentService.ts
@@ -4,7 +4,7 @@ import { AskForStudies, Consent } from '@covid/core/user/dto/UserAPIContracts';
 import { ApiClientBase } from '@covid/core/api/ApiClientBase';
 import { AsyncStorageService } from '@covid/core/AsyncStorageService';
 import appConfig from '@covid/appConfig';
-import { isGBCountry } from '@covid/core/localisation/LocalisationService';
+import { isGBCountry, isSECountry } from '@covid/core/localisation/LocalisationService';
 
 export interface IConsentService {
   postConsent(document: string, version: string, privacy_policy_version: string): void; // TODO: define return object
@@ -99,7 +99,8 @@ export class ConsentService extends ApiClientBase implements IConsentService {
   }
 
   async shouldShowDietStudy(): Promise<boolean> {
-    if (!isGBCountry()) return Promise.resolve(false);
+    if (isSECountry()) return Promise.resolve(false);
+
     const url = `/study_consent/status/`;
     const response = await this.client.get<AskForStudies>(url);
     return response.data.should_ask_diet_study;
@@ -114,8 +115,8 @@ export class ConsentService extends ApiClientBase implements IConsentService {
   }
 
   async getStudyStatus(): Promise<AskForStudies> {
-    // Currently all existing studies are UK only so short-circuit and save a call the server.
-    if (!isGBCountry()) return Promise.resolve(this.getDefaultStudyResponse());
+    // Sweden has no studies - so short circuit and save a call to server.
+    if (isSECountry()) return Promise.resolve(this.getDefaultStudyResponse());
 
     const url = `/study_consent/status/?home_screen=true`;
     const response = await this.client.get<AskForStudies>(url);

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -229,6 +229,12 @@ export class AppCoordinator extends Coordinator implements SelectProfile {
       } else {
         this.startAssessmentFlow(this.patientData);
       }
+    } else if (isUSCountry() && !this.patientData.patientState.isReportedByAnother) {
+      if (await this.shouldShowDietStudyInvite()) {
+        this.startDietStudyFlow(this.patientData, false);
+      } else {
+        this.startAssessmentFlow(this.patientData);
+      }
     } else {
       this.startAssessmentFlow(this.patientData);
     }


### PR DESCRIPTION
# Description

Previously the calls the the consent_status backend endpoint (which controls whether or not to ask about the Diet Study) was short circuited for Sweden and US (as there are no active studies). 

This PR changes the behaviour so:
-  for US Users it will check and display the Diet Study in the menu. 
- For US Primary Users starting an assessment flow, they will be shown an interstitial to participate in the Diet Study. 


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
