### PR TITLE
Fix bug that can return user to incorrect screen after ThankYou screens

### DIFF
--- a/src/core/assessment/AssessmentCoordinator.ts
+++ b/src/core/assessment/AssessmentCoordinator.ts
@@ -10,6 +10,7 @@ import { Services } from '@covid/provider/services.types';
 import { lazyInject } from '@covid/provider/services';
 import NavigatorService from '@covid/NavigatorService';
 import { PatientData } from '@covid/core/patient/PatientData';
+import { Coordinator } from '@covid/core/Coordinator';
 
 import { IProfileService } from '../profile/ProfileService';
 
@@ -23,7 +24,7 @@ export type AssessmentData = {
   patientData: PatientData;
 };
 
-export class AssessmentCoordinator {
+export class AssessmentCoordinator extends Coordinator {
   @lazyInject(Services.Profile)
   private readonly profileService: IProfileService;
 
@@ -36,7 +37,7 @@ export class AssessmentCoordinator {
   assessmentData: AssessmentData;
   appCoordinator: AppCoordinator;
 
-  screenFlow: ScreenFlow = {
+  screenFlow: Partial<ScreenFlow> = {
     ProfileBackDate: () => {
       this.startAssessment();
     },
@@ -58,7 +59,16 @@ export class AssessmentCoordinator {
     TreatmentOther: () => {
       this.gotoEndAssessment();
     },
-  } as ScreenFlow;
+    ViralThankYou: () => {
+      NavigatorService.reset([{ name: 'WelcomeRepeat' }]);
+    },
+    ThankYouUK: () => {
+      NavigatorService.reset([{ name: 'Dashboard' }]);
+    },
+    ThankYou: () => {
+      NavigatorService.reset([{ name: 'WelcomeRepeat' }]);
+    },
+  };
 
   init = (
     appCoordinator: AppCoordinator,
@@ -100,15 +110,6 @@ export class AssessmentCoordinator {
     } else {
       const thankYouScreen = AssessmentCoordinator.getThankYouScreen();
       NavigatorService.navigate(thankYouScreen);
-    }
-  };
-
-  gotoNextScreen = (screenName: ScreenName) => {
-    if (this.screenFlow[screenName]) {
-      this.screenFlow[screenName]();
-    } else {
-      // We don't have nextScreen logic for this page. Explain loudly.
-      console.error('[ROUTE] no next route found for:', screenName);
     }
   };
 
@@ -166,6 +167,19 @@ export class AssessmentCoordinator {
     this.appCoordinator.startEditLocation(
       this.assessmentData.patientData.patientState.profile,
       this.assessmentData.patientData
+    );
+  }
+
+  gotoSelectProfile() {
+    NavigatorService.reset(
+      [
+        { name: 'Dashboard' },
+        {
+          name: 'SelectProfile',
+          params: { editing: true },
+        },
+      ],
+      1
     );
   }
 }

--- a/src/features/thank-you/ThankYouScreen.tsx
+++ b/src/features/thank-you/ThankYouScreen.tsx
@@ -17,6 +17,7 @@ import { ExternalCallout } from '@covid/components/ExternalCallout';
 import { FacebookSECard } from '@covid/components/Cards/FacebookSE';
 
 import { ScreenParamList } from '../ScreenParamList';
+import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 
 type RenderProps = {
   navigation: StackNavigationProp<ScreenParamList, 'ThankYou'>;
@@ -80,7 +81,9 @@ export default class ThankYouScreen extends Component<RenderProps, State> {
 
               <RegularText style={styles.shareSubtitle}>{i18n.t('check-in-tomorrow')}</RegularText>
 
-              <BrandedButton onPress={this.props.navigation.popToTop} style={styles.done}>
+              <BrandedButton
+                onPress={() => assessmentCoordinator.gotoNextScreen(this.props.route.name)}
+                style={styles.done}>
                 <RegularText>{i18n.t('completed')}</RegularText>
               </BrandedButton>
             </View>

--- a/src/features/thank-you/ThankYouUKScreen.tsx
+++ b/src/features/thank-you/ThankYouUKScreen.tsx
@@ -20,6 +20,7 @@ import ExpoPushTokenEnvironment from '@covid/core/push-notifications/expo';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import appCoordinator from '@covid/features/AppCoordinator';
 import { IConsentService } from '@covid/core/consent/ConsentService';
+import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 
 type RenderProps = {
   navigation: StackNavigationProp<ScreenParamList, 'ThankYouUK'>;
@@ -115,25 +116,14 @@ export default class ThankYouUKScreen extends Component<RenderProps, State> {
               </View>
 
               <BrandedButton
-                onPress={() => this.props.navigation.navigate(appCoordinator.homeScreenName)}
+                onPress={() => assessmentCoordinator.gotoNextScreen(this.props.route.name)}
                 style={styles.ctaSingleProfile}>
                 <Text style={styles.ctaSingleProfileText}>{i18n.t('thank-you-uk.cta-single-profile')}</Text>
               </BrandedButton>
 
               <View style={styles.ctaMultipleProfile}>
                 <ClickableText
-                  onPress={() =>
-                    this.props.navigation.reset({
-                      index: 1,
-                      routes: [
-                        { name: appCoordinator.homeScreenName },
-                        {
-                          name: 'SelectProfile',
-                          params: { editing: true },
-                        },
-                      ],
-                    })
-                  }
+                  onPress={() => assessmentCoordinator.gotoSelectProfile()}
                   style={styles.ctaMultipleProfileText}>
                   {i18n.t('thank-you-uk.cta-multi-profile')}
                 </ClickableText>

--- a/src/features/thank-you/ViralThankYouScreen.tsx
+++ b/src/features/thank-you/ViralThankYouScreen.tsx
@@ -20,6 +20,7 @@ import { ShareAppCardViral } from '@covid/components/Cards/ShareAppViral';
 import { MoreContribution } from '@covid/components/Stats/MoreContribution';
 import { IContentService } from '@covid/core/content/ContentService';
 import { openWebLink } from '@covid/utils/links';
+import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 
 import { ScreenParamList } from '../ScreenParamList';
 
@@ -171,6 +172,7 @@ export default class ViralThankYouScreen extends Component<Props, State> {
         <SafeAreaView>
           <ScrollView contentContainerStyle={styles.scrollView}>
             <View style={styles.rootContainer}>
+              <View />
               <ThankYouModal
                 visible={this.state.modalVisible}
                 onClose={() => {
@@ -201,7 +203,11 @@ export default class ViralThankYouScreen extends Component<Props, State> {
 
               <Partners />
 
-              <Footer doneOnPress={this.props.navigation.popToTop} />
+              <Footer
+                doneOnPress={() => {
+                  assessmentCoordinator.gotoNextScreen(this.props.route.name);
+                }}
+              />
             </View>
           </ScrollView>
         </SafeAreaView>


### PR DESCRIPTION
ThankYou screens were still using old nav code which could sometimes take the user to the wrong screens. e.g. after first assessment