### PR TITLE
Bring covid test screen closer to designs

### DIFF
--- a/src/features/covid-tests/CovidTestListScreen.tsx
+++ b/src/features/covid-tests/CovidTestListScreen.tsx
@@ -3,7 +3,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { Text } from 'native-base';
 import key from 'weak-key';
 import React, { Component } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { colors } from '@theme';
 import ProgressStatus from '@covid/components/ProgressStatus';
@@ -102,7 +102,7 @@ export default class CovidTestListScreen extends Component<Props, State> {
 
     return (
       <View style={styles.rootContainer}>
-        <Screen profile={currentPatient.profile} navigation={this.props.navigation}>
+        <Screen profile={currentPatient.profile} navigation={this.props.navigation} scrollEnabled={false}>
           <Header>
             <HeaderText>{i18n.t('covid-test-list.title')}</HeaderText>
           </Header>
@@ -124,30 +124,30 @@ export default class CovidTestListScreen extends Component<Props, State> {
             </View>
           )}
 
-          {isLoading ? (
-            <Loading status="" error={null} />
-          ) : (
-            <View style={styles.content}>
-              {this.state.covidTests.map((item: CovidTest) => {
-                return <CovidTestRow type={item.type} item={item} key={key(item)} />;
-              })}
-            </View>
-          )}
-        </Screen>
-
-        <View>
           <BrandedButton style={styles.newButton} onPress={this.gotoAddTest}>
             <Text style={styles.newText}>{i18n.t('covid-test-list.add-new-test')}</Text>
           </BrandedButton>
 
-          <BrandedButton style={styles.continueButton} onPress={this.handleNextQuestion}>
-            <Text>
-              {this.state.covidTests.length === 0
-                ? i18n.t('covid-test-list.never-had-test')
-                : i18n.t('covid-test-list.above-list-correct')}
-            </Text>
-          </BrandedButton>
-        </View>
+          <ScrollView>
+            {isLoading ? (
+              <Loading status="" error={null} />
+            ) : (
+              <View style={styles.content}>
+                {this.state.covidTests.map((item: CovidTest) => {
+                  return <CovidTestRow type={item.type} item={item} key={key(item)} />;
+                })}
+              </View>
+            )}
+          </ScrollView>
+        </Screen>
+
+        <BrandedButton style={styles.continueButton} onPress={this.handleNextQuestion}>
+          <Text>
+            {this.state.covidTests.length === 0
+              ? i18n.t('covid-test-list.never-had-test')
+              : i18n.t('covid-test-list.above-list-correct')}
+          </Text>
+        </BrandedButton>
       </View>
     );
   }
@@ -163,10 +163,8 @@ const styles = StyleSheet.create({
   },
   newButton: {
     marginHorizontal: 16,
-    marginBottom: 16,
-    backgroundColor: colors.white,
-    borderWidth: 1,
-    borderColor: colors.primary,
+    marginVertical: 16,
+    backgroundColor: colors.backgroundTertiary,
   },
   newText: {
     color: colors.primary,


### PR DESCRIPTION
Moves the button placement and puts the tests within their own scroll view. 

![Simulator Screen Shot - iPhone 11 - 2020-10-06 at 16 33 43](https://user-images.githubusercontent.com/36822087/95223631-b9c2db80-07f1-11eb-860d-1bd345d2f360.png)
