### PR TITLE
Fix for null LAD for folks with an invalid 

### DIFF
--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -98,7 +98,7 @@ export const DashboardScreen: React.FC<Props> = ({ navigation, route }) => {
   useEffect(() => {
     if (!content) return;
     const { startupInfo, localTrendline } = content;
-    if (startupInfo?.local_data.lad && !localTrendline) {
+    if (startupInfo?.local_data?.lad && !localTrendline) {
       store.dispatch(fetchLocalTrendLine());
     }
   }, [content?.startupInfo]);


### PR DESCRIPTION
# Description

Add a null check for startupInfo.lad which is not returned if you have an invalid postcode. 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
