### PR TITLE
Dont use assessment screen when selecting edit profile

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -588,7 +588,8 @@
   "report-for-others-not-right-now": "Not right now? You can add additional profiles from the menu icon above at any time.",
   "report-for-others-skip": "Skip",
 
-  "select-profile-title": "Select profile you want to report for",
+  "select-profile-title-assessment": "Select profile you want to report for",
+  "select-profile-title-edit": "Select profile you want to edit",
   "select-profile-text": "Or add more profiles",
   "select-profile-button": "New profile",
   "select-profile-last-report": "Last report:",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -758,7 +758,8 @@
   "report-for-others-not-right-now": "¿No ahora? Puede agregar perfiles adicionales en el ícono de menú en cualquier momento.",
   "report-for-others-skip": "Omitir",
 
-  "select-profile-title": "Seleccione el perfil para el que informará",
+  "select-profile-title-assessment": "Seleccione el perfil para el que informará",
+  "select-profile-title-edit": "Seleccione el perfil que desea editar",
   "select-profile-text": "O agregue más perfiles",
   "select-profile-button": "Nuevo perfil",
   "select-profile-last-report": "Último informe:",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -510,7 +510,8 @@
   "report-for-others-not-right-now": "Inte just nu? Du kan när som helst lägga till ytterligare profiler från menyikonen ovan.",
   "report-for-others-skip": "Hoppa över",
 
-  "select-profile-title": "Välj den profil du vill rapportera åt",
+  "select-profile-title-assessment": "Välj den profil du vill rapportera åt",
+  "select-profile-title-edit": "Välj den profil du vill redigera",
   "select-profile-text": "Eller lägg till fler profiler",
   "select-profile-button": "Ny profil",
   "select-profile-last-report": "Sista rapport:",

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -29,11 +29,13 @@ export const ProfileCard: React.FC<Props> = (props) => {
       </View>
       <ClippedText>{profile.name}</ClippedText>
       <LastReported timeAgo={profile.last_reported_at} />
-      <TouchableOpacity onPress={props.onEditPressed}>
-        <SecondaryText style={{ textAlign: 'center', fontSize: 12, color: colors.accent }}>
-          {i18n.t('nav-edit-profile')}
-        </SecondaryText>
-      </TouchableOpacity>
+      {props.onEditPressed && (
+        <TouchableOpacity onPress={props.onEditPressed}>
+          <SecondaryText style={{ textAlign: 'center', fontSize: 12, color: colors.accent }}>
+            {i18n.t('nav-edit-profile')}
+          </SecondaryText>
+        </TouchableOpacity>
+      )}
     </Card>
   );
 };

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -118,7 +118,7 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
       NavigatorService.navigate('SelectProfile', { assessmentFlow: true });
     },
     ArchiveReason: () => {
-      NavigatorService.navigate('SelectProfile', { assessmentFlow: true });
+      NavigatorService.navigate('SelectProfile'); // Go back to SelectProfile with last used params
     },
     ValidationStudyIntro: () => {
       NavigatorService.navigate('ValidationStudyInfo');

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -34,7 +34,7 @@ import {
 } from '@covid/core/content/state/contentSlice';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import { UserResponse } from '@covid/core/user/dto/UserAPIContracts';
-import { Coordinator, SelectProfile } from '@covid/core/Coordinator';
+import { Coordinator, EditableProfile, SelectProfile } from '@covid/core/Coordinator';
 
 type ScreenName = keyof ScreenParamList;
 type ScreenFlow = {
@@ -43,7 +43,7 @@ type ScreenFlow = {
 
 export type NavigationType = StackNavigationProp<ScreenParamList, keyof ScreenParamList>;
 
-export class AppCoordinator extends Coordinator implements SelectProfile {
+export class AppCoordinator extends Coordinator implements SelectProfile, EditableProfile {
   @lazyInject(Services.User)
   private readonly userService: IUserService;
 
@@ -108,17 +108,17 @@ export class AppCoordinator extends Coordinator implements SelectProfile {
     WelcomeRepeat: () => {
       const config = this.getConfig();
       if (config.enableMultiplePatients) {
-        NavigatorService.navigate('SelectProfile', { editing: true });
+        NavigatorService.navigate('SelectProfile', { assessmentFlow: true });
       } else {
         this.startAssessmentFlow(this.patientData);
       }
     },
     Dashboard: () => {
       // UK only so currently no need to check config.enableMultiplePatients
-      NavigatorService.navigate('SelectProfile', { editing: true });
+      NavigatorService.navigate('SelectProfile', { assessmentFlow: true });
     },
     ArchiveReason: () => {
-      NavigatorService.navigate('SelectProfile', { editing: true });
+      NavigatorService.navigate('SelectProfile', { assessmentFlow: true });
     },
     ValidationStudyIntro: () => {
       NavigatorService.navigate('ValidationStudyInfo');
@@ -178,7 +178,7 @@ export class AppCoordinator extends Coordinator implements SelectProfile {
   }
 
   resetToProfileStartAssessment() {
-    NavigatorService.navigate('SelectProfile', { editing: true });
+    NavigatorService.navigate('SelectProfile', { assessmentFlow: true });
     this.startAssessmentFlow(this.patientData);
   }
 

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -37,7 +37,7 @@ export type ScreenParamList = {
 
   // Profile screens
   ReportForOther: undefined;
-  SelectProfile: { editing: boolean };
+  SelectProfile: { assessmentFlow: boolean };
   CreateProfile: { avatarName: string };
   AdultOrChild: { profileName: string; avatarName?: string };
   ConsentForOther: { profileName: string; avatarName?: string; consentType: ConsentType };

--- a/src/features/menu/DrawerMenu.tsx
+++ b/src/features/menu/DrawerMenu.tsx
@@ -92,7 +92,7 @@ export const DrawerMenu: React.FC<DrawerContentComponentProps> = (props) => {
           image={<EditProfilesIcon />}
           label={i18n.t('nav-edit-profile')}
           onPress={() => {
-            NavigatorService.navigate('SelectProfile', { editing: true });
+            NavigatorService.navigate('SelectProfile', { assessmentFlow: false });
           }}
         />
 

--- a/src/features/school-network/SchoolNetworkCoordinator.ts
+++ b/src/features/school-network/SchoolNetworkCoordinator.ts
@@ -43,7 +43,7 @@ export class SchoolNetworkCoordinator extends Coordinator implements SelectProfi
       NavigatorService.navigate('SchoolHowTo', { patientData: this.patientData });
     },
     SchoolHowTo: () => {
-      NavigatorService.navigate('SelectProfile', { editing: false });
+      NavigatorService.navigate('SelectProfile', { assessmentFlow: false });
     },
     JoinSchoolGroup: () => {
       this.goToGroupList();


### PR DESCRIPTION
This is not an ideal solution but it works. I spent quite a while looking to make it better but decided the refactoring would be too much.

The coordinator pattern is something that is very helpful for us IMO but it may need slight tweaking in future projects to get this use case to work smoothly. (Using a screen independently in 2 different flows and having the buttons call backs handled by the coordinator).

Ideally I would want to pass coordinators to a screen so it is totally decoupled from logic, however, even though this can be done, by passing a non-serializable object it has potential side effects with rebuilding state (if we were to ever do that) and also deep linking. The code in its current state might not need too much refactoring to get something like this working but I would want to discuss potential options if we do want to explore this for future learnings.