### PR TITLE
feat(trendline): increase overview chart time scale from 7 to 30 days

### DIFF
--- a/assets/charts/trendline-overview.html
+++ b/assets/charts/trendline-overview.html
@@ -80,7 +80,7 @@
             yAxes: [{
               ticks: {
                 max: Math.max(...data),
-                stepSize: Math.max(...data) / 6,
+                stepSize: Math.max(...data) / 30,
                 callback: (value) => Math.round(value),
               },
               gridLines: {

--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -85,10 +85,13 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
       case TrendLineViewMode.overview:
         const overviewSorted = timeseries.sort((a: any, b: any) => (a.date < b.date ? 1 : -1));
         const filtered = overviewSorted.filter((_: any, index: number) => index <= 30);
-        const monthLabels = (filtered ?? []).map((data) => moment(data.date).format("MMM"))
-        const monthLabelSet = monthLabels.reduce((unique: string[], item: string) => unique.includes(item) ? unique : [...unique, item], []);
+        const monthLabels = (filtered ?? []).map((data) => moment(data.date).format('MMM'));
+        const monthLabelSet = monthLabels.reduce(
+          (unique: string[], item: string) => (unique.includes(item) ? unique : [...unique, item]),
+          []
+        );
         if (monthLabelSet.length > 0) {
-          setMonthRangeLabel(`${monthLabelSet[0]} - ${monthLabelSet[monthLabelSet.length - 1]}`)
+          setMonthRangeLabel(`${monthLabelSet[0]} - ${monthLabelSet[monthLabelSet.length - 1]}`);
         }
         webview.current?.call('setData', {
           payload: {
@@ -133,13 +136,7 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
           }
         }}
       />
-      {
-        monthRangeLabel && (
-          <RegularText style={{ textAlign: 'center', fontSize: 12 }}>
-            {monthRangeLabel}
-          </RegularText>
-        )
-      }
+      {monthRangeLabel && <RegularText style={{ textAlign: 'center', fontSize: 12 }}>{monthRangeLabel}</RegularText>}
     </View>
   );
 };

--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -90,9 +90,11 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
           (unique: string[], item: string) => (unique.includes(item) ? unique : [...unique, item]),
           []
         );
-        if (monthLabelSet.length > 0) {
+        if (monthLabelSet.length >= 2) {
           setMonthRangeLabel(`${monthLabelSet[monthLabelSet.length - 1]} - ${monthLabelSet[0]}`);
-        }
+        } else if (monthLabelSet.length === 1) {
+          setMonthRangeLabel(`${monthLabelSet[0]}`);
+        } 
         webview.current?.call('setData', {
           payload: {
             labels: filtered.map((item) => item.label).reverse(),

--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -94,7 +94,7 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
           setMonthRangeLabel(`${monthLabelSet[monthLabelSet.length - 1]} - ${monthLabelSet[0]}`);
         } else if (monthLabelSet.length === 1) {
           setMonthRangeLabel(`${monthLabelSet[0]}`);
-        } 
+        }
         webview.current?.call('setData', {
           payload: {
             labels: filtered.map((item) => item.label).reverse(),

--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -91,7 +91,7 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
           []
         );
         if (monthLabelSet.length > 0) {
-          setMonthRangeLabel(`${monthLabelSet[0]} - ${monthLabelSet[monthLabelSet.length - 1]}`);
+          setMonthRangeLabel(`${monthLabelSet[monthLabelSet.length - 1]} - ${monthLabelSet[0]}`);
         }
         webview.current?.call('setData', {
           payload: {

--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -83,7 +83,7 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
     switch (viewMode) {
       case TrendLineViewMode.overview:
         const overviewSorted = timeseries.sort((a: any, b: any) => (a.date < b.date ? 1 : -1));
-        const filtered = overviewSorted.filter((_: any, index: number) => index <= 7);
+        const filtered = overviewSorted.filter((_: any, index: number) => index <= 30);
         webview.current?.call('setData', {
           payload: {
             labels: filtered.map((item) => item.label).reverse(),

--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -8,7 +8,7 @@ import { ITrendLineData } from '@covid/core/content/dto/ContentAPIContracts';
 import { loadTrendLineExplore, loadTrendLineOverview } from '@covid/utils/files';
 
 import { WebView } from '../WebView';
-import { MutedText } from '../Text';
+import { MutedText, RegularText } from '../Text';
 
 export enum TrendlineTimeFilters {
   week = 'WEEK',
@@ -36,6 +36,7 @@ export const TrendLineEmptyView: React.FC = () => {
 
 export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode }) => {
   const [html, setHtml] = useState<string>('');
+  const [monthRangeLabel, setMonthRangeLabel] = useState<string>('');
   const webview = useRef<WebView>(null);
   const trendline = useSelector<RootState, ITrendLineData | undefined>((state) => {
     if (viewMode === TrendLineViewMode.explore) {
@@ -84,6 +85,11 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
       case TrendLineViewMode.overview:
         const overviewSorted = timeseries.sort((a: any, b: any) => (a.date < b.date ? 1 : -1));
         const filtered = overviewSorted.filter((_: any, index: number) => index <= 30);
+        const monthLabels = (filtered ?? []).map((data) => moment(data.date).format("MMM"))
+        const monthLabelSet = monthLabels.reduce((unique: string[], item: string) => unique.includes(item) ? unique : [...unique, item], []);
+        if (monthLabelSet.length > 0) {
+          setMonthRangeLabel(`${monthLabelSet[0]} - ${monthLabelSet[monthLabelSet.length - 1]}`)
+        }
         webview.current?.call('setData', {
           payload: {
             labels: filtered.map((item) => item.label).reverse(),
@@ -127,6 +133,13 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
           }
         }}
       />
+      {
+        monthRangeLabel && (
+          <RegularText style={{ textAlign: 'center', fontSize: 12 }}>
+            {monthRangeLabel}
+          </RegularText>
+        )
+      }
     </View>
   );
 };


### PR DESCRIPTION
# Description

Increasing the trendline overview time window from weekly to monthly 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2020-11-10 at 10 19 19](https://user-images.githubusercontent.com/36766508/98661345-3e979c80-233e-11eb-81b1-3b636829f42a.png)


## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
