### PR TITLE
Catch empty string on trendline labels 

### DIFF
--- a/src/components/Stats/TrendLineChart.tsx
+++ b/src/components/Stats/TrendLineChart.tsx
@@ -138,7 +138,7 @@ export const TrendLineChart: React.FC<TrendLineChartProps> = ({ filter, viewMode
           }
         }}
       />
-      {monthRangeLabel && <RegularText style={{ textAlign: 'center', fontSize: 12 }}>{monthRangeLabel}</RegularText>}
+      {!!monthRangeLabel && <RegularText style={{ textAlign: 'center', fontSize: 12 }}>{monthRangeLabel}</RegularText>}
     </View>
   );
 };


### PR DESCRIPTION
# Description

Catch empty string on trendline labels that will cause a crash:

![Screenshot 2020-11-11 at 21 50 12](https://user-images.githubusercontent.com/7824212/98878062-e9f93c00-2479-11eb-9ef6-3732172bb776.png)

