### PR TITLE
Chores/ci cd

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ package = load_json(json_path: "./package.json")
 end
 
 lane :get_build_number_by_time do
-  Time.new.strftime("%Y%m%d%H%M") # e.g 202011121515
+  "#{Date.today.year % 100}#{Time.new.strftime("%m%d%H%M")}"  # e.g 2011121515
 end
 
 desc 'Bump build numbers, and set the version to match the pacakage.json version.'
@@ -111,10 +111,19 @@ platform :android do
 
   before_all do
     get_version_no
-
     @ac_notify_group = "Android"
     @ac_project_name = ENV['APPCENTER_ANDROID_PROJECT_NAME']
     @ac_token = ENV['APPCENTER_ANDROID_TOKEN']
+
+    gradle_path = './android/app/build.gradle'
+    increment_version_code(
+      gradle_file_path: gradle_path,
+      version_code: @build_number.to_i
+    )
+    increment_version_name(
+      gradle_file_path: gradle_path,
+      version_name: @package_json['version']
+    )
   end
   
   desc "Build Android Staging"
@@ -169,7 +178,7 @@ platform :ios do
     @ac_project_name = ENV['APPCENTER_IOS_PROJECT_NAME']
     @ac_token = ENV['APPCENTER_IOS_TOKEN']
     increment_build_number(
-      build_number: "#{@build_number}",
+      build_number: @build_number,
       xcodeproj: './ios/Covid.xcodeproj',
     )
   end

--- a/ios/Covid/Info.plist
+++ b/ios/Covid/Info.plist
@@ -33,18 +33,10 @@
 	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
+	<key>NSAppTransportSecurity</key>    
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string/>


### PR DESCRIPTION
# Description

- Set iOS & Android build number using current time e.g 13th Nov 2020 12:06AM to `2011131206`
- Set iOS & Android verison using `package.json` version
- Replace allow `localhost` with allow local network (https://stackoverflow.com/questions/38501012/is-it-safe-to-add-localhost-to-app-transport-security-ats-nsexceptiondomains)

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
