### PR TITLE
stage

### DIFF
--- a/.circleci/make_deploy_env.sh
+++ b/.circleci/make_deploy_env.sh
@@ -70,6 +70,6 @@ rm -f $EXPO_ANDROID_MANIFEST_TEMPLATE
 
 
 # Override app identifiers in expo's app.json
-if [ $RELEASE_TYPE == "stage" ]; then
-  # sed -e 's/'$COVID_IOS_APP_ID'/'$COVID_IOS_APP_ID'.qa/g' -e 's/'$COVID_ANDROID_APP_ID'/'$COVID_ANDROID_APP_ID'.qa/g' app.json > app.json.tmp && rm -f app.json && mv app.json.tmp app.json
-fi
+# if [ $RELEASE_TYPE == "stage" ]; then
+#   sed -e 's/'$COVID_IOS_APP_ID'/'$COVID_IOS_APP_ID'.qa/g' -e 's/'$COVID_ANDROID_APP_ID'/'$COVID_ANDROID_APP_ID'.qa/g' app.json > app.json.tmp && rm -f app.json && mv app.json.tmp app.json
+# fi

--- a/.circleci/make_deploy_env.sh
+++ b/.circleci/make_deploy_env.sh
@@ -5,6 +5,8 @@ mkdir -p .signing
 echo "$GOOGLE_SERVICE_JSON" | base64 --decode > google-services.json
 echo $KEYSTORE_FILE | base64 -d > .signing/release.jks
 
+cp google-services.json ./android/app/google-services.json
+
 EXPO_VERSION=$(cat package.json | jq -r '.dependencies.expo' | cut -d '^' -f2)
 EXPO_OTA_VERSION=$(cat app.json | jq -r '.expo.version')
 EXPO_RELEASE_CHANNEL=$RELEASE_TYPE'-v'$EXPO_OTA_VERSION

--- a/.circleci/make_deploy_env.sh
+++ b/.circleci/make_deploy_env.sh
@@ -70,6 +70,6 @@ rm -f $EXPO_ANDROID_MANIFEST_TEMPLATE
 
 
 # Override app identifiers in expo's app.json
-# if [ $RELEASE_TYPE == "stage" ]; then
-#   sed -e 's/'$COVID_IOS_APP_ID'/'$COVID_IOS_APP_ID'.qa/g' -e 's/'$COVID_ANDROID_APP_ID'/'$COVID_ANDROID_APP_ID'.qa/g' app.json > app.json.tmp && rm -f app.json && mv app.json.tmp app.json
-# fi
+if [ $RELEASE_TYPE == "stage" ]; then
+  sed -e 's/'$COVID_IOS_APP_ID'/'$COVID_IOS_APP_ID'.qa/g' -e 's/'$COVID_ANDROID_APP_ID'/'$COVID_ANDROID_APP_ID'.qa/g' app.json > app.json.tmp && rm -f app.json && mv app.json.tmp app.json
+fi

--- a/.circleci/make_deploy_env.sh
+++ b/.circleci/make_deploy_env.sh
@@ -71,5 +71,5 @@ rm -f $EXPO_ANDROID_MANIFEST_TEMPLATE
 
 # Override app identifiers in expo's app.json
 if [ $RELEASE_TYPE == "stage" ]; then
-  sed -e 's/'$COVID_IOS_APP_ID'/'$COVID_IOS_APP_ID'.qa/g' -e 's/'$COVID_ANDROID_APP_ID'/'$COVID_ANDROID_APP_ID'.qa/g' app.json > app.json.tmp && rm -f app.json && mv app.json.tmp app.json
+  # sed -e 's/'$COVID_IOS_APP_ID'/'$COVID_IOS_APP_ID'.qa/g' -e 's/'$COVID_ANDROID_APP_ID'/'$COVID_ANDROID_APP_ID'.qa/g' app.json > app.json.tmp && rm -f app.json && mv app.json.tmp app.json
 fi

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -178,7 +178,7 @@ android {
     signingConfigs {
         debug {
             // Override if needed during debug
-            storeFile file('debug.keystore')
+//            storeFile file('debug.keystore')
             storePassword 'android'
             keyAlias 'androiddebugkey'
             keyPassword 'android'
@@ -196,12 +196,12 @@ android {
     
     buildTypes {
         debug {
-            // applicationIdSuffix ".qa"
+            applicationIdSuffix ".qa"
             signingConfig signingConfigs.debug
             matchingFallbacks = ['debug']
         }
         staging {
-            // applicationIdSuffix ".qa"
+            applicationIdSuffix ".qa"
             signingConfig signingConfigs.release
             matchingFallbacks = ['debug', 'release']
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -196,12 +196,12 @@ android {
     
     buildTypes {
         debug {
-            applicationIdSuffix ".qa"
+            // applicationIdSuffix ".qa"
             signingConfig signingConfigs.debug
             matchingFallbacks = ['debug']
         }
         staging {
-            applicationIdSuffix ".qa"
+            // applicationIdSuffix ".qa"
             signingConfig signingConfigs.release
             matchingFallbacks = ['debug', 'release']
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -238,6 +238,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
+    apply plugin: 'com.google.gms.google-services'
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
@@ -269,5 +270,3 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
-
-// apply plugin: 'com.google.gms.google-services'

--- a/android/app/src/main/java/com/joinzoe/covid_zoe/generated/BasePackageList.java
+++ b/android/app/src/main/java/com/joinzoe/covid_zoe/generated/BasePackageList.java
@@ -8,6 +8,7 @@ public class BasePackageList {
   public List<Package> getPackageList() {
     return Arrays.<Package>asList(
         new expo.modules.analytics.amplitude.AmplitudePackage(),
+        new expo.modules.application.ApplicationPackage(),
         new expo.modules.constants.ConstantsPackage(),
         new expo.modules.errorrecovery.ErrorRecoveryPackage(),
         new expo.modules.filesystem.FileSystemPackage(),
@@ -18,6 +19,7 @@ public class BasePackageList {
         new expo.modules.lineargradient.LinearGradientPackage(),
         new expo.modules.localization.LocalizationPackage(),
         new expo.modules.location.LocationPackage(),
+        new expo.modules.notifications.NotificationsPackage(),
         new expo.modules.permissions.PermissionsPackage(),
         new expo.modules.sharing.SharingPackage(),
         new expo.modules.splashscreen.SplashScreenPackage(),

--- a/ios/Covid/covid-zoe.entitlements
+++ b/ios/Covid/covid-zoe.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -24,6 +24,8 @@ PODS:
     - Amplitude (~> 6.0.0)
     - UMConstantsInterface
     - UMCore
+  - EXApplication (2.3.0):
+    - UMCore
   - EXConstants (9.2.0):
     - UMConstantsInterface
     - UMCore
@@ -49,6 +51,9 @@ PODS:
     - UMCore
     - UMPermissionsInterface
     - UMTaskManagerInterface
+  - EXNotifications (0.7.2):
+    - UMCore
+    - UMPermissionsInterface
   - EXPermissions (9.3.0):
     - UMCore
     - UMPermissionsInterface
@@ -356,6 +361,7 @@ DEPENDENCIES:
   - appcenter-crashes (from `../node_modules/appcenter-crashes/ios`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXAmplitude (from `../node_modules/expo-analytics-amplitude/ios`)
+  - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - EXErrorRecovery (from `../node_modules/expo-error-recovery/ios`)
   - EXFileSystem (from `../node_modules/expo-file-system/ios`)
@@ -365,6 +371,7 @@ DEPENDENCIES:
   - EXLinearGradient (from `../node_modules/expo-linear-gradient/ios`)
   - EXLocalization (from `../node_modules/expo-localization/ios`)
   - EXLocation (from `../node_modules/expo-location/ios`)
+  - EXNotifications (from `../node_modules/expo-notifications/ios`)
   - EXPermissions (from `../node_modules/expo-permissions/ios`)
   - EXSharing (from `../node_modules/expo-sharing/ios`)
   - EXSQLite (from `../node_modules/expo-sqlite/ios`)
@@ -440,6 +447,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXAmplitude:
     :path: "../node_modules/expo-analytics-amplitude/ios"
+  EXApplication:
+    :path: "../node_modules/expo-application/ios"
   EXConstants:
     :path: "../node_modules/expo-constants/ios"
   EXErrorRecovery:
@@ -458,6 +467,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-localization/ios"
   EXLocation:
     :path: "../node_modules/expo-location/ios"
+  EXNotifications:
+    :path: "../node_modules/expo-notifications/ios"
   EXPermissions:
     :path: "../node_modules/expo-permissions/ios"
   EXSharing:
@@ -577,6 +588,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAmplitude: caa186767e48b4efcb07cf74be76ff16f4700e48
+  EXApplication: c346c5ab7d1a4607f1863e93490b79fe838148b1
   EXConstants: f486f6b4a36b86e47ab258d4d2b7b2699786fdce
   EXErrorRecovery: 16696fe023fb46a32c3b09033abc361cfcf150a7
   EXFileSystem: afe9b1fd937d30270bf5108ba44e2f4a1d1ad694
@@ -586,6 +598,7 @@ SPEC CHECKSUMS:
   EXLinearGradient: c7ca1c2933ac240ffbc805c014a72947e227ac75
   EXLocalization: 8621f60b37c3d3ad8c8e27c2cb3b05ebc7b484a2
   EXLocation: 90232c6f2773b04a3c146bfda9f181035722c10a
+  EXNotifications: 0a1152ef2bd0f1cdd72a46bb256523a6ce5fa6e5
   EXPermissions: 30cbe5b72bd209b65c00884180ad058a60bb413d
   EXSharing: 02ac909b58904235ab9405b9e69deb24613f8b40
   EXSQLite: d0d8677c13e60d5db2812387f059c697be27d3fb

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "expo-font": "^8.3.0",
     "expo-intent-launcher": "~8.3.0",
     "expo-localization": "~9.0.0",
+    "expo-notifications": "~0.7.2",
     "expo-sharing": "~8.4.1",
     "expo-splash-screen": "~0.6.1",
     "expo-status-bar": "~1.0.2",

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { Dimensions, StatusBar, Image } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Provider } from 'react-redux';
-import { Notifications } from 'expo';
+import * as Notifications from 'expo-notifications';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { colors } from '@theme/colors';
@@ -131,10 +131,9 @@ export default class CovidApp extends Component<object, State> {
     });
     this.setState({ isLoaded: true });
 
-    Notifications.addListener((notif) => {
-      if (notif.origin === 'selected') {
-        Analytics.track(events.OPEN_FROM_NOTIFICATION);
-      }
+    Notifications.addNotificationResponseReceivedListener((response) => {
+      // const url = response.notification.request.content.data.url;
+      Analytics.track(events.OPEN_FROM_NOTIFICATION);
     });
   }
 

--- a/src/core/push-notifications/PushNotificationService.ts
+++ b/src/core/push-notifications/PushNotificationService.ts
@@ -75,7 +75,8 @@ export default class PushNotificationService {
   }
 
   private tokenNeedsRefreshing(pushToken: PushToken) {
-    return isDateBefore(pushToken.lastUpdated, aWeekAgo());
+    return true;
+    // return isDateBefore(pushToken.lastUpdated, aWeekAgo());
   }
 
   private async sendPushToken(pushToken: PushToken) {

--- a/src/core/push-notifications/expo.ts
+++ b/src/core/push-notifications/expo.ts
@@ -1,5 +1,5 @@
 import Constants from 'expo-constants';
-import { Notifications } from 'expo';
+import * as Notifications from 'expo-notifications';
 import * as Permissions from 'expo-permissions';
 
 import { IPushTokenEnvironment } from './PushNotificationService';
@@ -14,8 +14,9 @@ export default class ExpoPushTokenEnvironment implements IPushTokenEnvironment {
     let token = null;
     try {
       if (await this.isGranted()) {
-        token = await Notifications.getExpoPushTokenAsync({ experienceId: '@julien.lavigne/covid-zoe' });
-        return token.data;
+        const { data } = await Notifications.getExpoPushTokenAsync({ experienceId: '@julien.lavigne/covid-zoe' });
+        token = data;
+        return token;
       }
     } catch (error) {
       // silently discard errors.

--- a/src/core/push-notifications/expo.ts
+++ b/src/core/push-notifications/expo.ts
@@ -14,14 +14,8 @@ export default class ExpoPushTokenEnvironment implements IPushTokenEnvironment {
     let token = null;
     try {
       if (await this.isGranted()) {
-        if (!Constants.manifest) {
-          // Absence of the manifest means we're in bare workflow
-          // @ts-ignore
-          token = await Notifications.getExpoPushTokenAsync({ experienceId: '@julien.lavigne/covid-zoe' });
-          return token.data;
-        } else {
-          token = await Notifications.getExpoPushTokenAsync();
-        }
+        token = await Notifications.getExpoPushTokenAsync({ experienceId: '@julien.lavigne/covid-zoe' });
+        return token.data;
       }
     } catch (error) {
       // silently discard errors.

--- a/src/core/push-notifications/expo.ts
+++ b/src/core/push-notifications/expo.ts
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import { Notifications } from 'expo';
 import * as Permissions from 'expo-permissions';
 
@@ -13,7 +14,13 @@ export default class ExpoPushTokenEnvironment implements IPushTokenEnvironment {
     let token = null;
     try {
       if (await this.isGranted()) {
-        token = await Notifications.getExpoPushTokenAsync();
+        if (!Constants.manifest) {
+          // Absence of the manifest means we're in bare workflow
+          // @ts-ignore
+          token = await Notifications.getExpoPushTokenAsync({ experienceId: '@julien.lavigne/covid-zoe' });
+        } else {
+          token = await Notifications.getExpoPushTokenAsync();
+        }
       }
     } catch (error) {
       // silently discard errors.

--- a/src/core/push-notifications/expo.ts
+++ b/src/core/push-notifications/expo.ts
@@ -18,6 +18,7 @@ export default class ExpoPushTokenEnvironment implements IPushTokenEnvironment {
           // Absence of the manifest means we're in bare workflow
           // @ts-ignore
           token = await Notifications.getExpoPushTokenAsync({ experienceId: '@julien.lavigne/covid-zoe' });
+          return token.data;
         } else {
           token = await Notifications.getExpoPushTokenAsync();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,7 +4246,7 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
-badgin@^1.1.2:
+badgin@^1.1.2, badgin@^1.1.5:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/badgin/-/badgin-1.2.2.tgz#cbb0b71b047230c681a68911eb24136f0632adc6"
   integrity sha512-XtoSjNhy2D09qGiLhFWBJmBwBlmleQuwyYyjddWNCJ3gqGRBOBR25VGcd8CAOSghpEUmghB3LD4NpHrUG89zCg==
@@ -6578,6 +6578,11 @@ expo-analytics-amplitude@~8.3.1:
   resolved "https://registry.yarnpkg.com/expo-analytics-amplitude/-/expo-analytics-amplitude-8.3.1.tgz#7e2622a3b156005586ee5ec529746b29b8665cf9"
   integrity sha512-BW7sORrB/AZRsGViNwE2triJyf/Sgp5hiobDaA1rQKkWjzWu6YqQ4WdvY+nBt3aQyShG6+ctaRgCPl+Qkm9enA==
 
+expo-application@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/expo-application/-/expo-application-2.3.0.tgz#5e6929a1fcee543ac433fb2cee1f88738369e26b"
+  integrity sha512-Jbx8iWAjL5JOvXNUnFaTr5PlMgs8k4MV6SGonYw/a21bWDDERyJQc9EYnaoaSJJJeE/4neVsF7Q3GN1QPz7pUA==
+
 expo-asset@~8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-8.2.0.tgz#2f72491064c02d4de32e9187d474deb9cec33003"
@@ -6589,7 +6594,7 @@ expo-asset@~8.2.0:
     path-browserify "^1.0.0"
     url-parse "^1.4.4"
 
-expo-constants@~9.2.0:
+expo-constants@9.2.0, expo-constants@~9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-9.2.0.tgz#e86a38793deaff9018878afac65bce2543c80a4c"
   integrity sha512-WKwiEMvBgPrEPEyZKm21UUB2KWQux9OCWf6ZDORLTln7kO3rsbaJEprfWUWTP7AxyaLMYfN+/0WFHjZc25SZWQ==
@@ -6659,6 +6664,16 @@ expo-location@~9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-9.0.1.tgz#adf93b8adf5e9dcf9570cba1d66c8e3831329156"
   integrity sha512-yl4V2IelxrjG1h3nshkyILwghysNJvvEuR4Of0U7oYAsBrT0cq8NxFuaDemRvqt9Yb19wVFNMoVtYFNpthcqpQ==
+
+expo-notifications@~0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/expo-notifications/-/expo-notifications-0.7.2.tgz#2e275036c4f8cc6223a4de263117828bf253a95f"
+  integrity sha512-a5QagTFObadEyWTDhAeHnzscLIUTIBF+iLsfKftegZjQIcv20mxu9Aom/e6OfMNg9470XV/HuuHaO9p+JaY9cg==
+  dependencies:
+    badgin "^1.1.5"
+    expo-application "~2.3.0"
+    expo-constants "9.2.0"
+    uuid "^3.4.0"
 
 expo-permissions@~9.3.0:
   version "9.3.0"


### PR DESCRIPTION
- Chore(ci/cd): automatic deployment to Appcenter for Adhoc & Store builds (Expo ejected) (#894)
- Stage (#901)
- fix(ci-android): set version / build number (#905)
- fixes/android ci (#906)
- Removes env text from welcome screen (#908)
- Changes to Fever Questions (#904)
- Add experienceID
- Return ExpoNotificationToken data
- Assume bare workflow
- fix(push-notifiaction): copy service json & add google serviec plugin
- chore(push-notification): force token refresh
- chore(push-notification): remove suffix for now
- chore(push-nofitication): avoid replacing app identifier for stage app
- feat(push-notifications): use latest expo lib for PN
- chore(push-notifications): avoid replacing app id
- fix(push-notification): add .qa suffix and add other missing files
