### PR TITLE
fixes/ios async storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,12 +61,14 @@ references:
     branches:
       only:
         - develop
+        - fixes/ios-async-storage
 
   release_filter: &release_filter
     branches:
       only:
         - master
         - develop
+        - fixes/ios-async-storage
 
   feature_filter: &feature_filter
     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,12 @@ references:
     branches:
       only:
         - develop
-        - fixes/ios-async-storage
 
   release_filter: &release_filter
     branches:
       only:
         - master
         - develop
-        - fixes/ios-async-storage
 
   feature_filter: &feature_filter
     branches:

--- a/src/utils/async-storage-migrate.ts
+++ b/src/utils/async-storage-migrate.ts
@@ -3,7 +3,7 @@ import * as FileSystem from 'expo-file-system';
 
 const AsyncLocalStorageFolderOptions = {
   fromList: [
-    `${FileSystem.documentDirectory}/RCTAsyncLocalStorage`,
+    `${FileSystem.documentDirectory}RCTAsyncLocalStorage`,
     `${FileSystem.documentDirectory}ExponentExperienceData/%2540julien.lavigne%252Fcovid-zoe/RCTAsyncLocalStorage`,
   ],
   to: `${FileSystem.documentDirectory}RCTAsyncLocalStorage_V1`,
@@ -29,7 +29,7 @@ const firstInList = async (fromList: string[]): Promise<ManifestSearchResult> =>
       found = !!content;
       path = Manifest.from(fromList[i]);
     } catch (error) {
-      console.error(error);
+      //
     } finally {
       i++;
     }


### PR DESCRIPTION
# Description

- Remove extra slash in file path
- Remove the use of `console.error`


There is a build on AppCenter which I've installed and launch experienced no crashes.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [x] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
