### PR TITLE
Remove AppCoordinator circular dependency

### DIFF
--- a/src/core/localisation/LocalisationService.ts
+++ b/src/core/localisation/LocalisationService.ts
@@ -2,6 +2,7 @@ import { injectable } from 'inversify';
 import * as Localization from 'expo-localization';
 
 import i18n from '@covid/locale/i18n';
+import { ScreenName } from '@covid/core/Coordinator';
 
 import { AsyncStorageService } from '../AsyncStorageService';
 import { ConfigType, getCountryConfig } from '../Config';
@@ -105,6 +106,10 @@ export class LocalisationService implements ILocalisationService {
     return i18n.locale;
   }
 }
+
+export const homeScreenName = (): ScreenName => {
+  return LocalisationService.userCountry === 'GB' ? 'Dashboard' : 'WelcomeRepeat';
+};
 
 export const isUSCountry = () => LocalisationService.userCountry === 'US';
 export const isGBCountry = () => LocalisationService.userCountry === 'GB';

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -7,6 +7,7 @@ import {
   isUSCountry,
   ILocalisationService,
   LocalisationService,
+  homeScreenName,
 } from '@covid/core/localisation/LocalisationService';
 import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 import { assessmentService } from '@covid/Services';
@@ -74,17 +75,17 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
       if (this.patientData && this.shouldShowCountryPicker) {
         NavigatorService.replace('CountrySelect', {
           onComplete: () => {
-            NavigatorService.replace(this.homeScreenName);
+            NavigatorService.replace(homeScreenName());
           },
         });
       } else if (this.patientData) {
-        NavigatorService.replace(this.homeScreenName);
+        NavigatorService.replace(homeScreenName());
       } else {
         NavigatorService.replace('Welcome');
       }
     },
     Login: () => {
-      NavigatorService.reset([{ name: this.homeScreenName }]);
+      NavigatorService.reset([{ name: homeScreenName() }]);
     },
     Register: () => {
       const config = appCoordinator.getConfig();
@@ -132,7 +133,7 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
       NavigatorService.navigate('Register');
     },
     VaccineRegistryInfo: () => {
-      NavigatorService.navigate(this.homeScreenName);
+      NavigatorService.navigate(homeScreenName());
     },
   };
 
@@ -153,7 +154,6 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
     }
 
     await this.fetchInitialData();
-    this.setHomeScreenName();
 
     // Track insights
     if (this.shouldShowCountryPicker) {
@@ -167,10 +167,6 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
     if (isGBCountry()) {
       await store.dispatch(fetchUKMetrics());
     }
-  }
-
-  setHomeScreenName(): void {
-    this.homeScreenName = isGBCountry() ? 'Dashboard' : 'WelcomeRepeat';
   }
 
   getConfig(): ConfigType {
@@ -205,13 +201,13 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
   async startEditProfile(profile: Profile) {
     await this.setPatientByProfile(profile);
 
-    editProfileCoordinator.init(this, this.patientData, this.userService);
+    editProfileCoordinator.init(this.patientData, this.userService);
     editProfileCoordinator.startEditProfile();
   }
 
   async startEditLocation(profile: Profile, patientData?: PatientData) {
     if (!patientData) await this.setPatientByProfile(profile);
-    editProfileCoordinator.init(this, patientData ?? this.patientData, this.userService);
+    editProfileCoordinator.init(patientData ?? this.patientData, this.userService);
     editProfileCoordinator.goToEditLocation();
   }
 

--- a/src/features/login/LoginScreen.tsx
+++ b/src/features/login/LoginScreen.tsx
@@ -80,7 +80,6 @@ export class LoginScreen extends Component<PropsType, StateType> {
         appCoordinator
           .setPatientById(patientId)
           .then(() => appCoordinator.fetchInitialData())
-          .then(() => appCoordinator.setHomeScreenName())
           .then(() => {
             appCoordinator.gotoNextScreen(this.props.route.name);
           });

--- a/src/features/multi-profile/edit-profile/EditProfileCoordinator.ts
+++ b/src/features/multi-profile/edit-profile/EditProfileCoordinator.ts
@@ -1,17 +1,15 @@
-import { AppCoordinator } from '@covid/features/AppCoordinator';
 import NavigatorService from '@covid/NavigatorService';
 import { Coordinator, ScreenFlow, UpdatePatient } from '@covid/core/Coordinator';
 import { PatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { PatientData } from '@covid/core/patient/PatientData';
 import { Services } from '@covid/provider/services.types';
 import { IPatientService } from '@covid/core/patient/PatientService';
-import { ILocalisationService, isGBCountry } from '@covid/core/localisation/LocalisationService';
+import { homeScreenName, ILocalisationService, isGBCountry } from '@covid/core/localisation/LocalisationService';
 import { IUserService } from '@covid/core/user/UserService';
 import { lazyInject } from '@covid/provider/services';
 import schoolNetworkCoordinator from '@covid/features/school-network/SchoolNetworkCoordinator';
 
 export class EditProfileCoordinator extends Coordinator implements UpdatePatient {
-  appCoordinator: AppCoordinator;
   userService: IUserService;
   patientData: PatientData;
 
@@ -41,7 +39,7 @@ export class EditProfileCoordinator extends Coordinator implements UpdatePatient
     NHSDetails: () => {
       NavigatorService.reset(
         [
-          { name: this.appCoordinator.homeScreenName, params: {} },
+          { name: homeScreenName(), params: {} },
           {
             name: 'SelectProfile',
             params: {
@@ -56,8 +54,7 @@ export class EditProfileCoordinator extends Coordinator implements UpdatePatient
     },
   };
 
-  init = (appCoordinator: AppCoordinator, patientData: PatientData, userService: IUserService) => {
-    this.appCoordinator = appCoordinator;
+  init = (patientData: PatientData, userService: IUserService) => {
     this.patientData = patientData;
     this.userService = userService;
   };
@@ -85,13 +82,13 @@ export class EditProfileCoordinator extends Coordinator implements UpdatePatient
     NavigatorService.navigate('YourStudy', { patientData: this.patientData, editing: true });
   }
 
-  goToSchoolNetwork(higherEducation: boolean) {
-    schoolNetworkCoordinator.init(this.appCoordinator, this.patientData, higherEducation);
+  goToSchoolNetwork() {
+    schoolNetworkCoordinator.init(this.patientData, false);
     schoolNetworkCoordinator.startFlow();
   }
 
   goToUniversityNetwork() {
-    schoolNetworkCoordinator.init(this.appCoordinator, this.patientData, true);
+    schoolNetworkCoordinator.init(this.patientData, true);
     NavigatorService.navigate('JoinHigherEducation', { patientData: this.patientData });
   }
 

--- a/src/features/multi-profile/edit-profile/EditProfileScreen.tsx
+++ b/src/features/multi-profile/edit-profile/EditProfileScreen.tsx
@@ -54,7 +54,7 @@ export const EditProfileScreen: React.FC<RenderProps> = (props) => {
         )}
 
         {editProfileCoordinator.shouldShowSchoolNetwork() && (
-          <LinkItem title="School network" action={() => editProfileCoordinator.goToSchoolNetwork(false)} />
+          <LinkItem title="School network" action={() => editProfileCoordinator.goToSchoolNetwork()} />
         )}
 
         {editProfileCoordinator.shouldShowUniNetwork() && (

--- a/src/features/register/RegisterScreen.tsx
+++ b/src/features/register/RegisterScreen.tsx
@@ -73,10 +73,7 @@ export class RegisterScreen extends Component<PropsType, State> {
           Analytics.identify({ isTester });
           Analytics.track(events.SIGNUP);
           const patientId = response.user.patients[0];
-          await appCoordinator
-            .setPatientById(patientId)
-            .then(() => appCoordinator.fetchInitialData())
-            .then(() => appCoordinator.setHomeScreenName());
+          await appCoordinator.setPatientById(patientId).then(() => appCoordinator.fetchInitialData());
           appCoordinator.gotoNextScreen(this.props.route.name);
         })
         .catch((err: AxiosError) => {

--- a/src/features/school-network/SchoolNetworkCoordinator.ts
+++ b/src/features/school-network/SchoolNetworkCoordinator.ts
@@ -1,10 +1,9 @@
-import appCoordinator, { AppCoordinator } from '@covid/features/AppCoordinator';
 import NavigatorService from '@covid/NavigatorService';
 import { ScreenFlow, Coordinator, SelectProfile } from '@covid/core/Coordinator';
 import { PatientData } from '@covid/core/patient/PatientData';
 import { Services } from '@covid/provider/services.types';
 import { IPatientService } from '@covid/core/patient/PatientService';
-import { ILocalisationService } from '@covid/core/localisation/LocalisationService';
+import { homeScreenName, ILocalisationService } from '@covid/core/localisation/LocalisationService';
 import { IUserService } from '@covid/core/user/UserService';
 import { lazyInject } from '@covid/provider/services';
 import { Profile } from '@covid/components/Collections/ProfileList';
@@ -19,7 +18,6 @@ import { fetchSubscribedSchoolGroups } from '@covid/core/schools/Schools.slice';
 import store from '@covid/core/state/store';
 
 export class SchoolNetworkCoordinator extends Coordinator implements SelectProfile {
-  appCoordinator: AppCoordinator;
   patientData: PatientData;
   higherEducation: boolean;
 
@@ -56,8 +54,7 @@ export class SchoolNetworkCoordinator extends Coordinator implements SelectProfi
     },
   };
 
-  init = (appCoordinator: AppCoordinator, patientData: PatientData, higherEducation: boolean) => {
-    this.appCoordinator = appCoordinator;
+  init = (patientData: PatientData, higherEducation: boolean) => {
     this.patientData = patientData;
     this.higherEducation = higherEducation;
     this.selectedSchool = undefined;
@@ -76,7 +73,7 @@ export class SchoolNetworkCoordinator extends Coordinator implements SelectProfi
   }
 
   resetToHome() {
-    NavigatorService.reset([{ name: appCoordinator.homeScreenName }], 0);
+    NavigatorService.reset([{ name: homeScreenName() }], 0);
   }
 
   goToJoinGroup() {


### PR DESCRIPTION
Removes circular imports on appCoordinator, by moving the getHomeScreen function to the Localisation service.
