### PR TITLE
Report card margins

### DIFF
--- a/src/features/dashboard/Header.tsx
+++ b/src/features/dashboard/Header.tsx
@@ -113,7 +113,8 @@ const styles = StyleSheet.create({
   },
 
   reportCard: {
-    width: '85%',
+    alignSelf: 'stretch',
+    marginHorizontal: 16,
     backgroundColor: 'rgba(255,255,255,0.1)',
     borderRadius: 16,
     alignItems: 'center',


### PR DESCRIPTION
Make the top card with the 'Report today..' button equal margin widths as below cards.

![Simulator Screen Shot - iPhone 11 - 2020-12-02 at 11 14 34](https://user-images.githubusercontent.com/36822087/100865751-ac436e00-348f-11eb-9c11-e8ea3207e8d9.png)
