### PR TITLE
add line-break and increase padding around c19 logo

### DIFF
--- a/src/components/Screens/share/label.tsx
+++ b/src/components/Screens/share/label.tsx
@@ -18,7 +18,10 @@ function ShareLabel({ colorPalette = 'teal', colorShade = 'main' }: IProps) {
       <SRowView>
         <STextContainer>
           <Text colorPalette={colorPalette} colorShade={colorShade} textClass="h6Regular">
-            Explore the state of the pandemic in your area via the COVID Symptom Study App covid.joinzoe.com
+            Explore the state of the pandemic in your area via the COVID Symptom Study App
+          </Text>
+          <Text colorPalette={colorPalette} colorShade={colorShade} textClass="h6Regular">
+            covid.joinzoe.com
           </Text>
         </STextContainer>
         <SLogoContainer>

--- a/src/components/Screens/share/styles.ts
+++ b/src/components/Screens/share/styles.ts
@@ -107,10 +107,10 @@ export const SImageContainer = styled(View)`
     background-color: #082A5D; 
     border-radius: ${props.theme.grid.s}px;
     justify-content: center;
-    height: ${props.theme.grid.xxxxl}px;
+    height: 56px;
     margin-bottom: ${props.theme.grid.l}px;
     padding: ${props.theme.grid.xs}px;
-    width: ${props.theme.grid.xxxxl}px;
+    width: 56px;
   `}
 `;
 


### PR DESCRIPTION
# Description

When the image is shared is is converted to a .jpg, this gave the c19 logo a solid background and revealed an overlap with the blue circular background. Increased circle size to prevent this

added a linebreak to the share copy

## On what platform have you tested the change?

- [x] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
