### PR TITLE
Fix incorrect field name

### DIFF
--- a/src/features/covid-tests/fields/CovidTestIsRapidQuestion.tsx
+++ b/src/features/covid-tests/fields/CovidTestIsRapidQuestion.tsx
@@ -64,6 +64,6 @@ CovidTestIsRapidQuestion.schema = () => {
 
 CovidTestIsRapidQuestion.createDTO = (formData: CovidTestIsRapidData): Partial<CovidTest> => {
   return {
-    ...(isGBCountry() && formData.isRapidTest && { invited_to_test: formData.isRapidTest === 'yes' }),
+    ...(isGBCountry() && formData.isRapidTest && { is_rapid_test: formData.isRapidTest === 'yes' }),
   } as Partial<CovidTest>;
 };


### PR DESCRIPTION
Fixes incorrect field name when submitting covid tests with the new `is_rapid_test` flag. 