### PR TITLE
Fix Swedish translation for rapid test

### DIFF
--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -268,6 +268,9 @@
     "required-mechanism": "Ange hur testet utfördes",
     "required-result": "Ange testresultatet",
 
+    "question-is-rapid-test": "Väntade du mindre än 2 timmar för att få resultaten (dvs. var det ett snabbtest som sidoflöde)?",
+    "question-invite-to-test": "Har vi bjudit in dig att utföra detta test?",
+
     "confirm-test": {
       "title": "",
       "body": "",
@@ -1016,11 +1019,6 @@
       "uni-hospital": false,
       "nct-number": false,
       "if-not": false
-    },
-
-    "covid-test": {
-      "question-is-rapid-test": "Väntade du mindre än 2 timmar för att få resultaten (dvs. var det ett snabbtest som sidoflöde)?",
-      "question-invite-to-test": "Har vi bjudit in dig att utföra detta test?"
     },
 
     "partners": {


### PR DESCRIPTION
Fixes a bug where Swedish translations strings are not in the right place in the JSON file, which means it falls back to the English text. 

Fixed version:

![Screenshot 2020-12-29 at 13 43 47](https://user-images.githubusercontent.com/7824212/103288114-12aea400-49dc-11eb-9e2c-981ddb8725a5.png)
