### PR TITLE
Bug: Remove validation on Rapid Tests

### DIFF
--- a/src/features/covid-tests/fields/CovidTestIsRapidQuestion.tsx
+++ b/src/features/covid-tests/fields/CovidTestIsRapidQuestion.tsx
@@ -16,8 +16,6 @@ interface Props {
   test?: CovidTest;
 }
 
-// CovidTestInvitedQuestion
-
 export interface CovidTestIsRapidQuestion<P, Data> extends React.FC<P> {
   initialFormValues: (test?: CovidTest) => Data;
   schema: () => Yup.ObjectSchema;
@@ -55,11 +53,7 @@ CovidTestIsRapidQuestion.initialFormValues = (test?: CovidTest): CovidTestIsRapi
 };
 
 CovidTestIsRapidQuestion.schema = () => {
-  return isGBCountry()
-    ? Yup.object().shape({
-        isRapidTest: Yup.string().required(i18n.t('please-select-option')),
-      })
-    : Yup.object().shape({});
+  return Yup.object().shape({});
 };
 
 CovidTestIsRapidQuestion.createDTO = (formData: CovidTestIsRapidData): Partial<CovidTest> => {


### PR DESCRIPTION
The RapidTest Yes/No question is conditionally displayed (if the mechanism is Nasal Swab / Spit and the user has a result) - but the validation is always applied. 

This means that users cannot log a test if their result is pending. This fixes the problem by removing the validation.


**Illustration of the problem:**

![Screenshot 2020-12-29 at 14 04 19](https://user-images.githubusercontent.com/7824212/103289307-cb75e280-49de-11eb-9a48-4ad9adfbb4c5.png)
