### PR TITLE
Vaccine Layout Tweeks

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1255,7 +1255,8 @@
 
   "vaccines": {
     "thank-you": {
-      "title": "Thank you.\nPlease continue to provide daily health reports following your COVID-19 vaccination ",
+      "title": "Thank you.",
+      "sub-title": "Please continue to provide daily health reports following your COVID-19 vaccination.",
       "text": "The 7 days following your vaccination are crucial for us to properly understand side-effects.\n\nYour daily reports will help maintain the accuracy of our COVID-19 infection data.",
       "confirm": "Start daily report"
     },

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1309,7 +1309,8 @@
     "vaccines": {
 
     "thank-you": {
-      "title": "Thank you.\nPlease continue to provide daily health reports following your COVID-19 vaccination ",
+      "title": "Thank you.",
+      "sub-title": "Please continue to provide daily health reports following your COVID-19 vaccination.",
       "text": "The 7 days following your vaccination are crucial for us to properly understand side-effects.\n\nYour daily reports will help maintain the accuracy of our COVID-19 infection data.",
       "confirm": "Start daily report"
     },

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1274,6 +1274,7 @@
     "vaccines": {
       "thank-you": {
         "title": "",
+        "sub-title": "",
         "text": "",
         "confirm": ""
       },

--- a/src/features/vaccines/VaccineThankYouScreen.tsx
+++ b/src/features/vaccines/VaccineThankYouScreen.tsx
@@ -34,6 +34,10 @@ export const VaccineThankYouScreen: React.FC<Props> = ({ route, navigation }) =>
 
           <HeaderText style={{ marginTop: 36, textAlign: 'center' }}>{i18n.t('vaccines.thank-you.title')}</HeaderText>
 
+          <HeaderText style={{ marginTop: 8, textAlign: 'center' }}>
+            {i18n.t('vaccines.thank-you.sub-title')}
+          </HeaderText>
+
           <RegularText style={{ marginTop: 36, textAlign: 'center' }}>{i18n.t('vaccines.thank-you.text')}</RegularText>
         </View>
       </Screen>

--- a/src/features/vaccines/fields/VaccineDateQuestion.tsx
+++ b/src/features/vaccines/fields/VaccineDateQuestion.tsx
@@ -83,6 +83,7 @@ export const VaccineDateQuestion: VaccineDateQuestion<Props, VaccineDateData> = 
 
       {(editIndex === undefined || editIndex === 1) && (
         <>
+          <Header3Text style={styles.labelStyle}>{i18n.t('vaccines.your-vaccine.second-dose')}</Header3Text>
           <YesNoField
             selectedValue={formikProps.values.hadSecondDose}
             onValueChange={(value: string) => {
@@ -96,7 +97,6 @@ export const VaccineDateQuestion: VaccineDateQuestion<Props, VaccineDateData> = 
 
           {formikProps.values.hadSecondDose === 'yes' && (
             <>
-              <Header3Text style={styles.labelStyle}>{i18n.t('vaccines.your-vaccine.second-dose')}</Header3Text>
               <SecondaryText>{i18n.t('vaccines.your-vaccine.when-injection')}</SecondaryText>
               {showSecondPicker ? (
                 <CalendarPicker

--- a/src/features/vaccines/fields/VaccineHesitancyQuestions.tsx
+++ b/src/features/vaccines/fields/VaccineHesitancyQuestions.tsx
@@ -60,8 +60,8 @@ export const VaccineHesitancyQuestions: FormQuestion<Props, VaccineHesitancyData
     { label: i18n.t('vaccines.hesitancy.unsure-is-working'), formKey: 'reason_efficacy' },
     { label: i18n.t('vaccines.hesitancy.availability'), formKey: 'reason_availability' },
     { label: i18n.t('vaccines.hesitancy.unnecessary'), formKey: 'reason_unnecessary' },
-    { label: i18n.t('vaccines.hesitancy.Other'), formKey: 'other' },
     { label: i18n.t('vaccines.hesitancy.not-to-say'), formKey: 'reason_pfnts' },
+    { label: i18n.t('vaccines.hesitancy.Other'), formKey: 'other' },
   ];
 
   return (


### PR DESCRIPTION
**[1] Move sub-heading for Vaccine Second Dose**
![Screenshot 2021-01-05 at 15 15 37](https://user-images.githubusercontent.com/7824212/103666411-84529900-4f6c-11eb-8efd-a988708a4791.png)

**[2] Switch order of "Prefer Not to Say" and "Other" on Vaccine Hesitancy**

![Screenshot 2021-01-05 at 14 48 51](https://user-images.githubusercontent.com/7824212/103666458-946a7880-4f6c-11eb-9134-117eb750890d.png)


[3] Fix line spacing on Thank You Screen

![Screenshot 2021-01-05 at 15 42 49](https://user-images.githubusercontent.com/7824212/103666552-b19f4700-4f6c-11eb-92a9-39f6dc6dd382.png)


