### PR TITLE
Visual Changes to Dose Symptoms Pages

### DIFF
--- a/assets/icons/InfoCircle.tsx
+++ b/assets/icons/InfoCircle.tsx
@@ -4,21 +4,22 @@ import Svg, { Path } from 'react-native-svg';
 type CheckProps = {
   width?: number | string;
   height?: number | string;
+  color?: string;
 };
 
-const InfoCircle: React.FC<CheckProps> = ({ width = 20, height = 20 }) => {
+const InfoCircle: React.FC<CheckProps> = ({ width = 20, height = 20, color = '#AAACAD' }) => {
   return (
     <Svg width={width} height={height} fill="none" viewBox="0 0 16 16">
       <Path
         d="M15.5 8C15.5 12.1421 12.1421 15.5 8 15.5C3.85786 15.5 0.5 12.1421 0.5 8C0.5 3.85786 3.85786 0.5 8 0.5C12.1421 0.5 15.5 3.85786 15.5 8Z"
-        stroke="#AAACAD"
+        stroke={color}
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <Path d="M8 12.5V8" stroke="#AAACAD" strokeLinecap="round" strokeLinejoin="round" />
+      <Path d="M8 12.5V8" stroke={color} strokeLinecap="round" strokeLinejoin="round" />
       <Path
         d="M7.9998 6.4C8.66255 6.4 9.1998 5.86274 9.1998 5.2C9.1998 4.53726 8.66255 4 7.9998 4C7.33706 4 6.7998 4.53726 6.7998 5.2C6.7998 5.86274 7.33706 6.4 7.9998 6.4Z"
-        fill="#AAACAD"
+        fill={color}
       />
     </Svg>
   );

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1273,7 +1273,10 @@
       "itch": "Itch",
       "tenderness": "Tenderness",
       "other": "Other",
-      "next": "Next"
+      "other-info": "Please enter symptoms near the injection site (most likely your arm) only. We’ll ask about general symptoms in the next section.",
+      "other-placeholder": "Describe your symptoms here...",
+      "next": "Next",
+
     },
 
     "vaccine-list": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1263,7 +1263,9 @@
 
     "dose-symptoms": {
       "label": "About your recent vaccine",
-      "title": "Are you experiencing any symptoms near the injection site?",
+      "title-1": "Are you experiencing any symptoms",
+      "title-2": " near the injection site",
+      "title-3": "?",
       "check-all-that-apply": "Check all that apply:",
       "pain": "Pain",
       "redness": "Redness",
@@ -1275,8 +1277,7 @@
       "other": "Other",
       "other-info": "Please enter symptoms near the injection site (most likely your arm) only. We’ll ask about general symptoms in the next section.",
       "other-placeholder": "Describe your symptoms here...",
-      "next": "Next",
-
+      "next": "Next"
     },
 
     "vaccine-list": {

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1317,7 +1317,9 @@
 
     "dose-symptoms": {
       "label": "About your recent vaccine",
-      "title": "Are you experiencing any symptoms near the injection site?",
+      "title-1": "Are you experiencing any symptoms",
+      "title-2": " near the injection site",
+      "title-3": "?",
       "check-all-that-apply": "Check all that apply:",
       "pain": "Pain",
       "redness": "Redness",
@@ -1327,6 +1329,8 @@
       "itch": "Itch",
       "tenderness": "Tenderness",
       "other": "Other",
+      "other-info": "Please enter symptoms near the injection site (most likely your arm) only. We’ll ask about general symptoms in the next section.",
+      "other-placeholder": "Describe your symptoms here...",
       "next": "Next"
     },
 

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1280,7 +1280,9 @@
       },
       "dose-symptoms": {
         "label": "",
-        "title": "",
+        "title-1": "",
+        "title-2": "",
+        "title-3": "",
         "check-all-that-apply": "",
         "pain": "",
         "redness": "",
@@ -1290,6 +1292,8 @@
         "itch": "",
         "tenderness": "",
         "other": "",
+        "other-info": "",
+        "other-placeholder": "",
         "next": ""
       },
       "hesitancy": {

--- a/src/features/vaccines/VaccineDoseSymptomsScreen.tsx
+++ b/src/features/vaccines/VaccineDoseSymptomsScreen.tsx
@@ -59,7 +59,11 @@ export const VaccineDoseSymptomsScreen: React.FC<Props> = ({ route, navigation }
             <RegularText>{i18n.t('vaccines.dose-symptoms.label')}</RegularText>
           </View>
 
-          <HeaderText>{i18n.t('vaccines.dose-symptoms.title')}</HeaderText>
+          <HeaderText>
+            <HeaderText>{i18n.t('vaccines.dose-symptoms.title-1')}</HeaderText>
+            <HeaderText style={{ color: colors.purple }}>{i18n.t('vaccines.dose-symptoms.title-2')}</HeaderText>
+            <HeaderText>{i18n.t('vaccines.dose-symptoms.title-3')}</HeaderText>
+          </HeaderText>
         </Header>
 
         <View>

--- a/src/features/vaccines/fields/DoseSymptomsQuestions.tsx
+++ b/src/features/vaccines/fields/DoseSymptomsQuestions.tsx
@@ -13,6 +13,8 @@ import {
   SymptomCheckBoxData,
 } from '@covid/features/assessment/fields/SymptomsTypes';
 import { DoseSymptomsRequest } from '@covid/core/vaccine/dto/VaccineRequest';
+import { colors } from '@covid/themes/theme/colors';
+import InfoCircle from '@assets/icons/InfoCircle';
 
 export type DoesSymptomsData = DoesSymptomsCheckBoxData & DoesSymptomsFollowUpData;
 
@@ -55,15 +57,28 @@ export const DoesSymptomsQuestions: DoseSymptomQuestions<Props, DoesSymptomsData
       <CheckboxList>{createSymptomCheckboxes(checkboxes, formikProps)}</CheckboxList>
 
       {formikProps.values.other && (
-        <Textarea
-          rowSpan={3}
-          bordered
-          placeholder={i18n.t('placeholder-max-500')}
-          value={formikProps.values.otherSymptoms}
-          onChangeText={formikProps.handleChange('otherSymptoms')}
-          underline={false}
-          style={{ borderRadius: 8 }}
-        />
+        <>
+          <View style={{ flexDirection: 'row', marginVertical: 16, paddingRight: 32 }}>
+            <View style={{ paddingRight: 8 }}>
+              <InfoCircle color={colors.burgundy.main.bgColor} />
+            </View>
+            <View>
+              <RegularText style={{ color: colors.burgundy.main.bgColor }}>
+                {i18n.t('vaccines.dose-symptoms.other-info')}
+              </RegularText>
+            </View>
+          </View>
+
+          <Textarea
+            rowSpan={4}
+            bordered
+            placeholder={i18n.t('vaccines.dose-symptoms.other-placeholder')}
+            value={formikProps.values.otherSymptoms}
+            onChangeText={formikProps.handleChange('otherSymptoms')}
+            underline={false}
+            style={{ borderRadius: 8 }}
+          />
+        </>
       )}
     </View>
   );


### PR DESCRIPTION
This PR changes:
- Emphasise purple title. 
- Add info text when selecting "Other"

I wanted to do something quick. Would be great to follow this up with cleaning up the use of colours / themes and to make the text bold like the design. But I'd rather not introduce another font weight in this OTA. 

![Screenshot 2021-01-05 at 19 05 45](https://user-images.githubusercontent.com/7824212/103688068-2e401e80-4f89-11eb-8e0d-f46fddb7feab.png)
