### PR TITLE
prevent the selection of a date earlier that the first

### DIFF
--- a/src/features/vaccines/fields/VaccineDateQuestion.tsx
+++ b/src/features/vaccines/fields/VaccineDateQuestion.tsx
@@ -104,6 +104,8 @@ export const VaccineDateQuestion: VaccineDateQuestion<Props, VaccineDateData> = 
               {showSecondPicker ? (
                 <CalendarPicker
                   onDateChange={setSecondDoseDate}
+                  minDate={formikProps.values.firstDoseDate}
+                  restrictMonthNavigation
                   maxDate={today}
                   {...(!!formikProps.values.secondDoseDate && {
                     selectedStartDate: formikProps.values.secondDoseDate,


### PR DESCRIPTION
# Description

When the user selects a date for their first vaccination, prevent them from selecting an earlier date when choosing the second.

## On what platform have you tested the change?

- [x] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots
Example: Earlier date selection disabled.

<img width="389" alt="image" src="https://user-images.githubusercontent.com/795789/103762880-f086d880-5010-11eb-8ebd-c7a3f832c46a.png">

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
