### PR TITLE
Stop default to PFIZER 

### DIFF
--- a/src/features/vaccines/AboutYourVaccineScreen.tsx
+++ b/src/features/vaccines/AboutYourVaccineScreen.tsx
@@ -49,7 +49,6 @@ export const AboutYourVaccineScreen: React.FC<Props> = ({ route, navigation }) =
         ...assessmentData.vaccineData,
         patient: assessmentData.patientData.patientId,
         vaccine_type: VaccineTypes.COVID_VACCINE,
-        brand: VaccineBrands.PFIZER,
       } as Partial<VaccineRequest>;
 
       if (vaccine.doses === undefined) {


### PR DESCRIPTION
For v2 we are no longer going to assumer PFIZER is the brand. 
A form entry will be added in v3 to allow the user to select it. 