### PR TITLE
feat(content-loading-state): shimmering / error message state

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1314,6 +1314,7 @@
     }
   },
   "generic": {
-    "share-this-with-someone": "Share this with someone"
+    "share-this-with-someone": "Share this with someone",
+    "content-can-not-be-loaded-atm": "This content can not be loaded at the moment."
   }
 }

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1319,6 +1319,7 @@
     }
   },
   "generic": {
-    "share-this-with-someone": ""
+    "share-this-with-someone": "",
+    "content-can-not-be-loaded-atm": ""
   }
 }

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1312,6 +1312,7 @@
     }
   },
   "generic": {
-    "share-this-with-someone": "Share this with someone"
+    "share-this-with-someone": "Share this with someone",
+    "content-can-not-be-loaded-atm": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-native-reanimated": "~1.13.0",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "~2.10.1",
+    "react-native-shimmer-placeholder": "^2.0.6",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "12.1.0",
     "react-native-unimodules": "~0.11.0",

--- a/src/components/Content/ContentLoadingView.tsx
+++ b/src/components/Content/ContentLoadingView.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import ShimmerPlaceholder from 'react-native-shimmer-placeholder';
+
+import { Text } from '../typography';
+
+const styles = StyleSheet.create({
+  container: {
+    height: 200,
+    backgroundColor: 'white',
+    borderRadius: 16,
+    marginVertical: 12,
+    padding: 20,
+    justifyContent: 'space-between',
+  },
+  base: {
+    borderRadius: 6,
+    height: 20,
+  },
+  one: {},
+  two: {
+    width: '30%',
+    marginTop: 12,
+  },
+  three: {
+    height: 12,
+    width: '35%',
+    marginTop: 12,
+  },
+});
+
+type ContentErrorViewProps = {
+  message: string;
+};
+
+export const ContentErrorView: React.FC<ContentErrorViewProps> = ({ message }) => {
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          justifyContent: 'center',
+        },
+      ]}>
+      <Text textAlign="center" textClass="p" style={{ marginHorizontal: 12 }}>
+        {message}
+      </Text>
+    </View>
+  );
+};
+
+type ContentLoadingViewProps = {
+  loading?: boolean;
+  errorMessage?: string;
+};
+
+export const ContentLoadingView: React.FC<ContentLoadingViewProps> = ({ loading, errorMessage, children }) => {
+  if (errorMessage) {
+    return <ContentErrorView message={errorMessage} />;
+  }
+
+  return (
+    <View>
+      {loading && (
+        <View style={styles.container}>
+          <View>
+            <ShimmerPlaceholder LinearGradient={LinearGradient} style={[styles.base]} />
+            <ShimmerPlaceholder LinearGradient={LinearGradient} style={[styles.base, styles.two]} />
+          </View>
+          <ShimmerPlaceholder LinearGradient={LinearGradient} style={[styles.base, styles.three]} />
+        </View>
+      )}
+      <View style={[loading && { position: 'absolute', opacity: 0 }]}>{children}</View>
+    </View>
+  );
+};

--- a/src/components/ExternalCallout.tsx
+++ b/src/components/ExternalCallout.tsx
@@ -16,6 +16,7 @@ import { closeIcon } from '@assets';
 import { RootState } from '@covid/core/state/root';
 import { addDismissCallout } from '@covid/core/content/state/contentSlice';
 import { useAppDispatch } from '@covid/core/state/store';
+import { ContentLoadingView } from '@covid/components/Content/ContentLoadingView';
 
 type ExternalCalloutProps = {
   link?: string;
@@ -32,6 +33,8 @@ export const ExternalCallout: React.FC<ExternalCalloutProps> = (props) => {
   const { calloutID, link, screenName, postClicked, canDismiss } = props;
   const dismissedCalloutIds = useSelector<RootState, string[]>((state) => state.content.dismissedCallouts);
   const [dismissed, setDismissed] = useState<boolean>(false);
+  const [imageLoading, setImageLoading] = useState<boolean>(false);
+  const [imageLoadError, setImageLoadError] = useState<string | undefined>(undefined);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -50,13 +53,30 @@ export const ExternalCallout: React.FC<ExternalCalloutProps> = (props) => {
   }
 
   return (
-    <>
+    <ContentLoadingView loading={imageLoading} errorMessage={imageLoadError}>
       {!dismissed && (
         <TouchableWithoutFeedback onPress={clickCallout}>
           <View style={styles.viewContainer}>
             <Image
               source={props.imageSource}
-              style={[styles.image, { aspectRatio: props.aspectRatio }, { ...(props.imageStyles as object) }]}
+              style={[
+                styles.image,
+                { aspectRatio: props.aspectRatio },
+                { ...(props.imageStyles as object) },
+                imageLoading && { opacity: 0 },
+              ]}
+              onLoadStart={() => {
+                setImageLoading(true);
+              }}
+              onLoadEnd={() => {
+                setTimeout(() => {
+                  setImageLoading(false);
+                }, 330);
+              }}
+              onError={() => {
+                setImageLoading(false);
+                setImageLoadError('This content can not be loaded at the moment.');
+              }}
             />
             {canDismiss && (
               <TouchableWithoutFeedback onPress={clickDismiss}>
@@ -66,7 +86,7 @@ export const ExternalCallout: React.FC<ExternalCalloutProps> = (props) => {
           </View>
         </TouchableWithoutFeedback>
       )}
-    </>
+    </ContentLoadingView>
   );
 };
 

--- a/src/components/ExternalCallout.tsx
+++ b/src/components/ExternalCallout.tsx
@@ -17,6 +17,7 @@ import { RootState } from '@covid/core/state/root';
 import { addDismissCallout } from '@covid/core/content/state/contentSlice';
 import { useAppDispatch } from '@covid/core/state/store';
 import { ContentLoadingView } from '@covid/components/Content/ContentLoadingView';
+import i18n from '@covid/locale/i18n';
 
 type ExternalCalloutProps = {
   link?: string;
@@ -75,7 +76,7 @@ export const ExternalCallout: React.FC<ExternalCalloutProps> = (props) => {
               }}
               onError={() => {
                 setImageLoading(false);
-                setImageLoadError('This content can not be loaded at the moment.');
+                setImageLoadError(i18n.t('content-can-not-be-loaded-atm'));
               }}
             />
             {canDismiss && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11588,6 +11588,11 @@ react-native-screens@~2.10.1:
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.10.1.tgz#06d22fae87ef0ce51c616c34a199726db1403b95"
   integrity sha512-Z2kKSk4AwWRQNCBmTjViuBQK0/Lx0jc25TZptn/2gKYUCOuVRvCekoA26u0Tsb3BIQ8tWDsZW14OwDlFUXW1aw==
 
+react-native-shimmer-placeholder@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-shimmer-placeholder/-/react-native-shimmer-placeholder-2.0.6.tgz#a6626d955945edb1aa01f8863f3e039a738d53d1"
+  integrity sha512-eq0Jxi/j/WseijfSeNjoAsaz1164XUCDvKpG/+My+c5YeVMfjTnl9SwoVAIr9uOpuDXXia67j8xME+eFJZvBXw==
+
 react-native-splash-screen@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"


### PR DESCRIPTION
# Description

Added shimmering (loading) & error state for featured content

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![2021-01-13 15 37 58](https://user-images.githubusercontent.com/36766508/104474151-a0ca8300-55b5-11eb-9b8b-5bb72d2dba77.gif)

![2021-01-13 15 36 42](https://user-images.githubusercontent.com/36766508/104473937-6a8d0380-55b5-11eb-8473-6eb8d5938c6b.gif)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [x] I have run `npm test`
- [x] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
