### PR TITLE
Remove expo-location library

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -253,7 +253,7 @@ dependencies {
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
-    addUnimodulesDependencies()
+    addUnimodulesDependencies([exclude: ['expo-location']])
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/android/app/src/main/java/com/joinzoe/covid_zoe/generated/BasePackageList.java
+++ b/android/app/src/main/java/com/joinzoe/covid_zoe/generated/BasePackageList.java
@@ -18,7 +18,6 @@ public class BasePackageList {
         new expo.modules.keepawake.KeepAwakePackage(),
         new expo.modules.lineargradient.LinearGradientPackage(),
         new expo.modules.localization.LocalizationPackage(),
-        new expo.modules.location.LocationPackage(),
         new expo.modules.notifications.NotificationsPackage(),
         new expo.modules.permissions.PermissionsPackage(),
         new expo.modules.sharing.SharingPackage(),

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,7 +14,7 @@ target 'Covid' do
   config = use_native_modules!
   use_react_native!(:path => config["reactNativePath"])
 
-  use_unimodules!(exclude: ['expo-splash-screen'])
+  use_unimodules!(exclude: ['expo-splash-screen', 'expo-location'])
 
   # use_flipper!
   post_install do |installer|


### PR DESCRIPTION
Expo was depending on the expo-location library, however this was adding location permissions into both the iOS and android build. This lib is being installed by expo unimodules (not by us via npm/yarn) and so had to removed during the build process. Ive tested and the permission is no longer merged into the final AndroidManifest.xml. Ive also removed it on the iOS side too.