### PR TITLE
Rename US Cohort

### DIFF
--- a/src/features/patient/YourStudyScreen.tsx
+++ b/src/features/patient/YourStudyScreen.tsx
@@ -342,7 +342,7 @@ export default class YourStudyScreen extends Component<YourStudyProps, State> {
               <Form>
                 <FieldWrapper>
                   <Item stackedLabel style={styles.textItemStyle}>
-                    <Label>{i18n.t('your-study.label-cohort')}</Label>
+                    <Label style={{ marginBottom: 16 }}>{i18n.t('your-study.label-cohort')}</Label>
                     <CheckboxList>
                       {countrySpecificCohorts.map((cohort) => (
                         <CheckboxItem

--- a/src/features/patient/YourStudyScreen.tsx
+++ b/src/features/patient/YourStudyScreen.tsx
@@ -101,7 +101,7 @@ const AllCohorts: CohortDefinition[] = [
   },
   {
     key: 'is_in_us_origins',
-    label: 'ORIGINS',
+    label: 'ORIGINS-Columbia University',
     country: 'US',
   },
   {


### PR DESCRIPTION
- This PR renames the display name of a US Study Cohort, as requested by Andy Chan. 
- Fixes padding that was a bit of an eye sore

## Before:

![Screenshot 2021-01-25 at 18 49 16](https://user-images.githubusercontent.com/7824212/105751617-2d722b00-5f3e-11eb-8dc0-e0ff841e86f8.png)

## After 

![Screenshot 2021-01-25 at 18 48 49](https://user-images.githubusercontent.com/7824212/105751649-3a8f1a00-5f3e-11eb-93b3-530edb3185a5.png)

