### PR TITLE
Downgrade to expo 39.0.0 and bump app verison (#1123)

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "owner": "julien.lavigne",
     "privacy": "public",
     "platforms": ["ios", "android"],
-    "version": "2.3.0",
+    "version": "2.4.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Covid",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "scripts": {
     "start": "react-native start",
     "start:reset": "react-native start --reset-cache",
@@ -66,7 +66,7 @@
     "axios": "0.21.1",
     "axios-mock-adapter": "1.19.0",
     "country-list": "2.2.0",
-    "expo": "39.0.5",
+    "expo": "39.0.0",
     "expo-analytics-amplitude": "^10.0.0",
     "expo-asset": "8.2.0",
     "expo-constants": "9.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3288,7 +3288,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@unimodules/core@~5.5.0", "@unimodules/core@~5.5.1":
+"@unimodules/core@~5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@unimodules/core/-/core-5.5.1.tgz#82afe960568c58da62c76ea45ca77aa43a31ce13"
   integrity sha512-4OADQJqQ52TsCzfK+xUGWjt3zZADYxRvBZe8JXrnx2qGMXhFFUUn2JMEZT3nDt4QwtM+rIp9BsrQCMIPlXCOHg==
@@ -6967,7 +6967,7 @@ expo-sharing@8.4.1:
   resolved "https://registry.yarnpkg.com/expo-sharing/-/expo-sharing-8.4.1.tgz#250e537d970af861a45fd194bd804e9389fdc25a"
   integrity sha512-Qg6CJQPwE00lm3cZrq4spJT+ahsZa8z1g1FwItQ5FFIUTfli97P6i6g5q12jL5KWaGycbw+La/5/vgT40I9Oxg==
 
-expo-splash-screen@0.6.2, expo-splash-screen@~0.6.2:
+expo-splash-screen@0.6.2, expo-splash-screen@^0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/expo-splash-screen/-/expo-splash-screen-0.6.2.tgz#2be7fc28ad62549e870c69f1fe133ebe756c524f"
   integrity sha512-Rvi+aiVDztFyLh5fYJYcZxVuQNDCy6ATSTfxuch5uVQ1jA9/vjVzUKG4iZCoChaSCnMV56aFftHBWSDNWPvLFQ==
@@ -7003,14 +7003,14 @@ expo-web-browser@8.5.0:
   dependencies:
     compare-urls "^2.0.0"
 
-expo@39.0.5:
-  version "39.0.5"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-39.0.5.tgz#d2a37a65859c8c5c1821a49012548bdf541a4c7f"
-  integrity sha512-uLywo0Gvx0SUz/Bso/2IMDeMr9Lvr4/4YB8yAYS3BW3872duFHKHVccKEqLzBN+q/5DuW5fmSNkOeQCThMFo/w==
+expo@39.0.0:
+  version "39.0.0"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-39.0.0.tgz#bee6b859b3faee2ac2018d9295022bbea231f80f"
+  integrity sha512-6TB31TNiJVo9o4HaUbeMl9wHkQKlBkMZG/dAGc1AxGURd19A7dctzlFo2kwNSAPJz0R9BUnGNVfephllsVI+ow==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@expo/vector-icons" "^10.0.2"
-    "@unimodules/core" "~5.5.1"
+    "@unimodules/core" "~5.5.0"
     "@unimodules/react-native-adapter" "~5.6.0"
     babel-preset-expo "~8.3.0"
     badgin "^1.1.2"
@@ -7025,7 +7025,7 @@ expo@39.0.5:
     expo-linking "~1.0.4"
     expo-location "~9.0.0"
     expo-permissions "~9.3.0"
-    expo-splash-screen "~0.6.2"
+    expo-splash-screen "^0.6.0"
     expo-sqlite "~8.4.0"
     fbemitter "^2.1.1"
     invariant "^2.2.2"


### PR DESCRIPTION
Cutting a new app store release (2.3.0 -> 2.4.0).  

The 2.3.0 release we did last week will not take any OTA updates. This appears to be because expo sdk was bumped from 39.0.0 -> 39.0.5. I have tested OTA's work with this release. 