### PR TITLE
Bug Fix for Diet Study Feedback Crashes

### DIFF
--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -233,7 +233,19 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
     this.patientData = await this.patientService.getPatientDataByProfile(profile);
   }
 
-  goToDietStudyPlayback() {
+  async setPatientToPrimary() {
+    const user = await this.userService.getUser();
+    const patientId = user?.patients[0] ?? null;
+
+    if (patientId) {
+      await this.setPatientById(patientId);
+    }
+  }
+
+  async goToDietStudyPlayback() {
+    if (this.patientData.patientState.isReportedByAnother) {
+      await this.setPatientToPrimary();
+    }
     this.startDietStudyPlaybackFlow(this.patientData);
   }
 

--- a/src/features/diet-study-playback/components/gut-score/index.tsx
+++ b/src/features/diet-study-playback/components/gut-score/index.tsx
@@ -8,7 +8,7 @@ import { SContainerView } from './styles';
 import Score from './score';
 
 interface IProps {
-  beforeScore?: number;
+  beforeScore: number | null;
   duringScore: number;
   minValue?: number;
   maxValue?: number;

--- a/src/features/thank-you/ThankYouUKScreen.tsx
+++ b/src/features/thank-you/ThankYouUKScreen.tsx
@@ -55,7 +55,11 @@ export default class ThankYouUKScreen extends Component<RenderProps, State> {
   async componentDidMount() {
     const { startupInfo } = store.getState().content;
     const variant = startExperiment(experiments.UK_DietScore_Invite, 2);
-    const showDietStudyPlayback = (variant === 'variant_2' && startupInfo?.show_diet_score) || false;
+    const showDietStudyPlayback =
+      (variant === 'variant_2' &&
+        startupInfo?.show_diet_score &&
+        !appCoordinator.patientData.patientState.isReportedByAnother) ||
+      false;
 
     if (showDietStudyPlayback) {
       Analytics.track(events.DIET_STUDY_PLAYBACK_DISPLAYED);


### PR DESCRIPTION
The PR fixes a bug where are user can enter the DietStudyPlayback flow, while this.patientData is set to secondary profile. 

1) Only should the DietStudy Invite on the ThankYou page, if reporting for the primary profile. 
2) When starting the flow (which can happen from the Dashboard) with this.patientData set to secondary profiles force a reset. (This currently incurs an extra API call, which ideally should not be necessary - but requires a bigger plumbing and moving patientLists and primary patientID into redux). 

- This kind of glosses over the question of "What should this.patientData point to, when you are on the Dashboard, after just finishing with reporting for a secondary profile. This is MUCH bigger re-architecture. 
