### PR TITLE
Updated homepage vaccine share to use current share system

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1122,7 +1122,8 @@
         "from-last-week": "from last week"
       },
       "share-cta": "Share your graph"
-    }
+    },
+    "share-cta": "Share"
   },
 
   "explore-trend-line": {

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -951,7 +951,8 @@
         "from-last-week": ""
       },
       "share-cta": ""
-    }
+    },
+    "share-cta": "Share"
   },
 
   "explore-trend-line": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1157,7 +1157,8 @@
         "from-last-week": ""
       },
       "share-cta": ""
-    }
+    },
+    "share-cta": "Share"
   },
 
   "explore-trend-line": {

--- a/src/components/Cards/ShareVaccineCard.tsx
+++ b/src/components/Cards/ShareVaccineCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useNavigation } from '@react-navigation/native';
+
+import { shareVaccineBanner, shareVaccine } from '@assets';
+
+import { ExternalCallout } from '../ExternalCallout';
+
+interface Props {
+  screenName: string;
+  isSharing?: boolean;
+}
+
+export const ShareVaccineCard: React.FC<Props> = ({ screenName, isSharing = false }) => {
+  const { navigate } = useNavigation();
+
+  return (
+    <>
+      {!isSharing && (
+        <ExternalCallout
+          calloutID="shareVaccineBanner"
+          imageSource={shareVaccineBanner}
+          aspectRatio={311 / 135}
+          screenName={screenName}
+          postClicked={() => navigate('Share', { sharable: 'VACCINES', hideLabel: true })}
+        />
+      )}
+
+      {isSharing && (
+        <ExternalCallout
+          calloutID="shareVaccine"
+          imageSource={shareVaccine}
+          aspectRatio={600 / 500}
+          screenName={screenName}
+          postClicked={() => navigate('Share', { sharable: 'VACCINES', hideLabel: true })}
+        />
+      )}
+    </>
+  );
+};

--- a/src/components/Cards/ShareVaccineCard.tsx
+++ b/src/components/Cards/ShareVaccineCard.tsx
@@ -29,7 +29,7 @@ export const ShareVaccineCard: React.FC<Props> = ({ screenName, isSharing = fals
         <ExternalCallout
           calloutID="shareVaccine"
           imageSource={shareVaccine}
-          aspectRatio={600 / 500}
+          aspectRatio={1125 / 877}
           screenName={screenName}
           postClicked={() => navigate('Share', { sharable: 'VACCINES', hideLabel: true })}
         />

--- a/src/components/Screens/share/container.tsx
+++ b/src/components/Screens/share/container.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { EstimatedCasesMapCard } from '@covid/components/Cards/EstimatedCasesMapCard';
 // import { TrendLineChart, TrendlineTimeFilters, TrendLineViewMode } from '@covid/components/Stats/TrendLineChart';
 import { TrendlineCard } from '@covid/components/Cards/EstimatedCase';
+import { ShareVaccineCard } from '@covid/components/Cards/ShareVaccineCard';
 
 import { SShareContainerView } from './styles';
 
-type Sharable = 'MAP' | 'TRENDLINE';
+type Sharable = 'MAP' | 'TRENDLINE' | 'VACCINES';
 
 interface IProps {
   sharable?: Sharable;
@@ -16,16 +17,25 @@ function ShareContainer({ sharable = 'MAP' }: IProps) {
   const getSharable = () => {
     switch (sharable) {
       case 'MAP':
-        return <EstimatedCasesMapCard isSharing />;
+        return (
+          <SShareContainerView>
+            <EstimatedCasesMapCard isSharing />
+          </SShareContainerView>
+        );
       case 'TRENDLINE':
-        return <TrendlineCard isSharing />;
-
+        return (
+          <SShareContainerView>
+            <TrendlineCard isSharing />
+          </SShareContainerView>
+        );
+      case 'VACCINES':
+        return <ShareVaccineCard isSharing />;
       default:
         return null;
     }
   };
 
-  return <SShareContainerView>{getSharable()}</SShareContainerView>;
+  return getSharable();
 }
 
 export default ShareContainer;

--- a/src/components/Screens/share/index.tsx
+++ b/src/components/Screens/share/index.tsx
@@ -20,6 +20,7 @@ function ShareScreen() {
   const viewRef = useRef<View>(null);
   const route = useRoute();
   const sharable = route.params.sharable;
+  const hideLabel = route.params.hideLabel;
 
   const share = async () => {
     try {
@@ -36,7 +37,7 @@ function ShareScreen() {
       <SContentView>
         <SInnerContentView ref={viewRef} collapsable={false}>
           <ShareContainer sharable={sharable} />
-          <ShareLabel />
+          {!hideLabel && <ShareLabel />}
         </SInnerContentView>
       </SContentView>
       <SButtonView>

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -1,5 +1,3 @@
-import * as Sharing from 'expo-sharing';
-import * as FileSystem from 'expo-file-system';
 import React, { useEffect, useState } from 'react';
 import { Image, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
@@ -23,13 +21,14 @@ import { updateTodayDate } from '@covid/core/content/state/contentSlice';
 import { RootState } from '@covid/core/state/root';
 import { Optional } from '@covid/utils/types';
 import { fetchSubscribedSchoolGroups } from '@covid/core/schools/Schools.slice';
-import { FeaturedContentList, FeaturedContentType, SchoolNetworks } from '@covid/components';
+import { FeaturedContentList, FeaturedContentType, SchoolNetworks, RegularText } from '@covid/components';
 import { SubscribedSchoolGroupStats } from '@covid/core/schools/Schools.dto';
 import { pushNotificationService } from '@covid/Services';
 import { selectApp, setDasboardVisited } from '@covid/core/state/app';
 import { StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
 import { experiments, startExperiment } from '@covid/core/Experiments';
 import { events, identify, track } from '@covid/core/Analytics';
+import { ShareVaccineCard } from '@covid/components/Cards/ShareVaccineCard';
 
 const HEADER_EXPANDED_HEIGHT = 328;
 const HEADER_COLLAPSED_HEIGHT = 100;
@@ -73,25 +72,6 @@ export const DashboardScreen: React.FC<Props> = ({ navigation, route }) => {
     await share(shareMessage);
   };
 
-  const onShareImage = async (
-    fileName: string,
-    image: any,
-    dialogTitle: string,
-    eventKey: string,
-    screenName: string
-  ) => {
-    try {
-      const uri = Image.resolveAssetSource(image).uri;
-      const downloadPath = FileSystem.cacheDirectory + fileName;
-      const { uri: localUrl } = await FileSystem.downloadAsync(uri, downloadPath);
-      await Sharing.shareAsync(localUrl, {
-        mimeType: 'image/png',
-        dialogTitle,
-      });
-      track(eventKey, { screenName });
-    } catch (_) {}
-  };
-
   useEffect(() => {
     (async () => {
       identify();
@@ -128,21 +108,7 @@ export const DashboardScreen: React.FC<Props> = ({ navigation, route }) => {
       compactHeader={<CompactHeader reportOnPress={onReport} />}
       expandedHeader={<Header reportOnPress={onReport} />}>
       <View style={styles.calloutContainer}>
-        <ExternalCallout
-          calloutID="shareVaccine"
-          imageSource={shareVaccineBanner}
-          aspectRatio={311 / 135}
-          screenName={route.name}
-          postClicked={() =>
-            onShareImage(
-              'ShareVaccine.png',
-              shareVaccine,
-              i18n.t('share-log-vaccine'),
-              events.LOG_YOUR_VACCINE_SHARED,
-              'Dashboard'
-            )
-          }
-        />
+        <ShareVaccineCard screenName="Dashboard" />
 
         {showDietStudyPlayback && (
           <TouchableWithoutFeedback

--- a/src/features/dashboard/DashboardUSScreen.tsx
+++ b/src/features/dashboard/DashboardUSScreen.tsx
@@ -1,5 +1,3 @@
-import * as Sharing from 'expo-sharing';
-import * as FileSystem from 'expo-file-system';
 import React, { useEffect, useState } from 'react';
 import { Image, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
@@ -13,7 +11,7 @@ import { ScreenParamList } from '@covid/features/ScreenParamList';
 import appCoordinator from '@covid/features/AppCoordinator';
 import { ExternalCallout } from '@covid/components/ExternalCallout';
 import { share } from '@covid/components/Cards/BaseShareApp';
-import { dietStudyPlaybackReadyUS, shareAppV3, shareVaccineBanner, shareVaccine } from '@assets';
+import { dietStudyPlaybackReadyUS, shareAppV3 } from '@assets';
 import i18n from '@covid/locale/i18n';
 import { useAppDispatch } from '@covid/core/state/store';
 import { updateTodayDate } from '@covid/core/content/state/contentSlice';
@@ -23,6 +21,7 @@ import { RootState } from '@covid/core/state/root';
 import { StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
 import { selectApp, setDasboardVisited } from '@covid/core/state/app';
 import AnalyticsService, { events } from '@covid/core/Analytics';
+import { ShareVaccineCard } from '@covid/components/Cards/ShareVaccineCard';
 
 const HEADER_EXPANDED_HEIGHT = 328;
 const HEADER_COLLAPSED_HEIGHT = 100;
@@ -54,25 +53,6 @@ export const DashboardUSScreen: React.FC<Props> = (params) => {
     await share(shareMessage);
   };
 
-  const onShareImage = async (
-    fileName: string,
-    image: any,
-    dialogTitle: string,
-    eventKey: string,
-    screenName: string
-  ) => {
-    try {
-      const uri = Image.resolveAssetSource(image).uri;
-      const downloadPath = FileSystem.cacheDirectory + fileName;
-      const { uri: localUrl } = await FileSystem.downloadAsync(uri, downloadPath);
-      await Sharing.shareAsync(localUrl, {
-        mimeType: 'image/png',
-        dialogTitle,
-      });
-      AnalyticsService.track(eventKey, { screenName });
-    } catch (_) {}
-  };
-
   useEffect(() => {
     (async () => {
       AnalyticsService.identify();
@@ -102,21 +82,7 @@ export const DashboardUSScreen: React.FC<Props> = (params) => {
       compactHeader={<CompactHeader reportOnPress={onReport} />}
       expandedHeader={<Header reportOnPress={onReport} />}>
       <View style={styles.calloutContainer}>
-        <ExternalCallout
-          calloutID="shareVaccine"
-          imageSource={shareVaccineBanner}
-          aspectRatio={311 / 135}
-          screenName={route.name}
-          postClicked={() =>
-            onShareImage(
-              'ShareVaccine.png',
-              shareVaccine,
-              i18n.t('share-log-vaccine'),
-              events.LOG_YOUR_VACCINE_SHARED,
-              'Dashboard'
-            )
-          }
-        />
+        <ShareVaccineCard screenName="DashboardUS" />
 
         {showDietStudyPlayback && (
           <TouchableWithoutFeedback


### PR DESCRIPTION
# Description

Uses the "overlay share screen" to share vaccine banner as the expo share didn;t work on device. We know this one does, so have added some options to reuse minus the wrap/label.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/3264113/107411486-7c0af200-6b06-11eb-9ad9-19768fc6be1e.png)

> share
![image](https://user-images.githubusercontent.com/3264113/107411514-85945a00-6b06-11eb-86cd-5cf9ee6ac1c6.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
