### PR TITLE
Filter the universities on the backend

### DIFF
--- a/src/core/schools/SchoolService.ts
+++ b/src/core/schools/SchoolService.ts
@@ -13,7 +13,7 @@ import { naturalCompare } from '@covid/utils/array';
 
 export interface ISchoolService {
   getSubscribedSchoolGroups(): Promise<SubscribedSchoolGroupStats[]>;
-  getSchools(): Promise<SchoolModel[]>;
+  getUniversities(): Promise<SchoolModel[]>;
   getSchoolById(id: string, higherEducation?: boolean): Promise<SchoolModel[]>;
   searchSchoolGroups(schoolId: string): Promise<SchoolGroupModel[]>;
   joinGroup(groupId: string, patientId: string): Promise<SchoolGroupJoinedResponse>;
@@ -25,8 +25,8 @@ export class SchoolService implements ISchoolService {
   @inject(Services.Api)
   private readonly apiClient: IApiClient;
 
-  getSchools(): Promise<SchoolModel[]> {
-    return this.apiClient.get<SchoolModel[]>('/schools/');
+  getUniversities(): Promise<SchoolModel[]> {
+    return this.apiClient.get<SchoolModel[]>('/schools/', { higher_education: true });
   }
 
   getSchoolById(id: string, higherEducation: boolean = false): Promise<SchoolModel[]> {

--- a/src/features/school-network/JoinHigherEducationScreen.tsx
+++ b/src/features/school-network/JoinHigherEducationScreen.tsx
@@ -30,8 +30,8 @@ function JoinHigherEducationScreen({ navigation, route }: IProps) {
 
   useEffect(() => {
     (async () => {
-      const schools = await service.getSchools();
-      setSchools(schools.filter((s) => s.higher_education === true));
+      const schools = await service.getUniversities();
+      setSchools(schools);
     })();
   }, []);
 


### PR DESCRIPTION
The plain getSchools() API call is only used for the purposes of listing universities (of which we have very few).
In all other use cases we have additional filtering we can apply (select by school id or member_verify_code).

# Description

_Description of the feature or fix with link to the issue if existing_

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
