### PR TITLE
Adding Swedish translation for hesitancy "I do not know yet" option

### DIFF
--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -104,7 +104,7 @@
 
   "picker-yes": "Ja",
   "picker-no": "Nej",
-  "picker-do-not-know": "",
+  "picker-do-not-know": "Vet ej/osäker",
   "picker-unsure": "Osäker",
   "please-select-option": "Välj ett alternativ",
   "placeholder-optional-question": "*Valfritt",


### PR DESCRIPTION
# Description

Adds a missing translation key

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/3264113/107929095-16d55780-6f71-11eb-8eba-8b33dc4d45e7.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
