### PR TITLE
Other free text fields for mental health

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1451,7 +1451,8 @@
     "answer-no": "No",
     "answer-other": "Other",
     "share": "Share this app",
-    "share-message": "Mental health share message"
+    "share-message": "Mental health share message",
+    "specify-other": "Please specify"
   },
   "navigation": {
     "next": "Next",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1456,7 +1456,8 @@
     "answer-no": "No",
     "answer-other": "Other",
     "share": "Share this app",
-    "share-message": "Mental health share message"
+    "share-message": "Mental health share message",
+    "specify-other": "Please specify"
   },
   "navigation": {
     "next": "Siguiente",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1368,7 +1368,7 @@
     "notified": "Utvecklingsteamet har meddelats och förhoppningsvis bör problemet åtgärdas så fort! Försök att starta om appen för att fortsätta."
   },
 
- "mental-health": {
+  "mental-health": {
     "doctor-name": "Dr Ellen Jo Thompson",
     "doctor-title": "Mental Health Researcher",
     "doctor-college": "King’s College London",
@@ -1449,7 +1449,8 @@
     "answer-no": "No",
     "answer-other": "Other",
     "share": "Share this app",
-    "share-message": "Mental health share message"
+    "share-message": "Mental health share message",
+    "specify-other": "Please specify"
   },
   "navigation": {
     "next": "Nästa",

--- a/src/core/state/mental-health/history/slice/index.ts
+++ b/src/core/state/mental-health/history/slice/index.ts
@@ -29,9 +29,20 @@ const mentalHealthHistorySlice = createSlice({
         hasDiagnosis: action.payload,
       };
     },
+    setHistoryOtherText: (state, action: PayloadAction<string>) => {
+      return {
+        ...state,
+        otherText: action.payload,
+      };
+    },
   },
 });
 
-export const { addHistoryCondition, removeHistoryCondition, setHasHistoryDiagnosis } = mentalHealthHistorySlice.actions;
+export const {
+  addHistoryCondition,
+  removeHistoryCondition,
+  setHasHistoryDiagnosis,
+  setHistoryOtherText,
+} = mentalHealthHistorySlice.actions;
 export const selectMentalHealthHistory = (state: RootState) => state.mentalHealthHistory;
 export default mentalHealthHistorySlice.reducer;

--- a/src/core/state/mental-health/history/types/index.ts
+++ b/src/core/state/mental-health/history/types/index.ts
@@ -23,4 +23,5 @@ export type THasDiagnosis = 'YES' | 'NO' | 'DECLINE_TO_SAY' | undefined;
 export interface IMentalHealthHistory {
   hasDiagnosis: THasDiagnosis;
   conditions: TMentalHealthCondition[];
+  otherText?: string;
 }

--- a/src/core/state/mental-health/learning/slice/index.ts
+++ b/src/core/state/mental-health/learning/slice/index.ts
@@ -29,6 +29,12 @@ const mentalHealthLearningSlice = createSlice({
         hasDisability: action.payload,
       };
     },
+    setLearningOtherText: (state, action: PayloadAction<string>) => {
+      return {
+        ...state,
+        otherText: action.payload,
+      };
+    },
   },
 });
 
@@ -36,6 +42,7 @@ export const {
   addLearningCondition,
   removeLearningCondition,
   setHasLearningDisability,
+  setLearningOtherText,
 } = mentalHealthLearningSlice.actions;
 export const selectMentalHealthLearning = (state: RootState) => state.mentalHealthLearning;
 export default mentalHealthLearningSlice.reducer;

--- a/src/core/state/mental-health/learning/types/index.ts
+++ b/src/core/state/mental-health/learning/types/index.ts
@@ -13,4 +13,5 @@ export type THasDisability = 'YES' | 'NO' | 'DECLINE_TO_SAY' | undefined;
 export interface IMentalHealthLearning {
   hasDisability: THasDisability;
   conditions: TMentalHealthLearning[];
+  otherText?: string;
 }

--- a/src/features/mental-health/MentalHealthApiClient.ts
+++ b/src/features/mental-health/MentalHealthApiClient.ts
@@ -110,6 +110,7 @@ export class MentalHealthApiClient implements IMentalHealthApiClient {
         substance_use: data.mentalHealthHistory.conditions.includes('SUBSTANCE_USE_DISORDER'),
         psychosis_or_psychotic_illness: data.mentalHealthHistory.conditions.includes('TYPE_OF_PSYCHOSIS'),
         history_other: data.mentalHealthHistory.conditions.includes('OTHER'),
+        history_other_text: data.mentalHealthHistory.otherText,
         history_prefer_not_to_say: data.mentalHealthHistory.conditions.includes('DECLINE_TO_SAY'),
       };
     }
@@ -125,6 +126,7 @@ export class MentalHealthApiClient implements IMentalHealthApiClient {
         oral: data.mentalHealthLearning.conditions.includes('ORAL_WRITTEN'),
         sensory_impairment: data.mentalHealthLearning.conditions.includes('SENSORY'),
         learning_other: data.mentalHealthLearning.conditions.includes('OTHER'),
+        learning_other_text: data.mentalHealthLearning.otherText,
         learning_prefer_not_to_say: data.mentalHealthLearning.conditions.includes('DECLINE_TO_SAY'),
       };
     }

--- a/src/features/mental-health/MentalHealthInfosRequest.ts
+++ b/src/features/mental-health/MentalHealthInfosRequest.ts
@@ -47,6 +47,7 @@ export type MentalHealthInfosRequest = {
   substance_use?: boolean;
   psychosis_or_psychotic_illness?: boolean;
   history_other?: boolean;
+  history_other_text?: string;
   history_prefer_not_to_say?: boolean;
 
   // Section 4
@@ -62,5 +63,6 @@ export type MentalHealthInfosRequest = {
   oral?: boolean;
   sensory_impairment?: boolean;
   learning_other?: boolean;
+  learning_other_text?: string;
   learning_prefer_not_to_say?: boolean;
 };

--- a/src/features/mental-health/data/history.ts
+++ b/src/features/mental-health/data/history.ts
@@ -83,11 +83,11 @@ export const questions: TQuestion[] = [
     value: 'TYPE_OF_PSYCHOSIS',
   },
   {
-    key: i18n.t('mental-health.answer-other'),
-    value: 'OTHER',
-  },
-  {
     key: i18n.t('mental-health.answer-prefer-not-to-say'),
     value: 'DECLINE_TO_SAY',
+  },
+  {
+    key: i18n.t('mental-health.answer-other'),
+    value: 'OTHER',
   },
 ];

--- a/src/features/mental-health/data/learning.ts
+++ b/src/features/mental-health/data/learning.ts
@@ -43,11 +43,11 @@ export const learningQuestions: TLearningQuestion[] = [
     value: 'SENSORY',
   },
   {
-    key: i18n.t('mental-health.answer-other'),
-    value: 'OTHER',
-  },
-  {
     key: i18n.t('mental-health.answer-prefer-not-to-say'),
     value: 'DECLINE_TO_SAY',
+  },
+  {
+    key: i18n.t('mental-health.answer-other'),
+    value: 'OTHER',
   },
 ];

--- a/src/features/mental-health/screens/MentalHealthHistory.tsx
+++ b/src/features/mental-health/screens/MentalHealthHistory.tsx
@@ -12,9 +12,11 @@ import {
   setHasHistoryDiagnosis,
   TMentalHealthCondition,
   THasDiagnosis,
+  setHistoryOtherText,
 } from '@covid/core/state/mental-health';
 import { mentalHealthApiClient } from '@covid/Services';
 import i18n from '@covid/locale/i18n';
+import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 
 import { TQuestion, questions, initialOptions } from '../data';
 import { MentalHealthInfosRequest } from '../MentalHealthInfosRequest';
@@ -86,6 +88,16 @@ function MentalHealthHistory() {
     next();
   };
 
+  const renderOtherTextInput = MentalHealthHistory.conditions.includes('OTHER') ? (
+    <ValidatedTextInput
+      placeholder={i18n.t('mental-health.specify-other')}
+      value={MentalHealthHistory.otherText}
+      onChangeText={(text: string) => {
+        dispatch(setHistoryOtherText(text));
+      }}
+    />
+  ) : null;
+
   return (
     <BasicPage active={canSubmit} footerTitle={i18n.t('navigation.next')} onPress={saveStateAndNavigate}>
       <View style={{ paddingHorizontal: grid.gutter }}>
@@ -101,12 +113,15 @@ function MentalHealthHistory() {
           />
         </View>
         {MentalHealthHistory.hasDiagnosis === 'YES' && (
-          <GenericSelectableList
-            collection={questions}
-            onPress={(data) => handleAddRemoveCondition(data.value)}
-            renderRow={(data) => renderRow(data)}
-            style={{ paddingBottom: grid.s, paddingTop: grid.s }}
-          />
+          <>
+            <GenericSelectableList
+              collection={questions}
+              onPress={(data) => handleAddRemoveCondition(data.value)}
+              renderRow={(data) => renderRow(data)}
+              style={{ paddingBottom: grid.s, paddingTop: grid.s }}
+            />
+            {renderOtherTextInput}
+          </>
         )}
       </View>
     </BasicPage>

--- a/src/features/mental-health/screens/MentalHealthLearning.tsx
+++ b/src/features/mental-health/screens/MentalHealthLearning.tsx
@@ -9,12 +9,14 @@ import {
   addLearningCondition,
   removeLearningCondition,
   setHasLearningDisability,
+  setLearningOtherText,
   selectMentalHealthLearning,
   THasDisability,
   TMentalHealthLearning,
 } from '@covid/core/state/mental-health';
 import { mentalHealthApiClient } from '@covid/Services';
 import i18n from '@covid/locale/i18n';
+import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 
 import { TLearningQuestion, learningQuestions, learningInitialOptions } from '../data';
 import { MentalHealthInfosRequest } from '../MentalHealthInfosRequest';
@@ -78,6 +80,16 @@ function MentalHealthLearning() {
     NavigatorService.navigate('MentalHealthEnd', undefined);
   };
 
+  const renderOtherTextInput = MentalHealthLearning.conditions.includes('OTHER') ? (
+    <ValidatedTextInput
+      placeholder={i18n.t('mental-health.specify-other')}
+      value={MentalHealthLearning.otherText}
+      onChangeText={(text: string) => {
+        dispatch(setLearningOtherText(text));
+      }}
+    />
+  ) : null;
+
   return (
     <BasicPage active={canSubmit} footerTitle={i18n.t('navigation.next')} onPress={saveStateAndNavigate}>
       <View style={{ paddingHorizontal: grid.gutter }}>
@@ -93,12 +105,15 @@ function MentalHealthLearning() {
           />
         </View>
         {MentalHealthLearning.hasDisability === 'YES' && (
-          <GenericSelectableList
-            collection={learningQuestions}
-            onPress={(data) => handleAddRemoveCondition(data.value)}
-            renderRow={(data) => renderRow(data)}
-            style={{ paddingBottom: grid.s, paddingTop: grid.s }}
-          />
+          <>
+            <GenericSelectableList
+              collection={learningQuestions}
+              onPress={(data) => handleAddRemoveCondition(data.value)}
+              renderRow={(data) => renderRow(data)}
+              style={{ paddingBottom: grid.s, paddingTop: grid.s }}
+            />
+            {renderOtherTextInput}
+          </>
         )}
       </View>
     </BasicPage>


### PR DESCRIPTION
# Description

Adding free text field for mental health history and learning screens.

requires field from BE PR https://github.com/zoe/covid-app/pull/409 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots
Other not ticked (no text box):
![image](https://user-images.githubusercontent.com/3264113/108513407-79548d80-72ba-11eb-9402-63330f255e69.png)

Placeholder EG:
![image](https://user-images.githubusercontent.com/3264113/108513353-6477fa00-72ba-11eb-83e8-eb5e07853fb7.png)

Active inputs for both:
![image](https://user-images.githubusercontent.com/3264113/108513250-385c7900-72ba-11eb-81d1-1283d7a7a62b.png)
![image](https://user-images.githubusercontent.com/3264113/108513301-4ca07600-72ba-11eb-8ae3-edac587feffc.png)

BE admin showing saved data:
![image](https://user-images.githubusercontent.com/3264113/108513315-5629de00-72ba-11eb-9e11-fd5100ccaf6e.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
