### PR TITLE
Vaccine edit modal fix

### DIFF
--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -3,6 +3,7 @@ import { AssessmentData } from '@covid/core/assessment/AssessmentCoordinator';
 import { PatientStateType } from '@covid/core/patient/PatientState';
 import { PatientData } from '@covid/core/patient/PatientData';
 import { SchoolModel, SubscribedSchoolStats } from '@covid/core/schools/Schools.dto';
+import { VaccineRequest } from '@covid/core/vaccine/dto/VaccineRequest';
 
 export enum ConsentType {
   Adult = 'adult',
@@ -128,7 +129,7 @@ export type ScreenParamList = {
   Modal: undefined;
   Main: undefined;
   Share: undefined;
-  VaccineListMissing: { assessmentData: AssessmentData };
+  VaccineListMissing: { vaccine: VaccineRequest };
 
   // __HYGEN_INJECT_SCREEN_PARAMS_BELOW__
   Trendline: { lad?: string };

--- a/src/features/vaccines/VaccineListMissingModal.tsx
+++ b/src/features/vaccines/VaccineListMissingModal.tsx
@@ -12,14 +12,13 @@ import assessmentCoordinator, { AssessmentData } from '@covid/core/assessment/As
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'VaccineList'>;
   route: RouteProp<ScreenParamList, 'VaccineList'>;
-  assessmentData: AssessmentData;
 };
 
-export const VaccineListMissingModal: React.FC<Props> = ({ navigation, route, assessmentData }) => {
+export const VaccineListMissingModal: React.FC<Props> = ({ route }) => {
   const coordinator = assessmentCoordinator;
 
   const close = () => {
-    coordinator.goToAddEditVaccine(route.params.assessmentData.vaccineData);
+    coordinator.goToAddEditVaccine(route.params.vaccine);
   };
 
   return (

--- a/src/features/vaccines/VaccineListScreen.tsx
+++ b/src/features/vaccines/VaccineListScreen.tsx
@@ -138,7 +138,7 @@ export const VaccineListScreen: React.FC<Props> = ({ route, navigation }) => {
     }
   };
   const showPopup = () => {
-    NavigatorService.navigate('VaccineListMissing', { assessmentData: route.params.assessmentData });
+    NavigatorService.navigate('VaccineListMissing', { vaccine: vaccines[0] });
   };
 
   const navigateToNextPageOrShowPopup = () => {


### PR DESCRIPTION
# Description

Passes vaccine and not patient data to edit vaccine from via modal.

note - showPopup is called when vaccine exists but has errors, so doesn't need an ? check on it there.

**HOW TO TEST:**

on local / staging, create a valid vaccine. 
Access the valid vaccine in the Django Admin: http://127.0.0.1:8000/admin/vaccines/dose/ 
Set the date and/or name to empty & save
On the app, go back and return to the vaccine list page (to reload state)
Tap the next button at the bottom: modal should appear
Modal should link to your [first] vaccine, in edit mode


## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
