### PR TITLE
add missing icon, delay pop up, remove start screen

### DIFF
--- a/src/components/icons/Icon/selection.json
+++ b/src/components/icons/Icon/selection.json
@@ -49,6 +49,28 @@
     },
     {
       "icon": {
+        "paths": ["M170 640v-86h684v86h-684zM854 384v86h-684v-86h684z"],
+        "attrs": [],
+        "isMulticolor": false,
+        "isMulticolor2": false,
+        "tags": ["drag_handle"],
+        "grid": 24
+      },
+      "attrs": [],
+      "properties": {
+        "ligatures": "drag_handle",
+        "id": 302,
+        "order": 526,
+        "prevSize": 24,
+        "code": 59912,
+        "name": "drag_handle"
+      },
+      "setIdx": 0,
+      "setId": 3,
+      "iconIdx": 302
+    },
+    {
+      "icon": {
         "paths": ["M498 166l-346 346 346 346-76 76-422-422 422-422z"],
         "attrs": [],
         "isMulticolor": false,

--- a/src/components/icons/types/index.ts
+++ b/src/components/icons/types/index.ts
@@ -83,6 +83,7 @@ export type TIconName =
   | 'dinner-low'
   | 'dna'
   | 'docs'
+  | 'drag_handle'
   | 'edit-left-sharp'
   | 'edit-left'
   | 'edit-right-sharp'

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -328,7 +328,7 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
   }
 
   goToMentalHealthStudy() {
-    NavigatorService.navigate('MentalHealthStart');
+    NavigatorService.navigate('MentalHealthChanges');
   }
   goToMentalHealthModal() {
     NavigatorService.navigate('MentalHealthModal');

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -98,13 +98,21 @@ export const DashboardScreen: React.FC<Props> = ({ navigation, route }) => {
   }, [navigation]);
 
   useEffect(() => {
+    let isMounted = true;
     if (!app.dashboardHasBeenViewed) {
       if (showDietStudyPlayback) {
         track(events.DIET_STUDY_PLAYBACK_DISPLAYED);
       }
       dispatch(setDashboardHasBeenViewed(true));
-      showMentalHealthModal();
+      setTimeout(() => {
+        if (isMounted) {
+          showMentalHealthModal();
+        }
+      }, 800);
     }
+    return function () {
+      isMounted = false;
+    };
   }, []);
 
   const hasNetworkData = networks && networks.length > 0;

--- a/src/features/mental-health/partials/questions/changes-question.tsx
+++ b/src/features/mental-health/partials/questions/changes-question.tsx
@@ -36,7 +36,7 @@ function ChangesQuestion({ disabled = false, onPress, question, state }: IProps)
       keyValue: { key: i18n.t('mental-health.answer-less'), value: 'LESS' },
     },
     {
-      iconName: 'equal-2',
+      iconName: 'drag_handle',
       keyValue: { key: i18n.t('mental-health.answer-no-change'), value: 'NO_CHANGE' },
     },
     {


### PR DESCRIPTION
# Description

* change equals icon
* add missing icon
* remove start screen
* add delay of 800ms to pop up

NOTE icon font has been updated at https://github.com/zoe/covid-symptoms-study-assets, you will need to pull these to test locally

## On what platform have you tested the change?

- [x] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

<img width="395" alt="image" src="https://user-images.githubusercontent.com/795789/108502196-53bf8800-72aa-11eb-9d5e-3c0bd258e4b1.png">


_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
