### PR TITLE
Fix to mental health routing

### DIFF
--- a/src/features/mental-health/screens/MentalHealthHistory.tsx
+++ b/src/features/mental-health/screens/MentalHealthHistory.tsx
@@ -63,10 +63,6 @@ function MentalHealthHistory() {
   };
 
   const next = () => {
-    if (MentalHealthHistory.hasDiagnosis === 'NO' || MentalHealthHistory.hasDiagnosis === 'DECLINE_TO_SAY') {
-      NavigatorService.navigate('MentalHealthLearning', undefined);
-      return;
-    }
     NavigatorService.navigate('MentalHealthSupport', undefined);
   };
 


### PR DESCRIPTION
This corrects (and simplifies) the screen routing, to always navigate to `MentalHealthSupport`

## Logic before:

From `MentalHealthHistory` the next screen has conditional logic:
 if Yes -> Next Screen is `MentalHealthSupport` followed by `MentalHealthLearning`
 if no / prefer not to stay -> `MentalHealthLearning` (skipping MentalHealthSupport)

## Logic now:

`MentalHealthHistory` -> `MentalHealthSupport` -> `MentalHealthLearning`


---
There's been some lost in translation from spec -> figma -> code. 
Something to discuss in the retro!!
