### PR TITLE
Fix/mental health frequency buttons

### DIFF
--- a/src/features/mental-health/partials/questions/frequency-question.tsx
+++ b/src/features/mental-health/partials/questions/frequency-question.tsx
@@ -22,7 +22,7 @@ type TAnswer = {
   keyValue: TKeyValue;
 };
 
-function FrequencyQuestion({ disabled = false, onPress, question, state }: IProps) {
+function FrequencyQuestion({ disabled = true, onPress, question, state }: IProps) {
   const { grid } = useTheme();
   const fadeAnim = useFade(0.2, disabled ? 0.2 : 1, 500);
 
@@ -61,6 +61,7 @@ function FrequencyQuestion({ disabled = false, onPress, question, state }: IProp
             <View key={key} style={{ flex: 1, marginRight: index < answers.length - 1 ? 8 : 0 }}>
               <QuestionBlock
                 active={state === answer.keyValue.value}
+                disabled={disabled}
                 keyValue={answer.keyValue}
                 onPress={() => handleOnPress(answer.keyValue.value)}
               />
@@ -72,6 +73,7 @@ function FrequencyQuestion({ disabled = false, onPress, question, state }: IProp
         <QuestionBlock
           active={state === decline.keyValue.value}
           backgroundColor="transparent"
+          disabled={disabled}
           keyValue={decline.keyValue}
           onPress={() => handleOnPress(decline.keyValue.value)}
         />


### PR DESCRIPTION
# Description

add missing 'disabled' property. This prevent the button from being tapped.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
