### PR TITLE
Upgrade and reinstate tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@storybook/addon-ondevice-actions": "5.3.19",
     "@storybook/react-native": "5.3.19",
     "@storybook/react-native-server": "5.3.19",
-    "@testing-library/react-native": "5.0.3",
+    "@testing-library/react-native": "7.2.0",
     "@types/body-parser": "1.19.0",
     "@types/express": "4.17.6",
     "@types/jest": "25.2.1",

--- a/src/components/BrandedButton/__tests__/BrandedButton.test.tsx
+++ b/src/components/BrandedButton/__tests__/BrandedButton.test.tsx
@@ -31,6 +31,7 @@ describe('BrandedButton tests', () => {
     fireEvent.press(getByTestId('buttonTestID'));
     expect(onPress).toHaveBeenCalledTimes(0);
   });
+
   it('Handles style props being passed', () => {
     const onPress = jest.fn();
     const style = { background: 'red' };
@@ -41,25 +42,4 @@ describe('BrandedButton tests', () => {
     );
     expect(getByTestId('buttonTestID').props.style.background).toBe('red');
   });
-  // it('Shows loading if disabled', () => {
-  //   const onPress = jest.fn();
-  //   const { queryByTestId } = render(
-  //     <BrandedButton onPress={onPress} enable={false}>
-  //       This is a branded button
-  //     </BrandedButton>
-  //   );
-  //   const activityIndicator = queryByTestId('activityIndicator')
-  //   console.log('activityIndicator ',activityIndicator)
-  //   expect(activityIndicator).toBeTruthy();
-  // });
-  // it('Can hide loading when disabled', () => {
-  //   const onPress = jest.fn();
-  //   const { queryByTestId } = render(
-
-  //     <BrandedButton onPress={onPress} enable={false} hideLoading>
-  //       This is a branded button
-  //     </BrandedButton>
-  //   );
-  //   expect(queryByTestId('activityIndicator')).toBeNull();
-  // });
 });

--- a/src/components/BrandedButton/__tests__/BrandedButton.test.tsx
+++ b/src/components/BrandedButton/__tests__/BrandedButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { fireEvent, queryByTestId, render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 
 import { BrandedButton } from '..';
 
@@ -11,51 +11,55 @@ describe('BrandedButton tests', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  // it('Handles press events', () => {
-  //   const onPress = jest.fn();
-  //   const { getByTestId } = render(<BrandedButton onPress={onPress}>This is a branded button</BrandedButton>);
-  //   expect(onPress).toHaveBeenCalledTimes(0);
-  //   fireEvent.press(getByTestId('buttonTestID'));
-  //   expect(onPress).toHaveBeenCalledTimes(1);
-  // });
+  it('Handles press events', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(<BrandedButton onPress={onPress}>This is a branded button</BrandedButton>);
+    expect(onPress).toHaveBeenCalledTimes(0);
+    const button = getByTestId('buttonTestID');
+    fireEvent.press(button);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
 
-  // it('Does not fire press events when disabled', () => {
-  //   const onPress = jest.fn();
-  //   const { getByTestId } = render(
-  //     <BrandedButton onPress={onPress} enable={false}>
-  //       This is a branded button
-  //     </BrandedButton>
-  //   );
-  //   expect(onPress).toHaveBeenCalledTimes(0);
-  //   fireEvent.press(getByTestId('buttonTestID'));
-  //   expect(onPress).toHaveBeenCalledTimes(0);
-  // });
-  // it('Handles style props being passed', () => {
-  //   const onPress = jest.fn();
-  //   const style = { background: 'red' };
-  //   const { getByTestId } = render(
-  //     <BrandedButton style={style} onPress={onPress} enable={false}>
-  //       This is a branded button
-  //     </BrandedButton>
-  //   );
-  //   expect(getByTestId('buttonTestID').props.style.background).toBe('red');
-  // });
+  it('Does not fire press events when disabled', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <BrandedButton onPress={onPress} enable={false}>
+        This is a branded button
+      </BrandedButton>
+    );
+    expect(onPress).toHaveBeenCalledTimes(0);
+    fireEvent.press(getByTestId('buttonTestID'));
+    expect(onPress).toHaveBeenCalledTimes(0);
+  });
+  it('Handles style props being passed', () => {
+    const onPress = jest.fn();
+    const style = { background: 'red' };
+    const { getByTestId } = render(
+      <BrandedButton style={style} onPress={onPress} enable={false}>
+        This is a branded button
+      </BrandedButton>
+    );
+    expect(getByTestId('buttonTestID').props.style.background).toBe('red');
+  });
   // it('Shows loading if disabled', () => {
   //   const onPress = jest.fn();
-  //   const { container } = render(
+  //   const { queryByTestId } = render(
   //     <BrandedButton onPress={onPress} enable={false}>
   //       This is a branded button
   //     </BrandedButton>
   //   );
-  //   expect(queryByTestId(container, 'activityIndicator')).toBeTruthy();
+  //   const activityIndicator = queryByTestId('activityIndicator')
+  //   console.log('activityIndicator ',activityIndicator)
+  //   expect(activityIndicator).toBeTruthy();
   // });
   // it('Can hide loading when disabled', () => {
   //   const onPress = jest.fn();
-  //   const { container } = render(
+  //   const { queryByTestId } = render(
+
   //     <BrandedButton onPress={onPress} enable={false} hideLoading>
   //       This is a branded button
   //     </BrandedButton>
   //   );
-  //   expect(queryByTestId(container, 'activityIndicator')).toBeNull();
+  //   expect(queryByTestId('activityIndicator')).toBeNull();
   // });
 });


### PR DESCRIPTION
# Description

Mucked around with fixing tests, then did a bit of research and upgraded packages. Reinstated several tests on BrandedButton & plan to write logic/test for "singleUse" - maybe not on Branded button though (would require some thought on state etc).

Getting this PR up for clarity between me/peters coincidental test fixing!

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/3264113/109795190-8bb1be00-7c0e-11eb-823f-3e84e8a73be2.png)


## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
