### PR TITLE
Fix incorrect patientData on DietScores v2 flow

### DIFF
--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -262,8 +262,13 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
     this.startDietStudyPlaybackFlow(this.patientData);
   }
 
-  goToDietStudy() {
-    dietStudyPlaybackCoordinator.init(this, this.patientData, this.contentService, this.dietScoreService);
+  async goToDietStudy() {
+    // Reset the current PatientData to the primary user.
+    // We can sometimes get here, if we start viewing DietScores after reporting from a secondary profile
+    if (this.patientData.patientState.isReportedByAnother) {
+      await this.setPatientToPrimary();
+    }
+    await dietStudyPlaybackCoordinator.init(this, this.patientData, this.contentService, this.dietScoreService);
     NavigatorService.navigate('DietStudy');
   }
 

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -264,11 +264,11 @@ export class AppCoordinator extends Coordinator implements SelectProfile, Editab
 
   async goToDietStudy() {
     // Reset the current PatientData to the primary user.
-    // We can sometimes get here, if we start viewing DietScores after reporting from a secondary profile
+    // We can get here if by viewing DietScores after reporting from a secondary profile
     if (this.patientData.patientState.isReportedByAnother) {
       await this.setPatientToPrimary();
     }
-    await dietStudyPlaybackCoordinator.init(this, this.patientData, this.contentService, this.dietScoreService);
+    dietStudyPlaybackCoordinator.init(this, this.patientData, this.contentService, this.dietScoreService);
     NavigatorService.navigate('DietStudy');
   }
 


### PR DESCRIPTION
If you navigate to the DietScores Feedback v2 (New Flow) after reporting for a secondary profile, it keeps the PatientData of the secondary profile (which of course has no scores). This causes an error / wrong scores to appear. 

This is a surgical fix to the v2 flow that was already applied to the v1 flow:
https://github.com/zoe/covid-tracker-react-native/commit/abb183a377bb5e87839dd1815bcbe6cbb02a7868

Sadly... DRY