### PR TITLE
Add Johnson Vaccine for US

### DIFF
--- a/src/core/vaccine/dto/VaccineRequest.ts
+++ b/src/core/vaccine/dto/VaccineRequest.ts
@@ -1,3 +1,5 @@
+import i18n from '@covid/locale/i18n';
+
 export type VaccineRequest = {
   id: string;
   version: string; // document/schema version
@@ -70,6 +72,14 @@ export enum VaccineBrands {
   JOHNSON = 'johnson',
   NOT_SURE = 'not_sure',
 }
+
+export const vaccineBrandDisplayName = {
+  [VaccineBrands.PFIZER]: 'Pfizer/BioNTech',
+  [VaccineBrands.ASTRAZENECA]: 'Oxford/Astrazeneca',
+  [VaccineBrands.MODERNA]: 'Moderna',
+  [VaccineBrands.JOHNSON]: 'Johnson and Johnson',
+  [VaccineBrands.NOT_SURE]: i18n.t('vaccines.your-vaccine.name-i-dont-know'),
+};
 
 export enum PlaceboStatus {
   YES = 'yes',

--- a/src/features/vaccines/AboutYourVaccineScreen.tsx
+++ b/src/features/vaccines/AboutYourVaccineScreen.tsx
@@ -12,7 +12,7 @@ import { BrandedButton, ClickableText, Header3Text, HeaderText, RegularText } fr
 import i18n from '@covid/locale/i18n';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
-import { Dose, VaccineRequest, VaccineTypes } from '@covid/core/vaccine/dto/VaccineRequest';
+import { Dose, VaccineBrands, VaccineRequest, VaccineTypes } from '@covid/core/vaccine/dto/VaccineRequest';
 import { ValidationError } from '@covid/components/ValidationError';
 import { VaccineDoseData, VaccineDoseQuestion } from '@covid/features/vaccines/fields/VaccineDoseQuestion';
 import { useInjection } from '@covid/provider/services.hooks';
@@ -41,6 +41,14 @@ export const AboutYourVaccineScreen: React.FC<Props> = ({ route, navigation }) =
   const { assessmentData } = route.params;
 
   function vaccineOrFormHasSecondDose() {
+    if (
+      assessmentData.vaccineData &&
+      assessmentData.vaccineData.doses[0] &&
+      assessmentData.vaccineData.brand === VaccineBrands.JOHNSON
+    ) {
+      return false;
+    }
+
     if (hasSecondDose !== undefined) {
       return hasSecondDose === 'yes';
     }
@@ -222,21 +230,26 @@ export const AboutYourVaccineScreen: React.FC<Props> = ({ route, navigation }) =
             <Form style={{ flex: 1 }}>
               <View style={{ marginHorizontal: 16, marginBottom: 32 }}>
                 {renderFirstDoseUI(props)}
-                <Header3Text style={{ marginTop: 16, marginBottom: 8 }}>
-                  {i18n.t('vaccines.your-vaccine.second-dose')}
-                </Header3Text>
-                <YesNoField
-                  selectedValue={vaccineOrFormHasSecondDose() ? 'yes' : 'no'}
-                  onValueChange={(value: string) => {
-                    props.values.hasSecondDose = value === 'yes';
-                    if (value === 'no') {
-                      props.values.secondDoseDate = undefined;
-                    }
-                    setHasSecondDose(value);
-                  }}
-                  label={i18n.t('vaccines.your-vaccine.have-had-second')}
-                />
-                {renderSecondDoseUI(props)}
+                {props.values.firstBrand && props.values.firstBrand !== VaccineBrands.JOHNSON && (
+                  <>
+                    <Header3Text style={{ marginTop: 48, marginBottom: 8 }}>
+                      {i18n.t('vaccines.your-vaccine.second-dose')}
+                    </Header3Text>
+
+                    <YesNoField
+                      selectedValue={vaccineOrFormHasSecondDose() ? 'yes' : 'no'}
+                      onValueChange={(value: string) => {
+                        props.values.hasSecondDose = value === 'yes';
+                        if (value === 'no') {
+                          props.values.secondDoseDate = undefined;
+                        }
+                        setHasSecondDose(value);
+                      }}
+                      label={i18n.t('vaccines.your-vaccine.have-had-second')}
+                    />
+                    {renderSecondDoseUI(props)}
+                  </>
+                )}
               </View>
               {!!Object.keys(props.errors).length && props.submitCount > 0 && (
                 <ValidationError style={{ marginBottom: 32 }} error={i18n.t('validation-error-text')} />

--- a/src/features/vaccines/AboutYourVaccineScreen.tsx
+++ b/src/features/vaccines/AboutYourVaccineScreen.tsx
@@ -40,12 +40,16 @@ export const AboutYourVaccineScreen: React.FC<Props> = ({ route, navigation }) =
   const [hasSecondDose, setHasSecondDose] = useState<string | undefined>(undefined);
   const { assessmentData } = route.params;
 
-  function vaccineOrFormHasSecondDose() {
-    if (
+  function isJohnsonVaccine() {
+    return (
       assessmentData.vaccineData &&
       assessmentData.vaccineData.doses[0] &&
       assessmentData.vaccineData.brand === VaccineBrands.JOHNSON
-    ) {
+    );
+  }
+
+  function vaccineOrFormHasSecondDose() {
+    if (isJohnsonVaccine()) {
       return false;
     }
 

--- a/src/features/vaccines/components/VaccineCard.tsx
+++ b/src/features/vaccines/components/VaccineCard.tsx
@@ -7,15 +7,8 @@ import { Header3Text, RegularText } from '@covid/components/Text';
 import { tick } from '@assets';
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
-import { Dose, VaccineBrands, VaccineRequest } from '@covid/core/vaccine/dto/VaccineRequest';
+import { vaccineBrandDisplayName, Dose, VaccineRequest, VaccineBrands } from '@covid/core/vaccine/dto/VaccineRequest';
 import QuestionCircle from '@assets/icons/QuestionCircle';
-
-export const displayBrandNameMap = {
-  [VaccineBrands.PFIZER]: 'Pfizer/BioNTech',
-  [VaccineBrands.MODERNA]: 'Moderna',
-  [VaccineBrands.ASTRAZENECA]: 'Oxford/Astrazeneca',
-  [VaccineBrands.NOT_SURE]: i18n.t('vaccines.your-vaccine.name-i-dont-know'),
-};
 
 export const displayDescriptionNameMap = {
   mrna: 'mRNA',
@@ -65,6 +58,7 @@ export const VaccineCard: React.FC<Props> = ({ vaccine, style, onPressEdit }) =>
   return (
     <TouchableWithoutFeedback onPress={() => onPressEdit(1)}>
       <View style={styles.container}>
+        {/* Dose 1 */}
         <View style={styles.dose}>
           <View style={styles.row}>
             {renderTick(hasFirstDoseDate, hasFirstDoseName)}
@@ -73,7 +67,7 @@ export const VaccineCard: React.FC<Props> = ({ vaccine, style, onPressEdit }) =>
           <RegularText style={[!hasFirstDoseName && styles.pendingText]}>
             {hasFirstDoseName
               ? hasFirstDoseBrand
-                ? displayBrandNameMap[dose1.brand]
+                ? vaccineBrandDisplayName[dose1.brand]
                 : displayDescriptionNameMap[dose1.description]
               : warningIconAndText('vaccines.vaccine-card.name-missing')}
           </RegularText>
@@ -89,29 +83,35 @@ export const VaccineCard: React.FC<Props> = ({ vaccine, style, onPressEdit }) =>
           )}
         </View>
 
-        <View style={styles.dose}>
-          <View style={styles.row}>
-            {renderTick(hasSecondDoseDate, hasSecondDoseName)}
-            <Header3Text>{i18n.t('vaccines.vaccine-card.dose-2')}</Header3Text>
-          </View>
-
-          {hasSecondDoseDate && (
-            <View style={{ marginTop: 0, marginBottom: 8 }}>
-              <RegularText style={[!hasSecondDoseName && styles.pendingText]}>
-                {hasSecondDoseName
-                  ? hasSecondDoseBrand
-                    ? displayBrandNameMap[dose2.brand]
-                    : displayDescriptionNameMap[dose2.description]
-                  : warningIconAndText('vaccines.vaccine-card.name-missing')}
-              </RegularText>
+        {/* Dose 2 */}
+        {dose1.brand && dose1.brand === VaccineBrands.JOHNSON ? (
+          <></>
+        ) : (
+          <View style={styles.dose}>
+            <View style={styles.row}>
+              {renderTick(hasSecondDoseDate, hasSecondDoseName)}
+              <Header3Text>{i18n.t('vaccines.vaccine-card.dose-2')}</Header3Text>
             </View>
-          )}
 
-          <RegularText style={[!hasSecondDoseDate && styles.pendingText]}>
-            {hasSecondDoseDate ? formatVaccineDate(dose2 as Dose) : notYetLogged}
-          </RegularText>
-        </View>
+            {hasSecondDoseDate && (
+              <View style={{ marginTop: 0, marginBottom: 8 }}>
+                <RegularText style={[!hasSecondDoseName && styles.pendingText]}>
+                  {hasSecondDoseName
+                    ? hasSecondDoseBrand
+                      ? vaccineBrandDisplayName[dose2.brand]
+                      : displayDescriptionNameMap[dose2.description]
+                    : warningIconAndText('vaccines.vaccine-card.name-missing')}
+                </RegularText>
+              </View>
+            )}
 
+            <RegularText style={[!hasSecondDoseDate && styles.pendingText]}>
+              {hasSecondDoseDate ? formatVaccineDate(dose2 as Dose) : notYetLogged}
+            </RegularText>
+          </View>
+        )}
+
+        {/* CTA */}
         <Text style={{ marginTop: 8, marginBottom: 8, textAlign: 'center' }}>
           <Text style={styles.clickableText}>{i18n.t('vaccines.vaccine-card.edit-vaccine')}</Text>
         </Text>

--- a/src/features/vaccines/fields/VaccineNameQuestion.tsx
+++ b/src/features/vaccines/fields/VaccineNameQuestion.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { View } from 'native-base';
 
 import i18n from '@covid/locale/i18n';
-import { VaccineBrands, VaccineRequest } from '@covid/core/vaccine/dto/VaccineRequest';
+import { vaccineBrandDisplayName, VaccineBrands, VaccineRequest } from '@covid/core/vaccine/dto/VaccineRequest';
 import DropdownField from '@covid/components/DropdownField';
 import { isGBCountry, isSECountry } from '@covid/core/localisation/LocalisationService';
 
@@ -19,18 +19,31 @@ export interface VaccineNameQuestion<P, Data> extends React.FC<P> {
 }
 
 export const VaccineNameQuestion: VaccineNameQuestion<Props, VaccineDoseData> = (props: Props) => {
-  const nameOptions = [
+  const gbVaccineOptions = [
     { label: i18n.t('choose-one-of-these-options'), value: '' },
-    // These are "Brand names" so don't need translations
-    { label: 'Pfizer/BioNTech', value: VaccineBrands.PFIZER },
-    { label: 'Moderna', value: VaccineBrands.MODERNA },
+    { label: vaccineBrandDisplayName[VaccineBrands.PFIZER], value: VaccineBrands.PFIZER },
+    { label: vaccineBrandDisplayName[VaccineBrands.ASTRAZENECA], value: VaccineBrands.ASTRAZENECA },
+    { label: vaccineBrandDisplayName[VaccineBrands.MODERNA], value: VaccineBrands.MODERNA },
     { label: i18n.t('vaccines.your-vaccine.name-i-dont-know'), value: VaccineBrands.NOT_SURE },
   ];
 
-  // Add in extra item specific to GB/Swedish users
-  if (isGBCountry() || isSECountry()) {
-    nameOptions.splice(2, 0, { label: 'Oxford/Astrazeneca', value: VaccineBrands.ASTRAZENECA });
-  }
+  const seVaccineOptions = [
+    { label: i18n.t('choose-one-of-these-options'), value: '' },
+    { label: vaccineBrandDisplayName[VaccineBrands.PFIZER], value: VaccineBrands.PFIZER },
+    { label: vaccineBrandDisplayName[VaccineBrands.ASTRAZENECA], value: VaccineBrands.ASTRAZENECA },
+    { label: vaccineBrandDisplayName[VaccineBrands.MODERNA], value: VaccineBrands.MODERNA },
+    { label: i18n.t('vaccines.your-vaccine.name-i-dont-know'), value: VaccineBrands.NOT_SURE },
+  ];
+
+  const usVaccineOptions = [
+    { label: i18n.t('choose-one-of-these-options'), value: '' },
+    { label: vaccineBrandDisplayName[VaccineBrands.PFIZER], value: VaccineBrands.PFIZER },
+    { label: vaccineBrandDisplayName[VaccineBrands.JOHNSON], value: VaccineBrands.JOHNSON },
+    { label: vaccineBrandDisplayName[VaccineBrands.MODERNA], value: VaccineBrands.MODERNA },
+    { label: i18n.t('vaccines.your-vaccine.name-i-dont-know'), value: VaccineBrands.NOT_SURE },
+  ];
+
+  const nameOptions = isGBCountry() ? gbVaccineOptions : isSECountry() ? seVaccineOptions : usVaccineOptions;
 
   const descriptionOptions = [
     { label: i18n.t('choose-one-of-these-options'), value: '' },


### PR DESCRIPTION
- This PR separates out the vaccines brand options between UK, SE and US instead of using splice for clarity
- Add's the J&J vaccine option for the US
- Hides the second dose on the Vaccine Card (List Display) and on the "AboutYourVaccine" screen (Create / Edit Vaccine)


This PR works with the fact that all the vaccine code was written with the assumption of 2 doses, rather than try to addrss that assumption.  When we get another vaccine with either 1 dose or 3 doses then we should refactor. For now and "if vaccine.brand == johnson" 