### PR TITLE
Set user signup date from profile for timeline modal

### DIFF
--- a/src/features/anniversary/screens/anniversary-modal.tsx
+++ b/src/features/anniversary/screens/anniversary-modal.tsx
@@ -1,17 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Image, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
+import moment from 'moment';
 
 import { SafeLayout, Text } from '@covid/components';
 import { timelineModalCard } from '@assets';
 import { setHasViewedAnniversaryModal } from '@covid/core/state';
+import { useInjection } from '@covid/provider/services.hooks';
+import { IPatientService } from '@covid/core/patient/PatientService';
+import { Services } from '@covid/provider/services.types';
+import { Profile } from '@covid/components/Collections/ProfileList';
 
 import appCoordinator from '../../AppCoordinator';
 
 function AnniversaryModal() {
   const { goBack } = useNavigation();
   const dispatch = useDispatch();
+  const patientService = useInjection<IPatientService>(Services.Patient);
+  const [signupDate, setSignupDate] = useState<string>('');
+
+  const updateSignupDate = async () => {
+    const profile: Profile | null = await patientService.myPatientProfile();
+
+    if (profile) {
+      setSignupDate(moment(profile.created_at).format('MMMM Do YYYY'));
+    }
+  };
+  useEffect(() => {
+    updateSignupDate();
+  });
 
   const handleViewTimeline = (view: boolean) => {
     dispatch(setHasViewedAnniversaryModal(true));
@@ -39,7 +57,7 @@ function AnniversaryModal() {
           <Text textClass="pLight" textAlign="center">
             Thank you for reporting with us since
           </Text>
-          <Text textAlign="center">[Dynamic date here]</Text>
+          <Text textAlign="center">{signupDate}</Text>
           <View style={{ marginBottom: 12 }}>
             <Image
               source={timelineModalCard}


### PR DESCRIPTION
# Description
Updates the timeline modal's date placeholder to use the date from the current user - assumed that this is the core user as it happens on app start

kind of confusing that the screenshot says feb... 3,2,1... design critique incoming ! :)
## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/3264113/112527267-c84e8080-8d9a-11eb-92e2-bda312a1a7a1.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevent
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

no