### PR TITLE
Remove Mental Health Study Entry Point

### DIFF
--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -97,30 +97,8 @@ export function DashboardScreen({ navigation, route }: IProps) {
       }
     }
     switch (settings.currentFeature) {
-      case 'MENTAL_HEALTH_STUDY':
-        showMentalHealthModal();
-        return;
       case 'UK_DIET_STUDY':
         showDietStudy();
-    }
-  };
-
-  const showMentalHealthModal = () => {
-    if (MentalHealthState.completed) {
-      return;
-    }
-    if (MentalHealthState.consent === 'LATER') {
-      // check time since
-      const previous = moment(MentalHealthState.lastPresentedDate);
-      const now = moment(new Date());
-      const diff = now.diff(previous, 'days');
-      if (diff >= 7) {
-        appCoordinator.goToMentalHealthModal();
-      }
-      return;
-    }
-    if (app.mentalHealthStudyActive && MentalHealthState.consent !== 'NO') {
-      appCoordinator.goToMentalHealthModal();
     }
   };
 

--- a/src/features/dashboard/DashboardUSScreen.tsx
+++ b/src/features/dashboard/DashboardUSScreen.tsx
@@ -3,7 +3,6 @@ import { Image, StyleSheet, TouchableWithoutFeedback, View } from 'react-native'
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { RouteProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import moment from 'moment';
 
 import { PoweredByZoeSmall } from '@covid/components/Logos/PoweredByZoe';
 import { CompactHeader, Header } from '@covid/features/dashboard/Header';
@@ -20,8 +19,7 @@ import { pushNotificationService } from '@covid/Services';
 import { PartnerLogoUSDash } from '@covid/components/Logos/PartnerLogo';
 import { RootState } from '@covid/core/state/root';
 import { StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
-import { selectMentalHealthState, setDashboardHasBeenViewed, selectApp } from '@covid/core/state';
-import AnalyticsService, { events, track } from '@covid/core/Analytics';
+import AnalyticsService, { events } from '@covid/core/Analytics';
 import { ShareVaccineCard } from '@covid/components/Cards/ShareVaccineCard';
 
 const HEADER_EXPANDED_HEIGHT = 328;
@@ -33,8 +31,6 @@ interface IProps {
 }
 
 export function DashboardUSScreen({ route, navigation }: IProps) {
-  const app = useSelector(selectApp);
-  const MentalHealthState = useSelector(selectMentalHealthState);
   const dispatch = useAppDispatch();
 
   const startupInfo = useSelector<RootState, StartupInfo | undefined>((state) => state.content.startupInfo);
@@ -54,25 +50,6 @@ export function DashboardUSScreen({ route, navigation }: IProps) {
     await share(shareMessage);
   };
 
-  const showMentalHealthModal = () => {
-    if (MentalHealthState.completed) {
-      return;
-    }
-    if (MentalHealthState.consent === 'LATER') {
-      // check time since
-      const previous = moment(MentalHealthState.lastPresentedDate);
-      const now = moment(new Date());
-      const diff = now.diff(previous, 'days');
-      if (diff >= 7) {
-        appCoordinator.goToMentalHealthModal();
-      }
-      return;
-    }
-    if (app.mentalHealthStudyActive && MentalHealthState.consent !== 'NO') {
-      appCoordinator.goToMentalHealthModal();
-    }
-  };
-
   useEffect(() => {
     (async () => {
       AnalyticsService.identify();
@@ -85,21 +62,6 @@ export function DashboardUSScreen({ route, navigation }: IProps) {
       dispatch(updateTodayDate());
     });
   }, [navigation]);
-
-  useEffect(() => {
-    let isMounted = true;
-    if (!app.dashboardHasBeenViewed) {
-      dispatch(setDashboardHasBeenViewed(true));
-      setTimeout(() => {
-        if (isMounted) {
-          showMentalHealthModal();
-        }
-      }, 800);
-    }
-    return function () {
-      isMounted = false;
-    };
-  }, []);
 
   return (
     <CollapsibleHeaderScrollView

--- a/src/features/diet-study-playback/v2/DietStudyModal.tsx
+++ b/src/features/diet-study-playback/v2/DietStudyModal.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, TouchableOpacity, View, ScrollView } from 'react-native';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 
 import { SafeLayout, Text } from '@covid/components';
-import { setCurrentFeature, setDietStudyConsent, setFeatureRunDate, TDietStudyConsent } from '@covid/core/state';
+import { setDietStudyConsent, TDietStudyConsent } from '@covid/core/state';
 import i18n from '@covid/locale/i18n';
 import { events, track } from '@covid/core/Analytics';
 import { getDietStudyDoctorImage } from '@covid/features/diet-study-playback/v2/utils';
@@ -18,10 +18,6 @@ function DietStudyModal() {
 
   const handleSetConsent = (consent: TDietStudyConsent) => {
     dispatch(setDietStudyConsent(consent));
-    const date = new Date();
-    date.setDate(date.getDate() + 1);
-    dispatch(setCurrentFeature('MENTAL_HEALTH_STUDY'));
-    dispatch(setFeatureRunDate(date.toString()));
     if (consent !== 'YES') {
       goBack();
       return;

--- a/src/features/thank-you/ThankYouUKScreen.tsx
+++ b/src/features/thank-you/ThankYouUKScreen.tsx
@@ -21,8 +21,6 @@ import { IConsentService } from '@covid/core/consent/ConsentService';
 import assessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 import { BigGreenTickFilled } from '@covid/components/BigGreenTick';
 import { BrandedButton, FeaturedContentList, FeaturedContentType } from '@covid/components';
-import store from '@covid/core/state/store';
-import { DietStudyCard } from '@covid/features';
 
 import { ImpactTimelineCard } from '../anniversary';
 import appCoordinator from '../AppCoordinator';
@@ -36,14 +34,12 @@ type State = {
   askForRating: boolean;
   inviteToStudy: boolean;
   shouldShowReminders: boolean;
-  showDietStudyPlayback: boolean;
 };
 
 const initialState = {
   askForRating: false,
   inviteToStudy: false,
   shouldShowReminders: false,
-  showDietStudyPlayback: false,
 };
 
 export default class ThankYouUKScreen extends Component<RenderProps, State> {
@@ -62,7 +58,6 @@ export default class ThankYouUKScreen extends Component<RenderProps, State> {
   }
 
   render() {
-    const { startupInfo } = store.getState().content;
     return (
       <>
         {this.state.askForRating && <AppRating />}
@@ -80,8 +75,6 @@ export default class ThankYouUKScreen extends Component<RenderProps, State> {
               <RegularText style={styles.signOff}>{i18n.t('thank-you-uk.sign-off')}</RegularText>
 
               <ImpactTimelineCard onPress={() => appCoordinator.goToAnniversary()} size="LARGE" />
-
-              {startupInfo?.show_diet_score && <DietStudyCard style={{ marginVertical: 12 }} />}
 
               <FeaturedContentList type={FeaturedContentType.ThankYou} screenName={this.props.route.name} />
 

--- a/src/features/thank-you/ThankYouUSScreen.tsx
+++ b/src/features/thank-you/ThankYouUSScreen.tsx
@@ -3,13 +3,13 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import I18n from 'i18n-js';
 import React, { Component } from 'react';
-import { ScrollView, StyleSheet, View, Text, Modal, TouchableOpacity, SafeAreaView } from 'react-native';
+import { Modal, SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
 import { AreaStatsResponse } from '@covid/core/user/dto/UserAPIContracts';
 import { IUserService } from '@covid/core/user/UserService';
-import { ClickableText, RegularBoldText, RegularText } from '@covid/components/Text';
+import { ClickableText, RegularText } from '@covid/components/Text';
 import BrandedSpinner from '@covid/components/Spinner';
 import { AppRating, shouldAskForRating } from '@covid/components/AppRating';
 import { lazyInject } from '@covid/provider/services';


### PR DESCRIPTION
This PR:

- Removes the Mental Health Study popup. This will effectively mean there is no other way to access the mental health study. We'll keep the code in here, as we might run this again in the future. 
- Removes the UK Diet Scores card from the UK Thank You page. You'll be able to get here via the Timeline Screen. 
