### PR TITLE
Change json format of timelines

### DIFF
--- a/src/features/anniversary/partials/timeline.tsx
+++ b/src/features/anniversary/partials/timeline.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import { useTheme } from '@covid/themes';
 import { Text } from '@covid/components';
 
-import { TTimelineEvent, TTimelineNode } from '../types';
+import { TTimelineEvent } from '../types';
 
 import StudyCard from './study-card';
 import TimelineNode from './timeline-node';
@@ -12,7 +12,7 @@ import FindingCard from './finding-card';
 import Highlight from './highlight';
 
 interface IProps {
-  timelineEvents: TTimelineNode[];
+  timelineEvents: TTimelineEvent[];
 }
 
 function Timeline({ timelineEvents }: IProps) {
@@ -43,7 +43,7 @@ function Timeline({ timelineEvents }: IProps) {
         <View style={styles.line} />
         {timelineEvents.map((timelineEvent, index) => {
           const key = `timeline-event-${index}`;
-          return <View key={key}>{getMappedTimelineEvent(timelineEvent.node)}</View>;
+          return <View key={key}>{getMappedTimelineEvent(timelineEvent)}</View>;
         })}
       </View>
     </>

--- a/src/features/anniversary/types/index.ts
+++ b/src/features/anniversary/types/index.ts
@@ -41,5 +41,5 @@ export type TTimelineNode = {
 
 export interface ITimeline {
   badges: TReportedEvent[];
-  items: TTimelineNode[];
+  items: TTimelineEvent[];
 }

--- a/src/features/anniversary/types/index.ts
+++ b/src/features/anniversary/types/index.ts
@@ -35,10 +35,6 @@ export type TTimelineEvent = {
   title: string | null;
 };
 
-export type TTimelineNode = {
-  node: TTimelineEvent;
-};
-
 export interface ITimeline {
   badges: TReportedEvent[];
   items: TTimelineEvent[];


### PR DESCRIPTION
The old timeline json format had an extra level of nesting that doesn't seem to serve any purpose. This nesting is no longer there in the new backend code.  

Old: 

```
 "items": [
       {
            node:  {
            "title": "SIGNED UP",
            "date": "2020-03-10",
            "event_type": "NODE",
            "sub_title": "You started reporting!",
            "summary": null,
            "route_name": null,
            "route_text": null,
            "external_link": null,
            "external_link_text": null,
            "ongoing": null,
            "progress": null,
            "your_contribution": null
        },
    },   
]


```


New: 

```
 "items": [
        {
            "title": "SIGNED UP",
            "date": "2020-03-10",
            "event_type": "NODE",
            "sub_title": "You started reporting!",
            "summary": null,
            "route_name": null,
            "route_text": null,
            "external_link": null,
            "external_link_text": null,
            "ongoing": null,
            "progress": null,
            "your_contribution": null
        },
]

```