### PR TITLE
Fix warning about missing units

### DIFF
--- a/src/components/messaging/banners/styles.ts
+++ b/src/components/messaging/banners/styles.ts
@@ -14,7 +14,7 @@ export const SContainerView = styled(Animated.View)<IContainerViewProps>`
     padding: ${props.top + props.theme.grid.xxl}px ${props.theme.grid.l}px ${props.theme.grid.l}px;
     position: absolute;
     top: 0;
-    width: ${props.width};
+    width: ${props.width}px;
   `}
 `;
 


### PR DESCRIPTION
Dimensions.get('window') returns 400 (number). This is passed into SContatinerView. Which uses it to set the width, but it needs units. 

```
function Banner({ active = true, message }: IProps) {
...
  const { width } = Dimensions.get('window');

...

    <SContainerView top={top} width={width} style={{ transform: [{ translateY: animateTo }] }}>
```