### PR TITLE
Fix Map Sharing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ references:
     branches:
       only:
         - develop
-        - selvach/fix_sharing
 
   feature_filter: &feature_filter
     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ references:
     branches:
       only:
         - develop
+        - selvach/fix_sharing
 
   feature_filter: &feature_filter
     branches:

--- a/src/components/Cards/EstimatedCasesMapCard.tsx
+++ b/src/components/Cards/EstimatedCasesMapCard.tsx
@@ -276,7 +276,7 @@ export function EstimatedCasesMapCard({ isSharing }: IProps) {
 
         <View style={styles.mapContainer}>
           {isSharing ? (
-            map()
+            <>{map()}</>
           ) : (
             <TouchableOpacity activeOpacity={0.6} onPress={onMapTapped}>
               {map()}

--- a/src/components/Screens/share/container.tsx
+++ b/src/components/Screens/share/container.tsx
@@ -36,7 +36,7 @@ function ShareContainer({ sharable = 'MAP' }: IProps) {
           </SShareContainerView>
         );
       case 'VACCINES':
-        return <ShareVaccineCard isSharing />;
+        return <ShareVaccineCard screenName="Share" isSharing />;
       default:
         return null;
     }


### PR DESCRIPTION
[1] This PR fixes the error you get on device only (it's fine in the simulator) when you try and share the Personalised map card. 

Here's the error:

![Screenshot_20210415-172446](https://user-images.githubusercontent.com/7824212/114904228-8a7bcf80-9e0f-11eb-8dea-8748f8d96759.png)

Here is it working:

![Screenshot 2021-04-15 at 17 25 26](https://user-images.githubusercontent.com/7824212/114904269-96679180-9e0f-11eb-8dab-cf53c1d1ea21.png)


[2] Also fixes a missing prop on the ShareVaccineCard
