### PR TITLE
Remove inconsistent shadows

### DIFF
--- a/src/features/diet-study-playback/v2/DietStudyCard.tsx
+++ b/src/features/diet-study-playback/v2/DietStudyCard.tsx
@@ -20,7 +20,7 @@ function DietStudyCard({ style }: IProps) {
 
   return (
     <TouchableOpacity onPress={handleOnPress}>
-      <View style={[styles.container, styles.shadow, style]}>
+      <View style={[styles.container, style]}>
         <View style={[styles.row, { marginBottom: 12 }]}>
           <View style={styles.column}>
             <QuoteMarks />


### PR DESCRIPTION
Removes inconsistent drop shadow on the DietScore card on the homepage. 

![shadows](https://user-images.githubusercontent.com/7824212/115359439-96241900-a1b6-11eb-91bb-4916d4fd602a.png)
