### PR TITLE
Set push tokens to refresh daily

### DIFF
--- a/src/core/push-notifications/PushNotificationService.test.ts
+++ b/src/core/push-notifications/PushNotificationService.test.ts
@@ -73,7 +73,7 @@ describe('PushNotificationService', () => {
     expect(service.tokenNeedsRefreshing(tokenFromThirtyDaysAgo)).toBeTruthy();
 
     // @ts-ignore
-    expect(service.tokenNeedsRefreshing(tokenFromFiveDaysAgo)).toBeFalsy();
+    expect(service.tokenNeedsRefreshing(tokenFromFiveDaysAgo)).toBeTruthy();
 
     // @ts-ignore
     expect(service.tokenNeedsRefreshing(tokenFromTheFuture)).toBeFalsy();

--- a/src/core/push-notifications/PushNotificationService.ts
+++ b/src/core/push-notifications/PushNotificationService.ts
@@ -1,7 +1,7 @@
 import { Platform, Linking } from 'react-native';
 import * as IntentLauncher from 'expo-intent-launcher';
 
-import { aWeekAgo, isDateBefore, now } from '@covid/utils/datetime';
+import { isDateBefore, now, yesterday } from '@covid/utils/datetime';
 
 import { IStorageService } from '../LocalStorageService';
 import { IApiClient } from '../api/ApiClient';
@@ -74,7 +74,7 @@ export default class PushNotificationService {
   }
 
   private tokenNeedsRefreshing(pushToken: PushToken) {
-    return isDateBefore(pushToken.lastUpdated, aWeekAgo());
+    return isDateBefore(pushToken.lastUpdated, yesterday());
   }
 
   async subscribeForPushNotifications() {

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -21,6 +21,10 @@ export const aWeekAgo = () => {
   return moment().subtract(7, 'days');
 };
 
+export const yesterday = () => {
+  return moment().subtract(1, 'days');
+};
+
 export const isDateBefore = (date: DateTypes, compDate: DateTypes): boolean => {
   return moment(date).isBefore(compDate);
 };


### PR DESCRIPTION
Start refreshing the pushing notifications on the server faster. Charlie suggests checking every time the app starts is no bad thing. 

Woo: Nice to have unit tests!