### PR TITLE
Fix Schema and bump app version

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="zoe_covid_study"/>
+        <data android:scheme="zoe-covid-study"/>
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "scheme": "zoe_covid_study",
+    "scheme": "zoe-covid-study",
     "name": "COVID Symptom Study",
     "slug": "covid-zoe",
     "owner": "julien.lavigne",

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "owner": "julien.lavigne",
     "privacy": "public",
     "platforms": ["ios", "android"],
-    "version": "2.4.0",
+    "version": "2.5.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/ios/Covid/Info.plist
+++ b/ios/Covid/Info.plist
@@ -26,10 +26,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>zoe_covid_study</string>
+			<string>zoe-covid-study</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>zoe_covid_study</string>
+				<string>zoe-covid-study</string>
 			</array>
 		</dict>
 	</array>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Covid",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "scripts": {
     "start": "react-native start",
     "start:reset": "react-native start --reset-cache",

--- a/src/CovidApp.tsx
+++ b/src/CovidApp.tsx
@@ -48,7 +48,7 @@ function CovidApp() {
         }}
         onStateChange={NavigatorService.handleStateChange}
         linking={{
-          prefixes: ['zoe_covid_study://', 'https://covid.joinzoe.com'],
+          prefixes: ['zoe-covid-study://', 'https://covid.joinzoe.com'],
         }}>
         <Stack.Navigator headerMode="none" mode="modal" initialRouteName="Main">
           <Stack.Screen name="Main" component={DrawNavigator} />


### PR DESCRIPTION
[1] Fixes the `scheme` attribute which cannot have hyphens
[2] Upgrade app store release from 2.4.0 -> 2.5.0

![Screenshot 2021-04-29 at 23 45 14](https://user-images.githubusercontent.com/7824212/116702976-a1025900-a9c1-11eb-9544-d44ea3dc673f.png)
