### PR TITLE
Set app store flag

### DIFF
--- a/ios/Covid/Info.plist
+++ b/ios/Covid/Info.plist
@@ -35,6 +35,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>4</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Set a flag so we are not prompted to upload and answer a compliance question every time we upload to the app store. 
https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption