### PR TITLE
Switch to using deep links

### DIFF
--- a/ios/Covid/Info.plist
+++ b/ios/Covid/Info.plist
@@ -37,6 +37,10 @@
 	<string>4</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>itms-apps</string>
+    </array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/src/core/VersionUpdateModal.tsx
+++ b/src/core/VersionUpdateModal.tsx
@@ -7,7 +7,7 @@ import { colors } from '@theme';
 import i18n from '@covid/locale/i18n';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
 import { HeaderText, Text, BrandedButton } from '@covid/components';
-import { getPlatformStoreLink } from '@covid/utils/platform';
+import { getPlatformStoreLinkDeep } from '@covid/utils/platform';
 import { openWebLink } from '@covid/utils/links';
 
 interface IProps {
@@ -17,7 +17,7 @@ interface IProps {
 
 export function VersionUpdateModal({ navigation, route }: IProps) {
   const goToAppStore = () => {
-    openWebLink(getPlatformStoreLink);
+    openWebLink(getPlatformStoreLinkDeep);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Switch to using deep links on the pop up that forces users to upgrade to the latest version. 

Inspired by this Stack Overflow:
https://stackoverflow.com/questions/62445835/how-to-open-directly-our-app-in-apple-store

