### PR TITLE
Add universal link permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,8 +33,8 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https"
-              android:host="*joinzoe.com"
-              android:pathPattern=".*" />
+              android:host="api.covidradar.com"
+              android:pathPattern="/launch/.*" />
       </intent-filter>
 
     </activity>

--- a/ios/Covid/covid-zoe.entitlements
+++ b/ios/Covid/covid-zoe.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:api.covidradar.org</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Following the instructions in here https://docs.expo.io/guides/linking/#universaldeep-links-without-a-custom-scheme to add Permissions for a universal link served from https://api.covidjoinzoe.com/launch/ to launch the app. 

