### PR TITLE
Long covid rollout strategy

### DIFF
--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -308,6 +308,7 @@ export type StartupInfo = {
   show_edit_location: boolean;
   show_trendline: boolean;
   show_timeline: boolean;
+  show_long_covid: boolean;
   show_diet_score: boolean;
   local_data: {
     map_url: string;

--- a/src/features/assessment/HowYouFeelScreen.tsx
+++ b/src/features/assessment/HowYouFeelScreen.tsx
@@ -19,6 +19,7 @@ import React, { useEffect, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 import { USStudyInvite } from './partials/USStudyInvite';
+import { StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
 
 type Props = {
   navigation: StackNavigationProp<ScreenParamList, 'HowYouFeel'>;
@@ -31,6 +32,9 @@ export const HowYouFeelScreen: React.FC<Props> = ({ route, navigation }) => {
   const [location, setLocation] = useState('');
   const currentProfileVaccines = useSelector<RootState, VaccineRequest[]>((state) => state.vaccines.vaccines);
   const isFocused = useIsFocused();
+
+  // Startup info is currently used to toggle long covid - this is per user account and not per profile
+  const startupInfo = useSelector<RootState, StartupInfo | undefined>((state) => state.content.startupInfo);
 
   useEffect(() => {
     const { patientInfo } = assessmentCoordinator.assessmentData.patientData;
@@ -52,7 +56,9 @@ export const HowYouFeelScreen: React.FC<Props> = ({ route, navigation }) => {
       return;
     }
     setIsSubmitting(true);
-    if (healthy && assessmentCoordinator.assessmentData.patientData.patientInfo?.should_ask_long_covid_questions) {
+    if (startupInfo.show_long_covid && healthy && 
+      assessmentCoordinator.assessmentData.patientData.patientInfo?.should_ask_long_covid_questions
+    ) {
       NavigatorService.navigate('LongCovidStart', { patientData: assessmentCoordinator.assessmentData.patientData });
       return;
     }


### PR DESCRIPTION
# Description

Rollout handling for long covid. This is done on a per-account (User) and not Profile, hence using StartupInfo on the HowYouFeelScreen

BR ticket: https://github.com/zoe/covid-app/pull/485

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevant
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
