### PR TITLE
Identify experiment cohort

### DIFF
--- a/src/core/Analytics.ts
+++ b/src/core/Analytics.ts
@@ -9,6 +9,7 @@ let isInitialized = false;
 type AdditionalUserProperties = {
   isTester?: boolean;
   Experiment_001?: string;
+  Experiment_mhip?: string;
 };
 
 const DietStudyEvents = {

--- a/src/core/content/ContentService.ts
+++ b/src/core/content/ContentService.ts
@@ -97,8 +97,7 @@ export default class ContentService implements IContentService {
   async getStartupInfo() {
     try {
       const info = await this.apiClient.getStartupInfo();
-      const appNeedsUpdating: boolean = await this.checkVersionOfAPIAndApp(info.min_supported_app_version);
-      info.app_requires_update = appNeedsUpdating;
+      info.app_requires_update = await this.checkVersionOfAPIAndApp(info.min_supported_app_version);
 
       LocalisationService.ipCountry = info.ip_country;
       await AsyncStorageService.setUserCount(info.users_count.toString());

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -167,7 +167,16 @@ export class AppCoordinator extends Coordinator implements ISelectProfile, IEdit
       this.goToVersionUpdateModal();
     }
 
-    // Track insights
+    // Setup Amplitude analytics
+    if (startupInfo?.mh_insight_cohort) {
+      // Identity Mental Health Insights experiment cohort
+      Analytics.identify({
+        Experiment_mhip: startupInfo.mh_insight_cohort,
+      });
+    } else {
+      Analytics.identify();
+    }
+
     if (this.shouldShowCountryPicker) {
       Analytics.track(events.MISMATCH_COUNTRY_CODE, { current_country_code: LocalisationService.userCountry });
     }

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -6,7 +6,7 @@ import { EstimatedCasesMapCard } from '@covid/components/cards/EstimatedCasesMap
 import { ShareVaccineCard } from '@covid/components/cards/ShareVaccineCard';
 import { ExternalCallout } from '@covid/components/ExternalCallout';
 import { PoweredByZoeSmall } from '@covid/components/logos/PoweredByZoe';
-import Analytics, { events, identify } from '@covid/core/Analytics';
+import Analytics, { events } from '@covid/core/Analytics';
 import { updateTodayDate } from '@covid/core/content/state/contentSlice';
 import { ISubscribedSchoolGroupStats } from '@covid/core/schools/Schools.dto';
 import { fetchSubscribedSchoolGroups } from '@covid/core/schools/Schools.slice';
@@ -108,9 +108,9 @@ export function DashboardScreen({ navigation, route }: IProps) {
     }
   };
 
+  // TODO: Can we move this into app initialisation?
   useEffect(() => {
     (async () => {
-      identify();
       await pushNotificationService.subscribeForPushNotifications();
     })();
   }, []);

--- a/src/features/dashboard/DashboardUSScreen.tsx
+++ b/src/features/dashboard/DashboardUSScreen.tsx
@@ -51,7 +51,6 @@ export function DashboardUSScreen({ route, navigation }: IProps) {
 
   useEffect(() => {
     (async () => {
-      AnalyticsService.identify();
       await pushNotificationService.subscribeForPushNotifications();
     })();
   }, []);

--- a/src/features/register/WelcomeRepeatScreen.tsx
+++ b/src/features/register/WelcomeRepeatScreen.tsx
@@ -6,7 +6,6 @@ import { LoadingModal } from '@covid/components/Loading';
 import { PartnerLogoSE, PartnerLogoUS } from '@covid/components/logos/PartnerLogo';
 import { PoweredByZoe } from '@covid/components/logos/PoweredByZoe';
 import { RegularText } from '@covid/components/Text';
-import AnalyticsService from '@covid/core/Analytics';
 import { ApiErrorState, initialErrorState } from '@covid/core/api/ApiServiceErrors';
 import { IConsentService } from '@covid/core/consent/ConsentService';
 import { IContentService } from '@covid/core/content/ContentService';
@@ -69,7 +68,6 @@ export class WelcomeRepeatScreen extends Component<PropsType, WelcomeRepeatScree
     const userCount = await this.contentService.getUserCount();
     const cleanUserCount = userCount ? cleanIntegerVal(userCount as string) : 0;
 
-    AnalyticsService.identify();
     await pushNotificationService.subscribeForPushNotifications();
 
     this.setState({


### PR DESCRIPTION
- Remove the Analytics.identify() call on each of the dashboards and move it into the app initialisation code. 
- Send the MHIP Cohort from startup_info to Amplitude 

## Screenshot of Amplitude

![Screenshot 2021-06-02 at 21 32 47](https://user-images.githubusercontent.com/7824212/120551528-0779fd00-c3ee-11eb-99e9-e6f3abf6ee01.png)
