### PR TITLE
Modal Events

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,19 +1,12 @@
 import { SafeLayout } from '@covid/components';
-import { generalApiClient } from '@covid/Services';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 
 interface IProps {
   children?: React.ReactNode;
-  event?: string;
 }
 
 export default function Modal(props: IProps) {
-  useEffect(() => {
-    if (props.event) {
-      generalApiClient.postUserEvent(props.event);
-    }
-  }, [props.event]);
   return (
     <SafeLayout>
       <ScrollView

--- a/src/core/VersionUpdateModal.tsx
+++ b/src/core/VersionUpdateModal.tsx
@@ -24,7 +24,7 @@ export default function VersionUpdateModal({ navigation }: IProps) {
   }, [navigation]);
 
   return (
-    <Modal event="view_version_update_modal-v1">
+    <Modal>
       <HeaderText style={styles.text}>{i18n.t('version-update.title')}</HeaderText>
       <Text style={styles.text}>{i18n.t('version-update.body')}</Text>
       <BrandedButton onPress={goToAppStore} style={styles.button}>

--- a/src/core/state/settings/slice/index.ts
+++ b/src/core/state/settings/slice/index.ts
@@ -1,11 +1,9 @@
 import ApiClient from '@covid/core/api/ApiClient';
 import { RootState } from '@covid/core/state/root';
-import { ISettings, TFeature } from '@covid/core/state/settings/types';
+import { ISettings } from '@covid/core/state/settings/types';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 const initialState: ISettings = {
-  currentFeature: 'TIMELINE',
-  featureRunDate: undefined,
   hasEmailSubscription: false,
 };
 
@@ -16,8 +14,7 @@ type TSubscriptionResponse = {
 };
 
 export const setEmailSubscription = createAsyncThunk('/users/email_preference/', async (preference: boolean) => {
-  const response = await apiClient.patch('/users/email_preference/', { nutrition_newsletter: preference });
-  return response;
+  return apiClient.patch('/users/email_preference/', { nutrition_newsletter: preference });
 });
 
 const settingsSlice = createSlice({
@@ -29,18 +26,6 @@ const settingsSlice = createSlice({
   initialState,
   name: 'Settings',
   reducers: {
-    setCurrentFeature: (state, action: PayloadAction<TFeature>) => {
-      return {
-        ...state,
-        currentFeature: action.payload,
-      };
-    },
-    setFeatureRunDate: (state, action: PayloadAction<string>) => {
-      return {
-        ...state,
-        featureRunDate: action.payload,
-      };
-    },
     setHasEmailSubscription: (state, action: PayloadAction<boolean>) => {
       return {
         ...state,
@@ -50,6 +35,6 @@ const settingsSlice = createSlice({
   },
 });
 
-export const { setCurrentFeature, setFeatureRunDate, setHasEmailSubscription } = settingsSlice.actions;
+export const { setHasEmailSubscription } = settingsSlice.actions;
 export const selectSettings = (state: RootState) => state.settings;
 export default settingsSlice.reducer;

--- a/src/core/state/settings/types/index.ts
+++ b/src/core/state/settings/types/index.ts
@@ -1,7 +1,3 @@
-export type TFeature = 'MENTAL_HEALTH_STUDY' | 'UK_DIET_STUDY' | 'TIMELINE';
-
 export interface ISettings {
-  currentFeature: TFeature | undefined;
-  featureRunDate: string | undefined;
   hasEmailSubscription: boolean;
 }

--- a/src/features/anniversary/screens/AnniversaryModal.tsx
+++ b/src/features/anniversary/screens/AnniversaryModal.tsx
@@ -42,7 +42,7 @@ export default function AnniversaryModal() {
   };
 
   return (
-    <Modal event="view_anniversary_modal-v1">
+    <Modal>
       <View style={{ alignItems: 'center' }}>
         <View style={styles.feature}>
           <Text style={{ color: 'white' }} textClass="pXSmall">

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -10,13 +10,7 @@ import Analytics, { events, identify } from '@covid/core/Analytics';
 import { updateTodayDate } from '@covid/core/content/state/contentSlice';
 import { ISubscribedSchoolGroupStats } from '@covid/core/schools/Schools.dto';
 import { fetchSubscribedSchoolGroups } from '@covid/core/schools/Schools.slice';
-import {
-  selectAnniversary,
-  selectApp,
-  selectDietStudy,
-  selectSettings,
-  setDashboardHasBeenViewed,
-} from '@covid/core/state';
+import { selectApp, setDashboardHasBeenViewed } from '@covid/core/state';
 import { RootState } from '@covid/core/state/root';
 import { useAppDispatch } from '@covid/core/state/store';
 import { StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
@@ -48,9 +42,6 @@ interface IProps {
 }
 
 export function DashboardScreen({ navigation, route }: IProps) {
-  const anniversary = useSelector(selectAnniversary);
-  const settings = useSelector(selectSettings);
-  const dietStudy = useSelector(selectDietStudy);
   const app = useSelector(selectApp);
   const dispatch = useAppDispatch();
   const networks = useSelector<RootState, ISubscribedSchoolGroupStats[]>((state) => state.school.joinedSchoolGroups);
@@ -83,28 +74,6 @@ export function DashboardScreen({ navigation, route }: IProps) {
   const runCurrentFeature = () => {
     if (startupInfo?.show_modal === 'mental-health-playback') {
       NavigatorService.navigate('MentalHealthPlaybackModal');
-      return;
-    }
-
-    // Enforce timeline if not yet viewed and is available.
-    if (startupInfo?.show_timeline && !anniversary.hasViewedModal) {
-      NavigatorService.navigate('AnniversaryModal');
-      return;
-    }
-
-    if (settings.featureRunDate) {
-      const now = new Date().getTime();
-      const featureRunDate = new Date(settings.featureRunDate).getTime();
-      if (featureRunDate > now) {
-        return;
-      }
-    }
-
-    if (settings.currentFeature === 'UK_DIET_STUDY') {
-      if (!startupInfo?.show_diet_score || dietStudy.consent === 'YES') {
-        return;
-      }
-      NavigatorService.navigate('DietStudyModal');
     }
   };
 

--- a/src/features/diet-study-playback/v2/DietStudyModal.tsx
+++ b/src/features/diet-study-playback/v2/DietStudyModal.tsx
@@ -32,7 +32,7 @@ export default function DietStudyModal() {
   });
 
   return (
-    <Modal event="view_diet_study_modal-v1">
+    <Modal>
       <Text fontFamily="SofiaProRegular" rhythm={20} textClass="h3">
         {i18n.t('diet-study.modal-title')}
       </Text>

--- a/src/features/mental-health-playback/MentalHealthPlaybackModal.tsx
+++ b/src/features/mental-health-playback/MentalHealthPlaybackModal.tsx
@@ -6,6 +6,7 @@ import { StartupInfo } from '@covid/core/user/dto/UserAPIContracts';
 import appCoordinator from '@covid/features/AppCoordinator';
 import { getMentalHealthStudyDoctorImage } from '@covid/features/diet-study-playback/v2/utils';
 import i18n from '@covid/locale/i18n';
+import { generalApiClient } from '@covid/Services';
 import { colors, styling } from '@covid/themes';
 import { useNavigation } from '@react-navigation/native';
 import React, { useEffect, useState } from 'react';
@@ -24,8 +25,18 @@ export default function MentalHealthPlaybackModal() {
     }
   });
 
+  function handlePositive() {
+    generalApiClient.postUserEvent('view-mental-health-insights');
+    appCoordinator.goToMentalHealthStudyPlayback(startupInfo);
+  }
+
+  function handleNegative() {
+    generalApiClient.postUserEvent('skip-mental-health-insights');
+    goBack();
+  }
+
   return (
-    <Modal event="view_mental_health_playback_modal-v1">
+    <Modal>
       <Tag
         color={colors.coral.main.bgColor}
         style={styling.selfCenter}
@@ -53,13 +64,10 @@ export default function MentalHealthPlaybackModal() {
           ? i18n.t('mental-health-playback.modal.description-general')
           : i18n.t('mental-health-playback.modal.description-personal')}
       </Text>
-      <BrandedButton
-        onPress={() => appCoordinator.goToMentalHealthStudyPlayback(startupInfo)}
-        style={styles.buttonPositive}
-      >
+      <BrandedButton onPress={handlePositive} style={styles.buttonPositive}>
         {i18n.t('mental-health-playback.modal.button-positive')}
       </BrandedButton>
-      <BrandedButton onPress={() => goBack()} style={styles.buttonNegative}>
+      <BrandedButton onPress={handleNegative} style={styles.buttonNegative}>
         <Text textClass="pSmallLight">{i18n.t('mental-health-playback.modal.button-negative')}</Text>
       </BrandedButton>
     </Modal>

--- a/src/features/mental-health/screens/MentalHealthModal.tsx
+++ b/src/features/mental-health/screens/MentalHealthModal.tsx
@@ -40,7 +40,7 @@ export default function MentalHealthModal() {
   });
 
   return (
-    <Modal event="view_mental_health_modal-v1">
+    <Modal>
       <Text fontFamily="SofiaProRegular" rhythm={20} textClass="h3">
         {i18n.t('mental-health.modal-title')}
       </Text>


### PR DESCRIPTION
This PR removes the existing modal events sent to our backend on every view of every modal. It's replaced with two specific events that are called when the Mental Health Playback modal (the only currently active modal) is interacted with. (View Insights or Skip Insights). 

