### PR TITLE
Add J&J vaccine to UK list 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,5 @@ android/app/src/main/assets/fonts/SofiaPro*.otf
 /assets/fonts/*
 fastlane/devices.txt
 .env.local
+.circleci/.private-assets/
+.circleci/assets/

--- a/src/features/vaccines/fields/VaccineNameQuestion.tsx
+++ b/src/features/vaccines/fields/VaccineNameQuestion.tsx
@@ -23,6 +23,7 @@ export const VaccineNameQuestion: IVaccineNameQuestion<IProps, IVaccineDoseData>
     { label: vaccineBrandDisplayName[VaccineBrands.PFIZER], value: VaccineBrands.PFIZER },
     { label: vaccineBrandDisplayName[VaccineBrands.ASTRAZENECA], value: VaccineBrands.ASTRAZENECA },
     { label: vaccineBrandDisplayName[VaccineBrands.MODERNA], value: VaccineBrands.MODERNA },
+    { label: vaccineBrandDisplayName[VaccineBrands.JOHNSON], value: VaccineBrands.JOHNSON },
     { label: i18n.t('vaccines.your-vaccine.name-i-dont-know'), value: VaccineBrands.NOT_SURE },
   ];
 


### PR DESCRIPTION
# Description

- Add J&J to UK vaccine list of options.
- https://www.notion.so/joinzoe/Add-J-J-Vaccine-for-the-UK-53f5e303df8f47c6bd87473c081a4470

## On what platform have you tested the change?

- [x] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

iOS
<img width="388" alt="Screenshot 2021-06-07 at 17 38 47" src="https://user-images.githubusercontent.com/7389546/121063246-fbab8380-c7bd-11eb-8cd1-bb816cb3a0c9.png">

Android
<img width="336" alt="Screenshot 2021-06-07 at 18 33 06" src="https://user-images.githubusercontent.com/7389546/121063937-d9fecc00-c7be-11eb-8488-0fdd033e8c01.png">

<img width="322" alt="Screenshot 2021-06-07 at 18 29 17" src="https://user-images.githubusercontent.com/7389546/121063493-4af1b400-c7be-11eb-8515-c352c90fe773.png">


## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevant
- [x] ~I have run `npm test`~ I ran `yarn test` instead
- [ ] ~I have run `npm run test:i18n`~ I ran `yarn test:i18n` instead and got this:
<img width="610" alt="Screenshot 2021-06-07 at 18 35 44" src="https://user-images.githubusercontent.com/7389546/121064250-39f57280-c7bf-11eb-87ef-93b8c879fed0.png">


## Out of scope and potential follow-up

- I'm going to make a small amend to the Typescript in a follow up PR because I noticed some Typescript errors in the file I changed (which were already present prior to my changes). There also seems to be related typescript errors in other files, so not sure whether my Typescript "fix" will have repercussions? If anyone has reservations, then LMK.
