### PR TITLE
Startup graph sync issue

### DIFF
--- a/src/core/content/state/contentSlice.ts
+++ b/src/core/content/state/contentSlice.ts
@@ -77,6 +77,9 @@ export const fetchDismissedCallouts = createAsyncThunk('content/dismissed_callou
 
 export const fetchStartUpInfo = createAsyncThunk('content/startup_info', async (): Promise<Partial<ContentState>> => {
   const service = container.get<IContentService>(Services.Content);
+  // TODO: refactor the ContentService - localData is a property set async on the class within getStartupInfo() (line 107)
+  // TICKET: https://www.notion.so/joinzoe/Refactor-ContentService-7ea01969fff54f8299d53f95f05dcb6d
+  const serviceData = await service.getStartupInfo();
   return {
     personalizedLocalData: service.localData,
     startupInfo: (await service.getStartupInfo()) ?? undefined,

--- a/src/core/content/state/contentSlice.ts
+++ b/src/core/content/state/contentSlice.ts
@@ -82,7 +82,7 @@ export const fetchStartUpInfo = createAsyncThunk('content/startup_info', async (
   const serviceData = await service.getStartupInfo();
   return {
     personalizedLocalData: service.localData,
-    startupInfo: (await service.getStartupInfo()) ?? undefined,
+    startupInfo: serviceData,
   };
 });
 


### PR DESCRIPTION
# Description

Caused by a mix of sync and async in the ContentService service. Have created a ticket to refactor the service completely ( https://www.notion.so/joinzoe/Refactor-ContentService-7ea01969fff54f8299d53f95f05dcb6d )

Issue caused by these two bits:
https://github.com/zoe/covid-tracker-react-native/blob/develop/src/core/content/ContentService.ts#L33
https://github.com/zoe/covid-tracker-react-native/blob/develop/src/core/content/ContentService.ts#L107

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevant
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
