### PR TITLE
Replace Textarea component with TextareaWithCharCount component

### DIFF
--- a/src/components/TextareaWithCharCount.tsx
+++ b/src/components/TextareaWithCharCount.tsx
@@ -1,0 +1,41 @@
+import { Textarea } from 'native-base';
+import React, { useState } from 'react';
+import { StyleProp, TextStyle } from 'react-native';
+
+import { CaptionText } from './Text';
+
+interface ITextareaWithCharCountProps {
+  maxLength?: number;
+  onChangeText: (value: string) => void;
+  placeholder: string;
+  rowSpan?: number;
+  style?: StyleProp<TextStyle>;
+  value: string | null;
+}
+
+export default function TextareaWithCharCount(props: ITextareaWithCharCountProps) {
+  const [charCount, setCharCount] = useState(0);
+
+  const maxLength = props.maxLength || 500;
+
+  return (
+    <>
+      <Textarea
+        bordered
+        maxLength={maxLength}
+        onChangeText={(value) => {
+          props.onChangeText(value);
+          setCharCount(value.length);
+        }}
+        placeholder={props.placeholder}
+        rowSpan={props.rowSpan || 5}
+        style={props.style}
+        underline={false}
+        value={props.value}
+      />
+      <CaptionText style={{ alignSelf: 'flex-end' }}>
+        {charCount} / {maxLength}
+      </CaptionText>
+    </>
+  );
+}

--- a/src/components/TextareaWithCharCount.tsx
+++ b/src/components/TextareaWithCharCount.tsx
@@ -5,9 +5,10 @@ import { StyleProp, TextStyle } from 'react-native';
 import { CaptionText } from './Text';
 
 interface ITextareaWithCharCountProps {
+  bordered?: boolean;
   maxLength?: number;
   onChangeText: (value: string) => void;
-  placeholder: string;
+  placeholder?: string;
   rowSpan?: number;
   style?: StyleProp<TextStyle>;
   value: string | null;
@@ -21,7 +22,7 @@ export default function TextareaWithCharCount(props: ITextareaWithCharCountProps
   return (
     <>
       <Textarea
-        bordered
+        bordered={props.bordered || false}
         maxLength={maxLength}
         onChangeText={(value) => {
           props.onChangeText(value);

--- a/src/components/TextareaWithCharCount.tsx
+++ b/src/components/TextareaWithCharCount.tsx
@@ -16,7 +16,7 @@ interface ITextareaWithCharCountProps {
 export default function TextareaWithCharCount(props: ITextareaWithCharCountProps) {
   const [charCount, setCharCount] = useState(0);
 
-  const maxLength = props.maxLength || 500;
+  const maxLength = props.maxLength || 1000;
 
   return (
     <>

--- a/src/components/TextareaWithCharCount.tsx
+++ b/src/components/TextareaWithCharCount.tsx
@@ -14,10 +14,13 @@ interface ITextareaWithCharCountProps {
   value: string | null;
 }
 
+const DEFAULT_MAX_LENGTH = 1000;
+const DEFAULT_ROW_SPAN = 5;
+
 export default function TextareaWithCharCount(props: ITextareaWithCharCountProps) {
   const [charCount, setCharCount] = useState(0);
 
-  const maxLength = props.maxLength || 1000;
+  const maxLength = props.maxLength || DEFAULT_MAX_LENGTH;
 
   return (
     <>
@@ -29,7 +32,7 @@ export default function TextareaWithCharCount(props: ITextareaWithCharCountProps
           setCharCount(value.length);
         }}
         placeholder={props.placeholder}
-        rowSpan={props.rowSpan || 5}
+        rowSpan={props.rowSpan || DEFAULT_ROW_SPAN}
         style={props.style}
         underline={false}
         value={props.value}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,3 +23,4 @@ export { default as Triangle } from './Triangle';
 export * from './typography';
 export { default as Modal } from './Modal';
 export { default as DoctorProfile } from './DoctorProfile';
+export { default as TextareaWithCharCount } from './TextareaWithCharCount';

--- a/src/features/assessment/TreatmentOtherScreen.tsx
+++ b/src/features/assessment/TreatmentOtherScreen.tsx
@@ -1,4 +1,4 @@
-import { BrandedButton } from '@covid/components';
+import { BrandedButton, TextareaWithCharCount } from '@covid/components';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { FieldWrapper, Header, ProgressBlock } from '@covid/components/Screen';
 import { HeaderText } from '@covid/components/Text';
@@ -10,7 +10,7 @@ import { assessmentService } from '@covid/Services';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik } from 'formik';
-import { Form, Item, Label, Textarea } from 'native-base';
+import { Form, Item, Label } from 'native-base';
 import React, { Component } from 'react';
 import { StyleSheet } from 'react-native';
 import * as Yup from 'yup';
@@ -81,15 +81,13 @@ export default class TreatmentOtherScreen extends Component<TreatmentOtherProps>
             return (
               <Form>
                 <FieldWrapper style={{ marginVertical: 64 }}>
-                  <Item stackedLabel>
+                  <Item stackedLabel style={{ borderBottomWidth: 0 }}>
                     <Label style={{ marginBottom: 16 }}>{question}</Label>
-                    <Textarea
+                    <TextareaWithCharCount
                       bordered
                       onChangeText={props.handleChange('description')}
                       placeholder={i18n.t('placeholder-optional-question')}
-                      rowSpan={5}
                       style={styles.textarea}
-                      underline={false}
                       value={props.values.description}
                     />
                   </Item>

--- a/src/features/assessment/fields/OtherSymptomsQuestions.tsx
+++ b/src/features/assessment/fields/OtherSymptomsQuestions.tsx
@@ -1,9 +1,9 @@
+import { TextareaWithCharCount } from '@covid/components';
 import { FieldWrapper } from '@covid/components/Screen';
 import { AssessmentInfosRequest } from '@covid/core/assessment/dto/AssessmentInfosRequest';
 import { ISymptomQuestions } from '@covid/features/assessment/fields/SymptomsTypes';
 import i18n from '@covid/locale/i18n';
 import { FormikProps } from 'formik';
-import { Textarea } from 'native-base';
 import React from 'react';
 import * as Yup from 'yup';
 
@@ -20,13 +20,11 @@ export const OtherSymptomsQuestions: ISymptomQuestions<Props, OtherSymptomsData>
 
   return (
     <FieldWrapper style={{ marginTop: 32 }}>
-      <Textarea
+      <TextareaWithCharCount
         bordered
         onChangeText={formikProps.handleChange('otherSymptoms')}
         placeholder={i18n.t('placeholder-optional-question')}
-        rowSpan={5}
         style={{ borderRadius: 8 }}
-        underline={false}
         value={formikProps.values.otherSymptoms}
       />
     </FieldWrapper>

--- a/src/features/long-covid/screens/LongCovidQuestionPageOne.tsx
+++ b/src/features/long-covid/screens/LongCovidQuestionPageOne.tsx
@@ -264,6 +264,7 @@ export default function LongCovidQuestionPageOneScreen({ route }: IProps) {
         {/* Do you have anything else to share regarding the evolution of your COVID-19 symptoms? */}
         <HeaderText style={{ marginBottom: 16 }}>{i18n.t('long-covid.comments')}</HeaderText>
         <TextareaWithCharCount
+          bordered
           onChangeText={props.handleChange('symptom_change_comments')}
           placeholder={i18n.t('placeholder-optional-question')}
           style={styles.textarea}

--- a/src/features/long-covid/screens/LongCovidQuestionPageOne.tsx
+++ b/src/features/long-covid/screens/LongCovidQuestionPageOne.tsx
@@ -1,7 +1,6 @@
 import InfoCircle from '@assets/icons/InfoCircle';
 import {
   BrandedButton,
-  CaptionText,
   CheckboxItem,
   CheckboxList,
   ColourHighlightHeaderTextText,
@@ -9,6 +8,7 @@ import {
   ErrorText,
   HeaderText,
   RegularText,
+  TextareaWithCharCount,
 } from '@covid/components';
 import { GenericTextField } from '@covid/components/GenericTextField';
 import { homeScreenName, thankYouScreenName } from '@covid/core/localisation/LocalisationService';
@@ -20,7 +20,7 @@ import { longCovidApiClient } from '@covid/Services';
 import { RouteProp } from '@react-navigation/native';
 import { colors } from '@theme';
 import { Formik, FormikProps } from 'formik';
-import { Form, Textarea } from 'native-base';
+import { Form } from 'native-base';
 import React, { useState } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from 'react-native';
 
@@ -216,8 +216,6 @@ export default function LongCovidQuestionPageOneScreen({ route }: IProps) {
       </View>
     ) : null;
 
-  const [symptomChangeCharCount, setSymptomChangeCharCount] = useState(0);
-
   const renderExtendedVaccineForm = (props: FormikProps<ILongCovid>) =>
     props.values.at_least_one_vaccine && props.values.at_least_one_vaccine === 'YES' ? (
       <View>
@@ -265,20 +263,13 @@ export default function LongCovidQuestionPageOneScreen({ route }: IProps) {
 
         {/* Do you have anything else to share regarding the evolution of your COVID-19 symptoms? */}
         <HeaderText style={{ marginBottom: 16 }}>{i18n.t('long-covid.comments')}</HeaderText>
-        <Textarea
-          bordered
+        <TextareaWithCharCount
           maxLength={1000}
-          onChangeText={(value) => {
-            props.handleChange('symptom_change_comments');
-            setSymptomChangeCharCount(value.length);
-          }}
+          onChangeText={props.handleChange('symptom_change_comments')}
           placeholder={i18n.t('placeholder-optional-question')}
-          rowSpan={5}
           style={styles.textarea}
-          underline={false}
           value={props.values.symptom_change_comments}
         />
-        <CaptionText style={{ alignSelf: 'flex-end' }}>{symptomChangeCharCount} / 1000</CaptionText>
       </View>
     ) : null;
 

--- a/src/features/long-covid/screens/LongCovidQuestionPageOne.tsx
+++ b/src/features/long-covid/screens/LongCovidQuestionPageOne.tsx
@@ -264,7 +264,6 @@ export default function LongCovidQuestionPageOneScreen({ route }: IProps) {
         {/* Do you have anything else to share regarding the evolution of your COVID-19 symptoms? */}
         <HeaderText style={{ marginBottom: 16 }}>{i18n.t('long-covid.comments')}</HeaderText>
         <TextareaWithCharCount
-          maxLength={1000}
           onChangeText={props.handleChange('symptom_change_comments')}
           placeholder={i18n.t('placeholder-optional-question')}
           style={styles.textarea}

--- a/src/features/mental-health-playback/screens/MHPRatingScreen.tsx
+++ b/src/features/mental-health-playback/screens/MHPRatingScreen.tsx
@@ -1,5 +1,5 @@
 import Star from '@assets/mental-health-playback/Star';
-import { BasicPage, Text } from '@covid/components';
+import { BasicPage, Text, TextareaWithCharCount } from '@covid/components';
 import Card from '@covid/components/cards/Card';
 import { homeScreenName } from '@covid/core/localisation/LocalisationService';
 import i18n from '@covid/locale/i18n';
@@ -7,7 +7,6 @@ import NavigatorService from '@covid/NavigatorService';
 import { mentalHealthApiClient } from '@covid/Services';
 import { grid, styling } from '@covid/themes';
 import lodash from 'lodash';
-import { Textarea } from 'native-base';
 import React, { useState } from 'react';
 import { LayoutChangeEvent, TouchableOpacity, View } from 'react-native';
 
@@ -99,12 +98,9 @@ export default function MHPRatingScreen() {
         >
           {i18n.t('mental-health-playback.rating.feedback')}
         </Text>
-        <Textarea
-          bordered={false}
+        <TextareaWithCharCount
           onChangeText={setComments}
-          rowSpan={5}
           style={[styling.textarea, styling.marginBottomAuto]}
-          underline={false}
           value={comments}
         />
       </View>

--- a/src/features/vaccines/VaccineDoseSymptomsScreen.tsx
+++ b/src/features/vaccines/VaccineDoseSymptomsScreen.tsx
@@ -24,6 +24,7 @@ type Props = {
 };
 
 export const VaccineDoseSymptomsScreen: React.FC<Props> = ({ route, navigation }) => {
+  const [errorMessage, setErrorMessage] = useState('');
   const [isSubmitting, setSubmitting] = useState(false);
 
   const vaccineService = useInjection<IVaccineService>(Services.Vaccine);
@@ -36,7 +37,10 @@ export const VaccineDoseSymptomsScreen: React.FC<Props> = ({ route, navigation }
         const dosePayload = DoseSymptomsQuestions.createDoseSymptoms(formData);
         dosePayload.dose = route.params.dose;
         await vaccineService.saveDoseSymptoms(patientId, dosePayload);
-      } catch (_) {
+      } catch (e) {
+        setErrorMessage(i18n.t('something-went-wrong'));
+        // TODO Show error message toast?
+      } finally {
         assessmentCoordinator.gotoNextScreen(route.name);
       }
     }

--- a/src/features/vaccines/fields/DoseSymptomsQuestions.tsx
+++ b/src/features/vaccines/fields/DoseSymptomsQuestions.tsx
@@ -1,4 +1,5 @@
 import InfoCircle from '@assets/icons/InfoCircle';
+import { TextareaWithCharCount } from '@covid/components';
 import { CheckboxList } from '@covid/components/Checkbox';
 import { RegularText } from '@covid/components/Text';
 import { DoseSymptomsRequest } from '@covid/core/vaccine/dto/VaccineRequest';
@@ -10,7 +11,6 @@ import {
 import i18n from '@covid/locale/i18n';
 import { colors } from '@covid/themes/theme/colors';
 import { FormikProps } from 'formik';
-import { Textarea } from 'native-base';
 import React from 'react';
 import { View } from 'react-native';
 import * as Yup from 'yup';
@@ -70,14 +70,13 @@ export const DoseSymptomsQuestions: IDoseSymptomQuestions<Props, DoseSymptomsDat
             </View>
           </View>
 
-          <Textarea
+          <TextareaWithCharCount
             bordered
             maxLength={500}
             onChangeText={formikProps.handleChange('otherSymptoms')}
             placeholder={i18n.t('vaccines.dose-symptoms.other-placeholder')}
             rowSpan={4}
             style={{ borderRadius: 8 }}
-            underline={false}
             value={formikProps.values.otherSymptoms}
           />
         </>


### PR DESCRIPTION
# Description

- Extract out `Textarea` with character count to a new component called `TextareaWithCharCount`
- Replace existing `Textarea` components throughout app with new component
- Ticket: https://www.notion.so/joinzoe/Refactor-TextArea-Component-with-Character-Limit-9ae797d55e494daba21787c5aea9c542

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevant
- [x] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

Should be part of Formik refactor as there's probably an opportunity to standardise how this looks throughout the app.
