### PR TITLE
Back button for forgot password screen

### DIFF
--- a/src/features/password-reset/ResetPasswordScreen.tsx
+++ b/src/features/password-reset/ResetPasswordScreen.tsx
@@ -1,3 +1,4 @@
+import { BasicPage } from '@covid/components';
 import { IUserService } from '@covid/core/user/UserService';
 import { ScreenParamList } from '@covid/features';
 import ResetPasswordForm, { IResetPasswordForm } from '@covid/features/password-reset/fields/ResetPasswordForm';
@@ -60,13 +61,15 @@ export class ResetPasswordScreen extends Component<PropsType, State> {
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <BasicPage style={{ backgroundColor: colors.white }} withFooter={false}>
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.rootContainer}>
           <Formik initialValues={{ email: '' }} onSubmit={this.handleClick} validationSchema={this.registerSchema}>
             {(props: IResetPasswordForm) => <ResetPasswordForm {...props} errorMessage={this.state.errorMessage} />}
           </Formik>
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>
+      </BasicPage>
     );
   }
 }


### PR DESCRIPTION
# Description

Adds a back button to forgot password screen 

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevant
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

_Is there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
