### PR TITLE
Reverted dropdown min height

### DIFF
--- a/src/components/DropdownField.tsx
+++ b/src/components/DropdownField.tsx
@@ -95,8 +95,7 @@ export function DropdownField({
 
   const renderDropdownSeparator = (): React.ReactNode => <View style={styles.dropdownSeparator} />;
 
-  const dropdownHeight: number = (options?.length ?? 1) * DROPDOWN_ROW_HEIGHT;
-
+  const dropdownHeight: number = Math.min((options?.length ?? 1) * DROPDOWN_ROW_HEIGHT, 220)
   const renderDropdownRow = (option: string, index: any, isSelected: boolean): React.ReactNode => {
     // There is a type error in renderDropdownRow index is actually a number, not a string
 


### PR DESCRIPTION
# Description

Restored the min dropdown height.
I wanted to do a bit of smarter work to handle content better, but am in fear of causing regressions! Let's replace this entire widget with one that automatically calculates its height (there's already a ticket).

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![image](https://user-images.githubusercontent.com/3264113/122389874-4f119480-cf69-11eb-9782-f59c873520f9.png)

## Checklist

- [ ] I have updated mockServer
- [ ] I've added analytics as relevant
- [ ] I have run `npm test`
- [ ] I have run `npm run test:i18n`

## Out of scope and potential follow-up

Ticket mentioned above to replace widget