### PR TITLE
Fixed About you form back error

### DIFF
--- a/src/features/patient/AboutYouScreen.tsx
+++ b/src/features/patient/AboutYouScreen.tsx
@@ -343,7 +343,6 @@ export default class AboutYouScreen extends React.Component<AboutYouProps, State
 
         <Formik
           validateOnChange
-          validateOnMount
           initialValues={this.props.route.params?.editing ? this.getPatientFormValues() : getInitialFormValues()}
           onSubmit={(values: IAboutYouData) => {
             return this.handleUpdateHealth(values);
@@ -458,7 +457,7 @@ export default class AboutYouScreen extends React.Component<AboutYouProps, State
                   ) : null}
                 </View>
 
-                <BrandedButton enable={props.isValid} loading={props.isSubmitting} onPress={props.handleSubmit}>
+                <BrandedButton enable={props.isValid && props.dirty} onPress={props.handleSubmit}>
                   {this.props.route.params?.editing ? i18n.t('edit-profile.done') : i18n.t('next-question')}
                 </BrandedButton>
               </FormWrapper>


### PR DESCRIPTION
# Description
Fixes the error state for "About you" form on back.
Note that this form, and others, should be refactored to be functional components, in which case we can better handle any back/navigation events with useEffect.

https://www.notion.so/joinzoe/017c3de591604a7b89d0b69e3c37b279?v=0133357df3ed42e1bd42c1e0d7afcf45&p=b928c836e318483aa47ff045eb9417a3

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device
