### PR TITLE
Refactor CovidTestDetail form for form validation

### DIFF
--- a/src/features/covid-tests/CovidTestDetailScreen.tsx
+++ b/src/features/covid-tests/CovidTestDetailScreen.tsx
@@ -200,6 +200,7 @@ export default class CovidTestDetailScreen extends React.Component<CovidProps, S
         </ProgressBlock>
 
         <Formik
+          validateOnMount
           initialValues={{
             ...CovidTestDateQuestion.initialFormValues(test),
             ...CovidTestMechanismQuestion.initialFormValues(test),
@@ -239,10 +240,7 @@ export default class CovidTestDetailScreen extends React.Component<CovidProps, S
                   ) : null}
                 </View>
 
-                <BrandedButton
-                  enable={!this.state.submitting && props.isValid && props.dirty}
-                  onPress={props.handleSubmit}
-                >
+                <BrandedButton enable={!this.state.submitting && props.isValid} onPress={props.handleSubmit}>
                   {i18n.t(this.testId ? 'covid-test.update-test' : 'covid-test.add-test')}
                 </BrandedButton>
               </FormWrapper>

--- a/src/features/covid-tests/CovidTestDetailScreen.tsx
+++ b/src/features/covid-tests/CovidTestDetailScreen.tsx
@@ -1,5 +1,6 @@
 import { BrandedButton } from '@covid/components';
 import { ClearButton } from '@covid/components/buttons/ClearButton';
+import { FormWrapper } from '@covid/components/Forms';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { ErrorText, HeaderText } from '@covid/components/Text';
@@ -30,7 +31,6 @@ import { Services } from '@covid/provider/services.types';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik, FormikProps } from 'formik';
-import { Form } from 'native-base';
 import * as React from 'react';
 import { Alert, View } from 'react-native';
 import * as Yup from 'yup';
@@ -215,7 +215,7 @@ export default class CovidTestDetailScreen extends React.Component<CovidProps, S
         >
           {(props) => {
             return (
-              <Form>
+              <FormWrapper hasRequiredFields>
                 <View style={{ marginHorizontal: 16 }}>
                   <CovidTestDateQuestion formikProps={props as FormikProps<ICovidTestDateData>} test={test} />
                   <CovidTestMechanismQuestion formikProps={props as FormikProps<ICovidTestMechanismData>} test={test} />
@@ -239,10 +239,13 @@ export default class CovidTestDetailScreen extends React.Component<CovidProps, S
                   ) : null}
                 </View>
 
-                <BrandedButton enable={!this.state.submitting} onPress={props.handleSubmit}>
+                <BrandedButton
+                  enable={!this.state.submitting && props.isValid && props.dirty}
+                  onPress={props.handleSubmit}
+                >
                   {i18n.t(this.testId ? 'covid-test.update-test' : 'covid-test.add-test')}
                 </BrandedButton>
-              </Form>
+              </FormWrapper>
             );
           }}
         </Formik>

--- a/src/features/covid-tests/fields/CovidTestDateQuestion.tsx
+++ b/src/features/covid-tests/fields/CovidTestDateQuestion.tsx
@@ -1,4 +1,5 @@
 import CalendarPicker from '@covid/components/CalendarPicker';
+import { requiredFormMarker } from '@covid/components/Forms';
 import { ClickableText, RegularText } from '@covid/components/Text';
 import YesNoField from '@covid/components/YesNoField';
 import { CovidTest } from '@covid/core/user/dto/CovidTestContracts';
@@ -70,6 +71,7 @@ export const CovidTestDateQuestion: ICovidTestDateQuestion<IProps, ICovidTestDat
   return (
     <>
       <YesNoField
+        required
         label={i18n.t('covid-test.question-knows-date-of-test')}
         onValueChange={(value: string) => {
           if (value === 'yes') {
@@ -94,7 +96,9 @@ export const CovidTestDateQuestion: ICovidTestDateQuestion<IProps, ICovidTestDat
 
       {formikProps.values.knowsDateOfTest === 'yes' && (
         <>
-          <RegularText style={styles.labelStyle}>{i18n.t('covid-test.question-date-test-occurred')}</RegularText>
+          <RegularText style={styles.labelStyle}>
+            {i18n.t('covid-test.question-date-test-occurred')} {requiredFormMarker}
+          </RegularText>
           {state.showDatePicker ? (
             <CalendarPicker
               maxDate={today}
@@ -117,7 +121,9 @@ export const CovidTestDateQuestion: ICovidTestDateQuestion<IProps, ICovidTestDat
 
       {formikProps.values.knowsDateOfTest === 'no' && (
         <>
-          <RegularText style={styles.labelStyle}>{i18n.t('covid-test.question-date-test-occurred-guess')}</RegularText>
+          <RegularText style={styles.labelStyle}>
+            {i18n.t('covid-test.question-date-test-occurred-guess')} {requiredFormMarker}
+          </RegularText>
 
           {state.showRangePicker ? (
             <CalendarPicker

--- a/src/features/covid-tests/fields/CovidTestInvitedQuesetion.tsx
+++ b/src/features/covid-tests/fields/CovidTestInvitedQuesetion.tsx
@@ -25,6 +25,7 @@ export const CovidTestInvitedQuestion: ICovidTestInvitedQuestion<IProps, ICovidT
   const { formikProps } = props;
   return isGBCountry() ? (
     <YesNoField
+      required
       error={formikProps.touched.invitedToTest && formikProps.errors.invitedToTest}
       label={i18n.t('covid-test.question-invite-to-test')}
       onValueChange={formikProps.handleChange('invitedToTest')}

--- a/src/features/covid-tests/fields/CovidTestIsRapidQuestion.tsx
+++ b/src/features/covid-tests/fields/CovidTestIsRapidQuestion.tsx
@@ -24,6 +24,7 @@ export const CovidTestIsRapidQuestion: ICovidTestIsRapidQuestion<IProps, ICovidT
   const { formikProps } = props;
   return (
     <YesNoField
+      required
       error={formikProps.touched.isRapidTest && formikProps.errors.isRapidTest}
       label={i18n.t('covid-test.question-is-rapid-test')}
       onValueChange={formikProps.handleChange('isRapidTest')}

--- a/src/features/covid-tests/fields/CovidTestLocation.tsx
+++ b/src/features/covid-tests/fields/CovidTestLocation.tsx
@@ -64,6 +64,7 @@ export const CovidTestLocationQuestion: ICovidTestLocationQuestion<IProps, ICovi
   return (
     <>
       <RadioInput
+        required
         error={formikProps.touched.location ? formikProps.errors.location : ''}
         items={locationItems}
         label={i18n.t('covid-test.location.question')}
@@ -73,6 +74,7 @@ export const CovidTestLocationQuestion: ICovidTestLocationQuestion<IProps, ICovi
 
       {formikProps.values.location === 'other' && (
         <GenericTextField
+          required
           formikProps={formikProps}
           label={i18n.t('covid-test.location.specify')}
           name="locationOther"

--- a/src/features/covid-tests/fields/CovidTestMechanismQuestion.tsx
+++ b/src/features/covid-tests/fields/CovidTestMechanismQuestion.tsx
@@ -92,6 +92,7 @@ export const CovidTestMechanismQuestion: ICovidTestMechanismQuestion<IProps, ICo
   return (
     <>
       <RadioInput
+        required
         error={formikProps.touched.mechanism ? formikProps.errors.mechanism : ''}
         items={mechanismItems}
         label={i18n.t('covid-test.question-mechanism')}
@@ -102,6 +103,7 @@ export const CovidTestMechanismQuestion: ICovidTestMechanismQuestion<IProps, ICo
 
       {formikProps.values.mechanism === 'other' && (
         <GenericTextField
+          required
           formikProps={formikProps}
           label={i18n.t('covid-test.question-mechanism-specify')}
           name="mechanismSpecify"
@@ -110,6 +112,7 @@ export const CovidTestMechanismQuestion: ICovidTestMechanismQuestion<IProps, ICo
 
       {formikProps.values.mechanism === 'nose_throat_swab' && (
         <RadioInput
+          required
           error={formikProps.touched.trainedWorker ? formikProps.errors.trainedWorker : ''}
           items={trainedWorkerItems}
           label={i18n.t('covid-test.question-trained-worker')}

--- a/src/features/covid-tests/fields/CovidTestResultQuestion.tsx
+++ b/src/features/covid-tests/fields/CovidTestResultQuestion.tsx
@@ -32,6 +32,7 @@ export const CovidTestResultQuestion: ICovidTestResultQuestion<IProps, ICovidTes
 
   return (
     <RadioInput
+      required
       error={formikProps.touched.result ? formikProps.errors.result : ''}
       items={resultItems}
       label={i18n.t('covid-test.question-result')}


### PR DESCRIPTION
# Description

- Add form validation to CovidTestDetail form.
- No specific ticket, logging finished refactors here: https://www.notion.so/joinzoe/Fun-with-Forms-d66ad33a88694d8aaa86777fbf4a75b8#22636d7c049b4132a051c3a5eea4b8fc

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-06-28 at 12 34 31](https://user-images.githubusercontent.com/7389546/123630636-aa674080-d80d-11eb-99ab-dae08ae1a7de.png)
![Simulator Screen Shot - iPhone 11 - 2021-06-28 at 12 37 39](https://user-images.githubusercontent.com/7389546/123630641-ac310400-d80d-11eb-9bdf-caaf22290a7e.png)
![Simulator Screen Shot - iPhone 11 - 2021-06-28 at 12 37 43](https://user-images.githubusercontent.com/7389546/123630648-ad623100-d80d-11eb-84bc-8ff9e8f1cf53.png)

## Checklist (for submission)

- ~[ ] Analytics/tracking events have been added (if needed)~

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [x] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

Part of bigger Form refactor.