### PR TITLE
Add required validation to ResetPasswordForm

### DIFF
--- a/src/features/password-reset/fields/ResetPasswordForm.tsx
+++ b/src/features/password-reset/fields/ResetPasswordForm.tsx
@@ -1,8 +1,8 @@
 import { BrandedButton } from '@covid/components';
+import { FormWrapper, requiredFormMarker } from '@covid/components/Forms';
 import { ErrorText, HeaderText } from '@covid/components/Text';
 import { ValidatedTextInput } from '@covid/components/ValidatedTextInput';
 import i18n from '@covid/locale/i18n';
-import { Form } from 'native-base';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
@@ -17,6 +17,7 @@ export interface IResetPasswordForm {
     email?: string;
   };
   errorMessage?: string;
+  isValid?: boolean;
   handleChange: (field: string) => (text: string) => void;
   handleBlur: (field: string) => () => void;
   handleSubmit: () => void;
@@ -30,12 +31,15 @@ function ResetPasswordForm({
   handleBlur,
   handleSubmit,
   errorMessage,
+  isValid,
 }: IResetPasswordForm) {
   return (
     <View>
       <View style={styles.formItem}>
-        <HeaderText>{i18n.t('reset-password.title')}</HeaderText>
-        <Form>
+        <HeaderText>
+          {i18n.t('reset-password.title')} {requiredFormMarker}
+        </HeaderText>
+        <FormWrapper>
           <ValidatedTextInput
             autoCapitalize="none"
             autoCompleteType="email"
@@ -49,14 +53,16 @@ function ResetPasswordForm({
           />
 
           {touched.email && errors.email ? <ErrorText> {i18n.t('reset-password.email-error')}</ErrorText> : null}
-        </Form>
+        </FormWrapper>
       </View>
       <View>
         <ErrorText>{errorMessage}</ErrorText>
       </View>
 
       <View>
-        <BrandedButton onPress={handleSubmit}>{i18n.t('reset-password.button')}</BrandedButton>
+        <BrandedButton enable={values.email.length > 0 && isValid && !errors.email} onPress={handleSubmit}>
+          {i18n.t('reset-password.button')}
+        </BrandedButton>
       </View>
     </View>
   );


### PR DESCRIPTION
# Description

- Add form validation to ResetPasswordForm.
- No specific ticket, logging finished refactors here: https://www.notion.so/joinzoe/Fun-with-Forms-d66ad33a88694d8aaa86777fbf4a75b8#22636d7c049b4132a051c3a5eea4b8fc
## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-06-28 at 13 06 25](https://user-images.githubusercontent.com/7389546/123633885-ac330300-d811-11eb-88f2-f1d72e9fd673.png)

## Checklist (for submission)

- ~[ ] Analytics/tracking events have been added (if needed)~

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

Part of bigger Form refactor.