### PR TITLE
Fix a couple of form refactor bugs upon testing on staging

### DIFF
--- a/src/features/assessment/HealthWorkerExposureScreen.tsx
+++ b/src/features/assessment/HealthWorkerExposureScreen.tsx
@@ -216,8 +216,6 @@ export default class HealthWorkerExposureScreen extends React.Component<HealthWo
                   ) : null}
                 </View>
 
-                {/* {Object.keys(props.errors).length ? <ErrorText>{i18n.t('validation-error-text')}</ErrorText> : null} */}
-
                 {!!Object.keys(props.errors).length && props.submitCount > 0 ? (
                   <ValidationError error={i18n.t('validation-error-text')} />
                 ) : null}

--- a/src/features/assessment/HealthWorkerExposureScreen.tsx
+++ b/src/features/assessment/HealthWorkerExposureScreen.tsx
@@ -4,6 +4,7 @@ import { RadioInput } from '@covid/components/inputs/RadioInput';
 import ProgressStatus from '@covid/components/ProgressStatus';
 import Screen, { Header, ProgressBlock } from '@covid/components/Screen';
 import { ErrorText, HeaderText } from '@covid/components/Text';
+import { ValidationError } from '@covid/components/ValidationError';
 import YesNoField from '@covid/components/YesNoField';
 import AssessmentCoordinator from '@covid/core/assessment/AssessmentCoordinator';
 import { AssessmentInfosRequest } from '@covid/core/assessment/dto/AssessmentInfosRequest';
@@ -215,7 +216,12 @@ export default class HealthWorkerExposureScreen extends React.Component<HealthWo
                   ) : null}
                 </View>
 
-                {Object.keys(props.errors).length ? <ErrorText>{i18n.t('validation-error-text')}</ErrorText> : null}
+                {/* {Object.keys(props.errors).length ? <ErrorText>{i18n.t('validation-error-text')}</ErrorText> : null} */}
+
+                {!!Object.keys(props.errors).length && props.submitCount > 0 ? (
+                  <ValidationError error={i18n.t('validation-error-text')} />
+                ) : null}
+
                 <ErrorText>{this.state.errorMessage}</ErrorText>
 
                 <BrandedButton enable={props.isValid} onPress={props.handleSubmit}>

--- a/src/features/vaccines/AboutYourVaccineScreen.tsx
+++ b/src/features/vaccines/AboutYourVaccineScreen.tsx
@@ -227,6 +227,7 @@ export function AboutYourVaccineScreen({ route, navigation }: IProps) {
       {renderFindInfoLink}
       <Formik
         validateOnChange
+        validateOnMount
         initialValues={{ ...buildInitialValues(assessmentData?.vaccineData) }}
         onSubmit={(formData: IAboutYourVaccineData) =>
           // Show an alert if any date value has changed. The prompt confirm will call processFormDataForSubmit thereafter.
@@ -267,7 +268,7 @@ export function AboutYourVaccineScreen({ route, navigation }: IProps) {
                 <ValidationError error={i18n.t('validation-error-text')} style={{ marginBottom: 32 }} />
               ) : null}
 
-              <BrandedButton enable={props.isValid && props.dirty} onPress={props.handleSubmit}>
+              <BrandedButton enable={props.isValid} onPress={props.handleSubmit}>
                 {i18n.t('vaccines.your-vaccine.confirm')}
               </BrandedButton>
               {renderDeleteButton()}


### PR DESCRIPTION
# Description

1. Do not show errors immediately upon "yes" being selected during daily assessment of health worker who has seen a patient in the last day.
2. Button now enabled immediately if user edits and existing vaccine.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

n/a

## Checklist (for submission)

- ~[ ] Analytics/tracking events have been added (if needed)~

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [x] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

n/a