### PR TITLE
Add required prop to fields in PreviousExposure form

### DIFF
--- a/src/features/patient/PreviousExposureScreen.tsx
+++ b/src/features/patient/PreviousExposureScreen.tsx
@@ -1,5 +1,6 @@
 import { BrandedButton } from '@covid/components';
 import { CheckboxItem, CheckboxList } from '@covid/components/Checkbox';
+import { FormWrapper } from '@covid/components/Forms';
 import { GenericTextField } from '@covid/components/GenericTextField';
 import { RadioInput } from '@covid/components/inputs/RadioInput';
 import ProgressStatus from '@covid/components/ProgressStatus';
@@ -18,7 +19,7 @@ import { stripAndRound } from '@covid/utils/number';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Formik } from 'formik';
-import { Form, Item, Label } from 'native-base';
+import { Item, Label } from 'native-base';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import * as Yup from 'yup';
@@ -33,7 +34,7 @@ interface IYourHealthData {
 
 const initialFormValues = {
   classicSymptoms: 'no',
-  pastSymptomsChanged: 'no',
+  pastSymptomsChanged: 'much_better',
   pastSymptomsDaysAgo: '',
   stillHavePastSymptoms: 'no',
   unwellMonthBefore: 'no',
@@ -168,6 +169,7 @@ export default class PreviousExposureScreen extends React.Component<HealthProps,
         </ProgressBlock>
 
         <Formik
+          validateOnChange
           initialValues={initialFormValues}
           onSubmit={(values: IYourHealthData) => {
             return this.handleUpdateHealth(values);
@@ -176,9 +178,10 @@ export default class PreviousExposureScreen extends React.Component<HealthProps,
         >
           {(props) => {
             return (
-              <Form>
+              <FormWrapper hasRequiredFields>
                 <View style={{ marginHorizontal: 16 }}>
                   <YesNoField
+                    required
                     label={i18n.t('label-unwell-month-before')}
                     onValueChange={props.handleChange('unwellMonthBefore')}
                     selectedValue={props.values.unwellMonthBefore}
@@ -261,6 +264,7 @@ export default class PreviousExposureScreen extends React.Component<HealthProps,
                       </FieldWrapper>
 
                       <GenericTextField
+                        required
                         formikProps={props}
                         keyboardType="numeric"
                         label={i18n.t('label-past-symptoms-days-ago')}
@@ -268,6 +272,7 @@ export default class PreviousExposureScreen extends React.Component<HealthProps,
                       />
 
                       <YesNoField
+                        required
                         label={i18n.t('label-past-symptoms-still-have')}
                         onValueChange={props.handleChange('stillHavePastSymptoms')}
                         selectedValue={props.values.stillHavePastSymptoms}
@@ -277,6 +282,7 @@ export default class PreviousExposureScreen extends React.Component<HealthProps,
 
                   {props.values.stillHavePastSymptoms === 'yes' ? (
                     <RadioInput
+                      required
                       items={symptomChangeChoices}
                       label={i18n.t('label-past-symptoms-changed')}
                       onValueChange={props.handleChange('pastSymptomsChanged')}
@@ -290,8 +296,10 @@ export default class PreviousExposureScreen extends React.Component<HealthProps,
                   ) : null}
                 </View>
 
-                <BrandedButton onPress={props.handleSubmit}>{i18n.t('next-question')}</BrandedButton>
-              </Form>
+                <BrandedButton enable={props.isValid} onPress={props.handleSubmit}>
+                  {i18n.t('next-question')}
+                </BrandedButton>
+              </FormWrapper>
             );
           }}
         </Formik>


### PR DESCRIPTION
# Description

Add required props to the PreviousExposure to COVID form.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-06-29 at 16 22 41](https://user-images.githubusercontent.com/7389546/123824811-44a2b380-d8f6-11eb-814a-107c41eb705a.png)


## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

Need to refactor to a functional component so that we can reset the form if a user clicks back on navbar after submitting. 
Ticket: https://www.notion.so/joinzoe/Product-Eng-Board-ca9e8b1b8926481f8c94cb01a88d567d?p=5c5011dd2c9f4b86a01f1db55820f8bd
