### PR TITLE
Removed yarn metro-empty-cache from circle ci build script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,6 @@ commands:
     steps:
       - prepare_code
       - install-dependencies
-      - run: yarn metro-empty-cache
       - run:
           name: "Bundle RN Android assets"
           command: npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res


### PR DESCRIPTION
# Description

This was introduced as a clean slate for the detox build, but is not needed without it and is causing the ota cache error.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

_Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
