### PR TITLE
Reconsent Flow - Request consent confirmation screen

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1711,6 +1711,19 @@
       "description": "Help detect early symptoms and uncover the role of nutrition and lifestyle in disease risk.",
       "sidenote": "This study has ethical approval from King's College London",
       "title": "Help us fight major diseases beyond COVID-19"
+    },
+    "request-consent": {
+      "title": "Are you in?",
+      "subtitle": "To fight other diseases, we need your consent to:",
+      "use-1-title": "1. Advance human health science",
+      "use-1-description": "ZOE and King's College London will use your data to improve the world’s understanding of human health, including but not limited to COVID-19. We may invite you to join third party research studies that you are eligible for.",
+      "use-2-title": "2. Help others improve human health ",
+      "use-2-description": "We may share your data with other bonafide research organisations to help them carry out scientific research into human health too. The full list of organisations will be shown in our Privacy Notice. We will only share your data in an anonymised or aggregated form, unless you permit us to do otherwise.",
+      "use-3-title": "3. Build health products",
+      "use-3-description": "ZOE may build health products based on this research to be sold commercially. This is needed to sustain the technology and team that maintain this app for the long-term. We will never sell your data.",
+      "learn-more": "Learn more in our Privacy Notice",
+      "consent-yes": "Yes, I'm in",
+      "consent-no": "No, I do not consent to fight other major diseases, only COVID-19"
     }
   },
 

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1716,6 +1716,19 @@
       "description": "Help detect early symptoms and uncover the role of nutrition and lifestyle in disease risk.",
       "sidenote": "This study has ethical approval from King's College London",
       "title": "Help us fight major diseases beyond COVID-19"
+    },
+    "request-consent": {
+      "title": "Are you in?",
+      "subtitle": "To fight other diseases, we need your consent to:",
+      "use-1-title": "1. Advance human health science",
+      "use-1-description": "ZOE and King's College London will use your data to improve the world’s understanding of human health, including but not limited to COVID-19. We may invite you to join third party research studies that you are eligible for.",
+      "use-2-title": "2. Help others improve human health ",
+      "use-2-description": "We may share your data with other bonafide research organisations to help them carry out scientific research into human health too. The full list of organisations will be shown in our Privacy Notice. We will only share your data in an anonymised or aggregated form, unless you permit us to do otherwise.",
+      "use-3-title": "3. Build health products",
+      "use-3-description": "ZOE may build health products based on this research to be sold commercially. This is needed to sustain the technology and team that maintain this app for the long-term. We will never sell your data.",
+      "learn-more": "Learn more in our Privacy Notice",
+      "consent-yes": "Yes, I'm in",
+      "consent-no": "No, I do not consent to fight other major diseases, only COVID-19"
     }
   },
 

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1700,6 +1700,19 @@
       "description": "Help detect early symptoms and uncover the role of nutrition and lifestyle in disease risk.",
       "sidenote": "This study has ethical approval from King's College London",
       "title": "Help us fight major diseases beyond COVID-19"
+    },
+    "request-consent": {
+      "title": "Are you in?",
+      "subtitle": "To fight other diseases, we need your consent to:",
+      "use-1-title": "1. Advance human health science",
+      "use-1-description": "ZOE and King's College London will use your data to improve the world’s understanding of human health, including but not limited to COVID-19. We may invite you to join third party research studies that you are eligible for.",
+      "use-2-title": "2. Help others improve human health ",
+      "use-2-description": "We may share your data with other bonafide research organisations to help them carry out scientific research into human health too. The full list of organisations will be shown in our Privacy Notice. We will only share your data in an anonymised or aggregated form, unless you permit us to do otherwise.",
+      "use-3-title": "3. Build health products",
+      "use-3-description": "ZOE may build health products based on this research to be sold commercially. This is needed to sustain the technology and team that maintain this app for the long-term. We will never sell your data.",
+      "learn-more": "Learn more in our Privacy Notice",
+      "consent-yes": "Yes, I'm in",
+      "consent-no": "No, I do not consent to fight other major diseases, only COVID-19"
     }
   },
 

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -332,7 +332,7 @@ export class AppCoordinator extends Coordinator implements ISelectProfile, IEdit
 
   goToReconsent() {
     // NavigatorService.navigate('ReconsentIntroduction');
-    NavigatorService.navigate('ReconsentDiseasePreferences');
+    NavigatorService.navigate('ReconsentRequestConsent');
   }
 }
 

--- a/src/features/reconsent/components/ReconsentScreen.tsx
+++ b/src/features/reconsent/components/ReconsentScreen.tsx
@@ -16,7 +16,7 @@ export default function ReconsentScreen(props: IProps) {
 
   return (
     <SafeLayout style={styles.safeLayout}>
-      <ScrollView contentContainerStyle={styling.flexGrow} style={{ paddingHorizontal: theme.grid.gutter }}>
+      <ScrollView contentContainerStyle={styling.flexGrow} style={{ paddingHorizontal: theme.grid.xxl }}>
         {props.children}
         <BrandedButton enable onPress={props.buttonOnPress} style={styles.button}>
           {props.buttonTitle}

--- a/src/features/reconsent/components/ReconsentScreen.tsx
+++ b/src/features/reconsent/components/ReconsentScreen.tsx
@@ -1,6 +1,6 @@
-import { SafeLayout } from '@covid/components';
+import { SafeLayout, Text } from '@covid/components';
 import { BrandedButton } from '@covid/components/buttons';
-import { styling, useTheme } from '@covid/themes';
+import { grid, styling, useTheme } from '@covid/themes';
 import { colors } from '@theme';
 import * as React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
@@ -9,6 +9,8 @@ interface IProps {
   buttonTitle: string;
   buttonOnPress: () => void;
   children?: React.ReactNode;
+  secondaryButtonTitle?: string;
+  secondaryButtonOnPress?: () => void;
 }
 
 export default function ReconsentScreen(props: IProps) {
@@ -21,6 +23,9 @@ export default function ReconsentScreen(props: IProps) {
         <BrandedButton enable onPress={props.buttonOnPress} style={styles.button}>
           {props.buttonTitle}
         </BrandedButton>
+        <Text onPress={props.secondaryButtonOnPress} style={styles.secondaryButton} textClass="pLight">
+          {props.secondaryButtonTitle}
+        </Text>
       </ScrollView>
     </SafeLayout>
   );
@@ -33,5 +38,12 @@ const styles = StyleSheet.create({
   },
   safeLayout: {
     backgroundColor: colors.backgroundPrimary,
+  },
+  secondaryButton: {
+    color: colors.secondary,
+    marginTop: grid.xxxl,
+    paddingHorizontal: grid.xs,
+    textAlign: 'center',
+    textDecorationLine: 'underline',
   },
 });

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -30,6 +30,7 @@ export default function ReconsentRequestConsentScreen() {
     return [1, 2, 3].map((i) => (
       <Callout
         description={i18n.t(`reconsent.request-consent.use-${i}-description`)}
+        key={i}
         title={i18n.t(`reconsent.request-consent.use-${i}-title`)}
       />
     ));
@@ -39,6 +40,8 @@ export default function ReconsentRequestConsentScreen() {
     <ReconsentScreen
       buttonOnPress={() => NavigatorService.navigate('ReconsentNewsletterSignup')}
       buttonTitle={i18n.t('reconsent.request-consent.consent-yes')}
+      secondaryButtonOnPress={() => NavigatorService.navigate('ReconsentFeedback')}
+      secondaryButtonTitle={i18n.t('reconsent.request-consent.consent-no')}
     >
       <ReconsentHeader showBackIcon showDots />
       <Text rhythm={16} style={styles.center} textClass="h2Light">

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -8,7 +8,7 @@ import { colors } from '@theme';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-function Callout(props: { title: string; description: string }) {
+const Callout = (props: { title: string; description: string }) => {
   return (
     <View style={styles.card}>
       <Text rhythm={8} style={styles.cardTitle} textClass="h4Medium">
@@ -19,9 +19,22 @@ function Callout(props: { title: string; description: string }) {
       </Text>
     </View>
   );
-}
+};
 
 export default function ReconsentRequestConsentScreen() {
+  const onPrivacyPolicyPress = () => {
+    NavigatorService.navigate('PrivacyPolicyUK', { viewOnly: true });
+  };
+
+  const renderCallouts = () => {
+    return [1, 2, 3].map((i) => (
+      <Callout
+        description={i18n.t(`reconsent.request-consent.use-${i}-description`)}
+        title={i18n.t(`reconsent.request-consent.use-${i}-title`)}
+      />
+    ));
+  };
+
   return (
     <ReconsentScreen
       buttonOnPress={() => NavigatorService.navigate('ReconsentNewsletterSignup')}
@@ -34,11 +47,11 @@ export default function ReconsentRequestConsentScreen() {
       <Text rhythm={24} style={[styles.center, styles.subtitle]} textClass="pLight">
         {i18n.t('reconsent.request-consent.subtitle')}
       </Text>
-
-      <Callout
-        description={i18n.t('reconsent.request-consent.use-1-description')}
-        title={i18n.t('reconsent.request-consent.use-1-title')}
-      />
+      {renderCallouts()}
+      <Text onPress={onPrivacyPolicyPress} style={styles.privacyLink} textClass="pSmallLight">
+        {i18n.t('reconsent.request-consent.learn-more')}{' '}
+      </Text>
+      <View style={styles.hr} />
     </ReconsentScreen>
   );
 }
@@ -47,6 +60,7 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: colors.lightBlueBackground,
     borderRadius: grid.l,
+    marginBottom: grid.l,
     paddingHorizontal: grid.xxl,
     paddingVertical: grid.xxl,
   },
@@ -59,10 +73,21 @@ const styles = StyleSheet.create({
   center: {
     textAlign: 'center',
   },
+  hr: {
+    borderBottomColor: colors.backgroundFour,
+    borderBottomWidth: 1,
+    marginBottom: grid.xxl,
+  },
   page: {
     backgroundColor: colors.backgroundPrimary,
   },
-
+  privacyLink: {
+    color: colors.darkblue,
+    marginBottom: 30,
+    marginTop: grid.s,
+    textAlign: 'center',
+    textDecorationLine: 'underline',
+  },
   subtitle: {
     color: colors.secondary,
   },

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -1,40 +1,69 @@
-import { Link, SafeLayout, Text } from '@covid/components';
-import ReconsentFooter from '@covid/features/reconsent/components/ReconsentFooter';
+import { Text } from '@covid/components';
 import ReconsentHeader from '@covid/features/reconsent/components/ReconsentHeader';
+import ReconsentScreen from '@covid/features/reconsent/components/ReconsentScreen';
 import i18n from '@covid/locale/i18n';
 import NavigatorService from '@covid/NavigatorService';
-import { styling, useTheme } from '@covid/themes';
+import { grid } from '@covid/themes';
 import { colors } from '@theme';
 import * as React from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+
+function Callout(props: { title: string; description: string }) {
+  return (
+    <View style={styles.card}>
+      <Text rhythm={8} style={styles.cardTitle} textClass="h4Medium">
+        {props.title}
+      </Text>
+      <Text style={styles.cardDescription} textClass="pLight">
+        {props.description}
+      </Text>
+    </View>
+  );
+}
 
 export default function ReconsentRequestConsentScreen() {
-  const theme = useTheme();
-
   return (
-    <SafeLayout style={styles.page}>
-      <ScrollView contentContainerStyle={styling.flexGrow} style={{ paddingHorizontal: theme.grid.gutter }}>
-        <ReconsentHeader showBackIcon showDots />
-        <View>
-          <Text>Request consent screen</Text>
-        </View>
-        <Link
-          linkText="No consent"
-          onPress={() => {
-            NavigatorService.navigate('ReconsentFeedback');
-          }}
-        />
-      </ScrollView>
-      <ReconsentFooter
-        onPress={() => NavigatorService.navigate('ReconsentNewsletterSignup')}
-        title={i18n.t('navigation.next')}
+    <ReconsentScreen
+      buttonOnPress={() => NavigatorService.navigate('ReconsentNewsletterSignup')}
+      buttonTitle={i18n.t('reconsent.request-consent.consent-yes')}
+    >
+      <ReconsentHeader showBackIcon showDots />
+      <Text rhythm={16} style={styles.center} textClass="h2Light">
+        {i18n.t('reconsent.request-consent.title')}
+      </Text>
+      <Text rhythm={24} style={[styles.center, styles.subtitle]} textClass="pLight">
+        {i18n.t('reconsent.request-consent.subtitle')}
+      </Text>
+
+      <Callout
+        description={i18n.t('reconsent.request-consent.use-1-description')}
+        title={i18n.t('reconsent.request-consent.use-1-title')}
       />
-    </SafeLayout>
+    </ReconsentScreen>
   );
 }
 
 const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.lightBlueBackground,
+    borderRadius: grid.l,
+    paddingHorizontal: grid.xxl,
+    paddingVertical: grid.xxl,
+  },
+  cardDescription: {
+    color: colors.darkblue,
+  },
+  cardTitle: {
+    color: colors.darkblue,
+  },
+  center: {
+    textAlign: 'center',
+  },
   page: {
     backgroundColor: colors.backgroundPrimary,
+  },
+
+  subtitle: {
+    color: colors.secondary,
   },
 });


### PR DESCRIPTION
# Description

Notion: https://www.notion.so/joinzoe/Re-consent-Flow-Request-Consent-screen-4th-screen-04f7a2e89a54477baa11795f257d0f0e

Notes:
- Have asked Sol about new copy for Privacy Policy. We'll probably need to create a new route for this.
- Didn't use `FlatList` to render callout boxes as thought it was a bit overkill in this case. :)
- I've allowed the subtitle to fill the width of the screen (goes against Figma designs). Do we have a rule on this / how do we deal with different screen sizes?

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-07-01 at 16 10 47](https://user-images.githubusercontent.com/7389546/124147781-eb1dbe80-da86-11eb-83e7-233d1e4586f1.png)
![Simulator Screen Shot - iPhone 11 - 2021-07-01 at 16 11 21](https://user-images.githubusercontent.com/7389546/124147876-02f54280-da87-11eb-857e-6fa5e392b267.png)
![Jul-01-2021 16-12-42](https://user-images.githubusercontent.com/7389546/124148053-320bb400-da87-11eb-97c4-5adc25e5c14a.gif)


## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [x] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

n/a