### PR TITLE
DiseasePreferences Screen: Move copy to translation files and use ReconsentScreen wrapper

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1700,6 +1700,9 @@
 
   "reconsent": {
     "disease-preferences": {
+      "title": "What matters most to you?",
+      "subtitle": "Select as many as you like",
+      "show-more": "+ Show more",
       "how-data-used": "Your data will help scientists research a wide range of disorders, not just the ones you’ve selected"
     },
     "introduction": {

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1705,6 +1705,9 @@
 
   "reconsent": {
     "disease-preferences": {
+      "title": "What matters most to you?",
+      "subtitle": "Select as many as you like",
+      "show-more": "+ Show more",
       "how-data-used": "Your data will help scientists research a wide range of disorders, not just the ones you’ve selected"
     },
     "introduction": {

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1689,6 +1689,9 @@
 
   "reconsent": {
     "disease-preferences": {
+      "title": "What matters most to you?",
+      "subtitle": "Select as many as you like",
+      "show-more": "+ Show more",
       "how-data-used": "Your data will help scientists research a wide range of disorders, not just the ones you’ve selected"
     },
     "introduction": {

--- a/src/features/reconsent/screens/ReconsentDiseasePreferencesScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentDiseasePreferencesScreen.tsx
@@ -1,15 +1,15 @@
 import { Brain } from '@assets/icons/svgIcons';
-import { SafeLayout, Text } from '@covid/components';
+import { Text } from '@covid/components';
 import DiseaseCard from '@covid/features/reconsent/components/DiseaseCard';
 import InfoBox from '@covid/features/reconsent/components/InfoBox';
-import ReconsentFooter from '@covid/features/reconsent/components/ReconsentFooter';
 import ReconsentHeader from '@covid/features/reconsent/components/ReconsentHeader';
+import ReconsentScreen from '@covid/features/reconsent/components/ReconsentScreen';
 import i18n from '@covid/locale/i18n';
 import NavigatorService from '@covid/NavigatorService';
-import { grid, styling, useTheme } from '@covid/themes';
+import { grid } from '@covid/themes';
 import { colors } from '@theme';
 import * as React from 'react';
-import { FlatList, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { FlatList, Pressable, StyleSheet, View } from 'react-native';
 
 type TDiseaseType = {
   iconName: React.ElementType;
@@ -69,7 +69,6 @@ const extendedDiseases: TDiseaseType[] = [
 ];
 
 export default function ReconsentDiseasePreferencesScreen() {
-  const theme = useTheme();
   const [showExtendedList, setShowExtendedList] = React.useState<boolean>(false);
   const addToPreferences = () => {
     console.log('hi');
@@ -91,40 +90,35 @@ export default function ReconsentDiseasePreferencesScreen() {
   const ShowMore = () => (
     <Pressable onPress={() => setShowExtendedList(true)}>
       <Text rhythm={16} style={styles.showMore} textClass="pMedium">
-        + Show more
+        {i18n.t('reconsent.disease-preferences.show-more')}
       </Text>
     </Pressable>
   );
 
   return (
-    <SafeLayout style={styles.page}>
-      <ScrollView contentContainerStyle={styling.flexGrow} style={{ paddingHorizontal: theme.grid.xxl }}>
-        <ReconsentHeader showBackIcon showDots />
-        <View>
-          <Text rhythm={24} style={styles.center} textClass="h2Light">
-            What matters most to you?
-          </Text>
-          <Text rhythm={16} style={[styles.center, styles.subtitle]} textClass="pLight">
-            Select as many as you like
-          </Text>
-          <FlatList
-            data={showExtendedList ? initialDiseases.concat(extendedDiseases) : initialDiseases}
-            keyExtractor={(disease: TDiseaseType) => disease.name}
-            ListFooterComponent={ShowMore}
-            ListFooterComponentStyle={showExtendedList ? { display: 'none' } : null}
-            renderItem={renderItem}
-            style={{ overflow: 'visible' }}
-          />
-          <View style={styles.infoBox}>
-            <InfoBox text={i18n.t('reconsent.disease-preferences.how-data-used')} />
-          </View>
-        </View>
-      </ScrollView>
-      <ReconsentFooter
-        onPress={() => NavigatorService.navigate('ReconsentDiseaseConfirmation')}
-        title={i18n.t('navigation.next')}
+    <ReconsentScreen
+      buttonOnPress={() => NavigatorService.navigate('ReconsentDiseaseConfirmation')}
+      buttonTitle={i18n.t('navigation.next')}
+    >
+      <ReconsentHeader showBackIcon showDots />
+      <Text rhythm={24} style={styles.center} textClass="h2Light">
+        {i18n.t('reconsent.disease-preferences.title')}
+      </Text>
+      <Text rhythm={16} style={[styles.center, styles.subtitle]} textClass="pLight">
+        {i18n.t('reconsent.disease-preferences.subtitle')}
+      </Text>
+      <FlatList
+        data={showExtendedList ? initialDiseases.concat(extendedDiseases) : initialDiseases}
+        keyExtractor={(disease: TDiseaseType) => disease.name}
+        ListFooterComponent={ShowMore}
+        ListFooterComponentStyle={showExtendedList ? { display: 'none' } : null}
+        renderItem={renderItem}
+        style={{ overflow: 'visible' }}
       />
-    </SafeLayout>
+      <View style={styles.infoBox}>
+        <InfoBox text={i18n.t('reconsent.disease-preferences.how-data-used')} />
+      </View>
+    </ReconsentScreen>
   );
 }
 


### PR DESCRIPTION
# Description

Refactor:
- Move copy to translation files
- Use the `ReconsentScreen` wrapper

https://www.notion.so/joinzoe/Product-Eng-Board-ca9e8b1b8926481f8c94cb01a88d567d?p=e1aa34fff0c54f7f8a49df052e13a990

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

_Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
