### PR TITLE
Restructuring "reconsent" slice and save disease preferences to backend

### DIFF
--- a/src/core/state/reconsent/slice/__tests__/index.ts
+++ b/src/core/state/reconsent/slice/__tests__/index.ts
@@ -4,22 +4,22 @@ import store from '@covid/core/state/store';
 describe('\n** redux reconsent state **\n', () => {
   let state = store.getState().reconsent;
   it('should initially set disease preferences to empty object', () => {
-    expect(state).toEqual({});
+    expect(state.diseasePreferences).toEqual({});
   });
   it('should be able to set dementia to true', () => {
     store.dispatch(updateDiseasePreferences({ dementia: true }));
     state = store.getState().reconsent;
-    expect(state.dementia).toBe(true);
+    expect(state.diseasePreferences.dementia).toBe(true);
   });
   it('should be able to set mental health to true', () => {
     store.dispatch(updateDiseasePreferences({ mental_health: true }));
     state = store.getState().reconsent;
-    expect(state.mental_health).toBe(true);
+    expect(state.diseasePreferences.mental_health).toBe(true);
   });
   it('should be able to set dementia to false', () => {
     store.dispatch(updateDiseasePreferences({ dementia: false, mental_health: true }));
     state = store.getState().reconsent;
-    expect(state.mental_health).toBe(true);
-    expect(state.dementia).toBe(false);
+    expect(state.diseasePreferences.mental_health).toBe(true);
+    expect(state.diseasePreferences.dementia).toBe(false);
   });
 });

--- a/src/core/state/reconsent/slice/index.ts
+++ b/src/core/state/reconsent/slice/index.ts
@@ -12,6 +12,7 @@ const reconsentSlice = createSlice({
   reducers: {
     updateDiseasePreferences: (state, action: PayloadAction<TDiseasePreferencesData>) => {
       return {
+        ...state,
         diseasePreferences: action.payload,
       };
     },

--- a/src/core/state/reconsent/slice/index.ts
+++ b/src/core/state/reconsent/slice/index.ts
@@ -1,30 +1,18 @@
-import { TDiseasePreferencesData } from '@covid/core/state/reconsent/types';
+import { IReconsent, TDiseasePreferencesData } from '@covid/core/state/reconsent/types';
 import { RootState } from '@covid/core/state/root';
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-export const initialStateDiseasePreferences: TDiseasePreferencesData = {};
-
-// TODO: Update API endpoint
-export const saveDiseasePreferences = createAsyncThunk<unknown, TDiseasePreferencesData>(
-  '/users/disease_preference/',
-  async (diseasePreferences: TDiseasePreferencesData) => {
-    console.log('sending data to backend', diseasePreferences);
-    // try {
-    //   await apiClient.patch('/users/disease_preference/', diseasePreferences);
-    // } catch (e) {
-    //   // eslint-disable-next-line no-console
-    //   console.error(`Failed to save disease preferences to database: ${e}`);
-    // }
-  },
-);
+export const initialStateReconsent: IReconsent = {
+  diseasePreferences: {},
+};
 
 const reconsentSlice = createSlice({
-  initialState: initialStateDiseasePreferences,
+  initialState: initialStateReconsent,
   name: 'ReconsentState',
   reducers: {
     updateDiseasePreferences: (state, action: PayloadAction<TDiseasePreferencesData>) => {
       return {
-        ...action.payload,
+        diseasePreferences: action.payload,
       };
     },
   },

--- a/src/core/state/reconsent/types/index.ts
+++ b/src/core/state/reconsent/types/index.ts
@@ -14,3 +14,7 @@ export type TDisease =
 export type TDiseasePreferencesData = {
   [key in TDisease]?: boolean;
 };
+
+export interface IReconsent {
+  diseasePreferences: TDiseasePreferencesData;
+}

--- a/src/core/state/root.ts
+++ b/src/core/state/root.ts
@@ -21,7 +21,7 @@ import {
   mentalHealthSupportSlice,
 } from './mental-health';
 import { IMentalHealthPlayback, mentalHealthPlaybackSlice } from './mental-health-playback';
-import { reconsentSlice, TDiseasePreferencesData } from './reconsent';
+import { IReconsent, reconsentSlice } from './reconsent';
 import { ISettings, settingsSlice } from './settings';
 import { IUser, userSlice } from './user';
 import { IVaccineState, vaccinesSlice } from './vaccines';
@@ -38,7 +38,7 @@ export type RootState = {
   mentalHealthPlayback: IMentalHealthPlayback;
   mentalHealthState: IMentalHealthState;
   mentalHealthSupport: IMentalHealthSupport;
-  reconsent: TDiseasePreferencesData;
+  reconsent: IReconsent;
   school: SchoolState;
   settings: ISettings;
   user: IUser;

--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -258,6 +258,19 @@ export type PatientInfosRequest = {
   should_ask_vaccine_questions: boolean;
   vaccine_status: VaccineStatus;
   should_ask_long_covid_questions: boolean;
+
+  // Reconsent
+  dementia: boolean;
+  cardiovascular_diseases: boolean;
+  cancer: boolean;
+  joint_and_bone_diseases: boolean;
+  mental_health: boolean;
+  womens_health: boolean;
+  vision_and_hearing_conditions: boolean;
+  autoimmune_conditions: boolean;
+  skin_conditions: boolean;
+  lung_diseases: boolean;
+  neurological_conditions: boolean;
 };
 
 export enum VaccineStatus {

--- a/src/features/reconsent/screens/ReconsentDiseasePreferencesScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentDiseasePreferencesScreen.tsx
@@ -69,7 +69,9 @@ const extendedDiseases: TDiseasePreference[] = [
 
 export default function ReconsentDiseasePreferencesScreen() {
   const dispatch = useDispatch();
-  const diseasePreferencesPersisted = useSelector<RootState, TDiseasePreferencesData>((state) => state.reconsent);
+  const diseasePreferencesPersisted = useSelector<RootState, TDiseasePreferencesData>(
+    (state) => state.reconsent.diseasePreferences,
+  );
 
   const extendedListDiseaseNames: TDisease[] = extendedDiseases.map((item) => item.name);
   const identifiers = Object.keys(diseasePreferencesPersisted) as TDisease[];

--- a/src/features/reconsent/screens/ReconsentDiseaseSummaryScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentDiseaseSummaryScreen.tsx
@@ -10,7 +10,9 @@ import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 
 export default function ReconsentDiseaseSummaryScreen() {
-  const diseasePreferences = useSelector<RootState, TDiseasePreferencesData>((state) => state.reconsent);
+  const diseasePreferences = useSelector<RootState, TDiseasePreferencesData>(
+    (state) => state.reconsent.diseasePreferences,
+  );
   const identifiers = Object.keys(diseasePreferences) as TDisease[];
   const diseasesChosen = identifiers.filter((key: keyof TDiseasePreferencesData) => diseasePreferences[key] === true);
   const numberDiseases = diseasesChosen.length;

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -1,6 +1,5 @@
 import { Text } from '@covid/components';
 import { TDiseasePreferencesData } from '@covid/core/state/reconsent';
-import { saveDiseasePreferences } from '@covid/core/state/reconsent/slice';
 import { RootState } from '@covid/core/state/root';
 import ReconsentScreen from '@covid/features/reconsent/components/ReconsentScreen';
 import { ScreenParamList } from '@covid/features/ScreenParamList';
@@ -32,7 +31,9 @@ const Callout = (props: { title: string; description: string }) => {
 
 export default function ReconsentRequestConsentScreen(props: IProps) {
   const dispatch = useDispatch();
-  const diseasePreferences = useSelector<RootState, TDiseasePreferencesData>((state) => state.reconsent);
+  const diseasePreferences = useSelector<RootState, TDiseasePreferencesData>(
+    (state) => state.reconsent.diseasePreferences,
+  );
 
   const onPrivacyPolicyPress = () => {
     NavigatorService.navigate('PrivacyPolicyUK', { viewOnly: true });
@@ -49,7 +50,8 @@ export default function ReconsentRequestConsentScreen(props: IProps) {
   };
 
   const onConfirmYes = () => {
-    dispatch(saveDiseasePreferences(diseasePreferences));
+    //  insert patient service
+    console.log(diseasePreferences);
     NavigatorService.navigate('ReconsentNewsletterSignup');
   };
 

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -1,4 +1,6 @@
 import { Text } from '@covid/components';
+import { ErrorText } from '@covid/components/Text';
+import { patientService } from '@covid/core/patient/PatientService';
 import { TDiseasePreferencesData } from '@covid/core/state/reconsent';
 import { RootState } from '@covid/core/state/root';
 import ReconsentScreen from '@covid/features/reconsent/components/ReconsentScreen';
@@ -10,7 +12,7 @@ import { RouteProp } from '@react-navigation/native';
 import { colors } from '@theme';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 interface IProps {
   route: RouteProp<ScreenParamList, 'ReconsentRequestConsent'>;
@@ -30,7 +32,9 @@ const Callout = (props: { title: string; description: string }) => {
 };
 
 export default function ReconsentRequestConsentScreen(props: IProps) {
-  const dispatch = useDispatch();
+  const [error, setError] = React.useState<string | null>(null);
+  const patientId = useSelector<RootState, string>((state) => state.user.patients[0]);
+
   const diseasePreferences = useSelector<RootState, TDiseasePreferencesData>(
     (state) => state.reconsent.diseasePreferences,
   );
@@ -49,10 +53,13 @@ export default function ReconsentRequestConsentScreen(props: IProps) {
     ));
   };
 
-  const onConfirmYes = () => {
-    //  insert patient service
-    console.log(diseasePreferences);
-    NavigatorService.navigate('ReconsentNewsletterSignup');
+  const onConfirmYes = async () => {
+    try {
+      await patientService.updatePatientInfo(patientId, diseasePreferences);
+      NavigatorService.navigate('ReconsentNewsletterSignup');
+    } catch {
+      setError(i18n.t('something-went-wrong'));
+    }
   };
 
   return (
@@ -76,6 +83,7 @@ export default function ReconsentRequestConsentScreen(props: IProps) {
         {i18n.t('reconsent.request-consent.learn-more')}{' '}
       </Text>
       <View style={styles.hr} />
+      {error ? <ErrorText style={{ marginBottom: 8, textAlign: 'center' }}>{error}</ErrorText> : null}
     </ReconsentScreen>
   );
 }


### PR DESCRIPTION
# Description

https://www.notion.so/joinzoe/Re-consent-Flow-Use-Formik-state-to-manage-disease-preferences-d2e26c534ea143a385f044a09e4aeefc

https://www.notion.so/joinzoe/Product-Eng-Board-ca9e8b1b8926481f8c94cb01a88d567d?p=5cd3749b554c4dfbaad17d5e1667a59f

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

n/a

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

Wait for backend migrations to check that disease preferences are being saved.