### PR TITLE
Fix the boolean being sent to the backend for the newsletter signup

### DIFF
--- a/src/features/reconsent/screens/ReconsentNewsletterSignupScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentNewsletterSignupScreen.tsx
@@ -24,7 +24,7 @@ export default function ReconsentNewsletterSignupScreen() {
 
   async function toggleNewsletterSignup() {
     try {
-      await contentService.signUpForDiseaseResearchNewsletter(signedUp);
+      await contentService.signUpForDiseaseResearchNewsletter(!signedUp);
       setSignedUp((prevState) => !prevState);
     } catch {
       setError(i18n.t('something-went-wrong'));


### PR DESCRIPTION
# Description

This is due to the sequence of when the component state is saved vs when the boolean is sent to the backend!

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

_Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
