### PR TITLE
Update copy on summary screen if no diseases are chosen

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1665,7 +1665,8 @@
   "reconsent": {
     "disease-summary": {
       "button": "Next",
-      "title": "We’ll invite you to answer additional questions occasionally and send you insights about"
+      "title": "We’ll invite you to answer additional questions occasionally and send you insights about",
+      "various-diseases": "various diseases"
     },
     "disease-preferences": {
       "title": "What matters most to you?",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -1666,7 +1666,8 @@
   "reconsent": {
     "disease-summary": {
       "button": "Next",
-      "title": "We’ll invite you to answer additional questions occasionally and send you insights about"
+      "title": "We’ll invite you to answer additional questions occasionally and send you insights about",
+      "various-diseases": "various diseases"
     },
     "disease-preferences": {
       "title": "What matters most to you?",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1648,7 +1648,8 @@
   "reconsent": {
     "disease-summary": {
       "button": "Next",
-      "title": "We’ll invite you to answer additional questions occasionally and send you insights about"
+      "title": "We’ll invite you to answer additional questions occasionally and send you insights about",
+      "various-diseases": "various diseases"
     },
     "disease-preferences": {
       "title": "What matters most to you?",

--- a/src/features/reconsent/screens/ReconsentDiseaseSummaryScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentDiseaseSummaryScreen.tsx
@@ -19,7 +19,7 @@ export default function ReconsentDiseaseSummaryScreen() {
   // TODO: Copy in the event of no choices being made
 
   if (numberDiseases === 0) {
-    diseasesTitle = 'Sol to provide';
+    diseasesTitle = 'various diseases';
   } else if (numberDiseases === 1) {
     diseasesTitle = i18n.t(`disease-cards.${diseasesChosen[0]}.name`);
   } else if (numberDiseases === 2) {
@@ -41,9 +41,15 @@ export default function ReconsentDiseaseSummaryScreen() {
       <Text textAlign="center" textClass="h2Light">
         {i18n.t('reconsent.disease-summary.title')}
       </Text>
-      <Text inverted colorPalette="actionSecondary" colorShade="main" textAlign="center" textClass="h2">
-        {diseasesTitle}
-      </Text>
+      {numberDiseases === 0 ? (
+        <Text textAlign="center" textClass="h2Light">
+          {diseasesTitle}
+        </Text>
+      ) : (
+        <Text inverted colorPalette="actionSecondary" colorShade="main" textAlign="center" textClass="h2">
+          {diseasesTitle}
+        </Text>
+      )}
       <IllustrationConfirmation style={styles.illustration} />
     </ReconsentScreen>
   );

--- a/src/features/reconsent/screens/ReconsentDiseaseSummaryScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentDiseaseSummaryScreen.tsx
@@ -19,7 +19,7 @@ export default function ReconsentDiseaseSummaryScreen() {
   // TODO: Copy in the event of no choices being made
 
   if (numberDiseases === 0) {
-    diseasesTitle = 'various diseases';
+    diseasesTitle = i18n.t('reconsent.disease-summary.various-diseases');
   } else if (numberDiseases === 1) {
     diseasesTitle = i18n.t(`disease-cards.${diseasesChosen[0]}.name`);
   } else if (numberDiseases === 2) {


### PR DESCRIPTION
# Description

https://www.notion.so/joinzoe/Re-consent-flow-Amend-copy-on-summary-screen-if-no-diseases-are-selected-Sol-to-provide-cb6feb3c8abe45b4a8ad949d191429d7

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-07-07 at 11 51 42](https://user-images.githubusercontent.com/7389546/124747475-dd9a8580-df19-11eb-9bf7-255115d92fcd.png)


## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

_Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
