### PR TITLE
Show reconsent flow based on show_research_consent flag

### DIFF
--- a/src/core/user/dto/UserAPIContracts.ts
+++ b/src/core/user/dto/UserAPIContracts.ts
@@ -327,6 +327,7 @@ export type StartupInfo = {
   show_new_dashboard: boolean;
   show_timeline: boolean;
   show_trendline: boolean;
+  show_research_consent: boolean;
   users_count: number;
   local_data: {
     app_users: number;

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -73,7 +73,9 @@ export function DashboardScreen({ navigation, route }: IProps) {
   const [shouldShowReminders, setShouldShowReminders] = React.useState(false);
 
   const runCurrentFeature = () => {
-    if (startupInfo?.show_modal === 'mental-health-playback') {
+    if (startupInfo?.show_research_consent) {
+      appCoordinator.goToReconsent();
+    } else if (startupInfo?.show_modal === 'mental-health-playback') {
       setMentalHealthPlaybackModalVisible(true);
     }
   };
@@ -114,14 +116,6 @@ export function DashboardScreen({ navigation, route }: IProps) {
 
   React.useEffect(() => {
     Linking.addEventListener('url', () => {});
-  }, []);
-
-  React.useEffect(() => {
-    if (startupInfo?.show_research_consent) {
-      setTimeout(() => {
-        appCoordinator.goToReconsent();
-      }, 500);
-    }
   }, []);
 
   return (

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -47,8 +47,6 @@ const headerConfig = {
   expanded: HEADER_EXPANDED_HEIGHT,
 };
 
-let userNeedsToReconsent = true;
-
 export function DashboardScreen({ navigation, route }: IProps) {
   const app = useSelector(selectApp);
   const dispatch = useAppDispatch();
@@ -119,8 +117,7 @@ export function DashboardScreen({ navigation, route }: IProps) {
   }, []);
 
   React.useEffect(() => {
-    if (userNeedsToReconsent) {
-      userNeedsToReconsent = false;
+    if (startupInfo?.show_research_consent) {
       setTimeout(() => {
         appCoordinator.goToReconsent();
       }, 500);


### PR DESCRIPTION
# Description

Only show the reconsent flow on startup if the `show_research_consent` flag is true.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Screenshots

_Please attach screenshots showing the change if relevant_

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if needed)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Out of scope and potential follow-up

_Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?_
