### PR TITLE
2.6.0-ota-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "expo-web-browser": "8.5.0",
     "formik": "2.2.6",
     "i18n-js": "3.8.0",
-    "immer": "8.0.1",
+    "immer": "9.0.6",
     "lodash": "^4.17.21",
     "moment": "2.29.1",
     "native-base": "2.13.14",

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -95,6 +95,12 @@ export function DashboardScreen({ navigation, route }: IProps) {
     Linking.addEventListener('url', () => {});
   }, []);
 
+  React.useEffect(() => {
+    if (startupInfo?.show_research_consent) {
+      appCoordinator.goToReconsent();
+    }
+  }, []);
+
   return (
     <CollapsibleHeaderScrollView
       compactHeader={<CompactHeader reportOnPress={onReport} />}

--- a/src/features/dashboard/DashboardScreen.tsx
+++ b/src/features/dashboard/DashboardScreen.tsx
@@ -97,7 +97,7 @@ export function DashboardScreen({ navigation, route }: IProps) {
 
   React.useEffect(() => {
     if (startupInfo?.show_research_consent) {
-      appCoordinator.goToReconsent();
+      setTimeout(() => appCoordinator.goToReconsent(), 500);
     }
   }, []);
 

--- a/src/features/thank-you/ThankYouUKScreen.tsx
+++ b/src/features/thank-you/ThankYouUKScreen.tsx
@@ -32,10 +32,6 @@ export default function ThankYouUKScreen(props: IProps) {
 
   React.useEffect(() => {
     (async () => {
-      if (startupInfo?.show_research_consent) {
-        appCoordinator.goToReconsent();
-        return;
-      }
       if (startupInfo?.show_modal === 'mental-health-playback') {
         dispatch(appActions.setModalMentalHealthPlaybackVisible(true));
         return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11160,10 +11160,10 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
-immer@^9.0.1:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.5.tgz#a7154f34fe7064f15f00554cc94c66cc0bf453ec"
-  integrity sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ==
+immer@9.0.6, immer@^9.0.1:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
# Description

- Moved the reconsent starting point to the home screen
- Sub dependency `Immer` updated by dependabot

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [ ] iOS - Emulator
- [ ] iOS - Physical device

## Out of scope and potential follow-up

[comment]: <> (Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?)

## Screenshots

[comment]: <> (Please attach screenshots showing the change, if relevant)

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if relevant)
- [ ] Added new screen(s) to `src/features/screens.ts` and new Redux slice(s) to `mocks/mockedInitialState.ts` (if relevant)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Checklist (for merger)

- [ ] Make sure the right merge strategy is chosen, commit merge into master and squash merge into develop.
