### PR TITLE
OTA release 2.6.0

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1521,6 +1521,7 @@
       "consent-no": "No, I do not consent",
       "consent-yes": "Yes, I consent",
       "information-sheet": "Information Sheet",
+      "primary-profile-only": "You are only providing consent for your profile, and not others you report for.",
       "privacy-notice": "Privacy Notice",
       "subtitle": "To fight other major health issues, we’d like your consent to:",
       "title": "Are you in?",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -991,7 +991,10 @@
     },
     "vaccine-list-updated": {
       "title": "Your COVID-19 vaccines",
-      "description": "Tell us if you’ve had at least one dose of a COVID-19 vaccine, including boosters, through the national roll-out.\n\nWe can now record COVID-19 vaccines taken as part of a trial - please select \"I received my vaccine via a vaccine trial\" when asked for the name of your vaccine.",
+      "description": "Tell us if you've had a COVID-19 vaccine. This now also includes *boosters and vaccines taken as part of a trial*.",
+      "modal-title": "Logging your vaccines",
+      "modal-body": "We can now record COVID-19 vaccines taken as part of a trial. Please select \"I received my vaccine via a vaccine trial\" when asked for the name of your vaccine.",
+      "modal-button": "OK",
       "add-button": "Add a vaccine dose",
       "correct-info": "This information is correct",
       "no-vaccine": "I haven't had a vaccine",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -1525,6 +1525,7 @@
       "consent-no": "No, I do not consent",
       "consent-yes": "Yes, I consent",
       "information-sheet": "Information Sheet",
+      "primary-profile-only": "You are only providing consent for your profile, and not others you report for.",
       "privacy-notice": "Privacy Notice",
       "subtitle": "To fight other major health issues, we’d like your consent to:",
       "title": "Are you in?",

--- a/assets/lang/sv-SE.json
+++ b/assets/lang/sv-SE.json
@@ -996,6 +996,9 @@
     "vaccine-list-updated": {
       "title": "Dina covid-19-vacciner",
       "description": "Berätta om du har fått minst en covid-19-vaccindos, inklusive eventuella boosterdoser.",
+      "modal-title": "Logging your vaccines",
+      "modal-body": "We can now record COVID-19 vaccines taken as part of a trial. Please select \"I received my vaccine via a vaccine trial\" when asked for the name of your vaccine.",
+      "modal-button": "OK",
       "add-button": "Lägg till vaccindos",
       "correct-info": "Informationen är korrekt",
       "no-vaccine": "Jag har inte vaccinerats",

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -66,6 +66,31 @@ export const RegularText = ({ style, children, testID }: IProps) => (
   </Text>
 );
 
+interface IRegularTextWithBoldInsertsProps {
+  text: string;
+  style?: StyleProp<ViewStyle | TextStyle | ImageStyle>;
+}
+
+export const RegularTextWithBoldInserts = ({ text, style }: IRegularTextWithBoldInsertsProps) => {
+  const textParts: string[] = text.split('*');
+  let boldText: boolean = !!text.startsWith('*');
+  return (
+    <Text style={style}>
+      {textParts
+        .filter((text: string) => text)
+        .map((text: string) => {
+          const node: React.ReactNode = boldText ? (
+            <Text style={{ fontWeight: '600' }}>{text}</Text>
+          ) : (
+            <Text>{text}</Text>
+          );
+          boldText = !boldText;
+          return node;
+        })}
+    </Text>
+  );
+};
+
 export const FieldLabel = ({ style, children }: IProps) => (
   <Text style={[fontStyles.bodyReg, styles.fieldLabel, style]}>{children}</Text>
 );

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -69,9 +69,16 @@ export default function ReconsentRequestConsentScreen() {
     setLoading(false);
   }
 
-  function onPressNo() {
+  async function onPressNo() {
     Analytics.track(events.RECONSENT_FIRST_NO_CLICKED);
-    NavigatorService.navigate('ReconsentFeedback');
+    try {
+      setLoading(true);
+      await patientService.updatePatientInfo(patientId, diseasePreferences);
+      NavigatorService.navigate('ReconsentFeedback');
+    } catch {
+      setError(i18n.t('something-went-wrong'));
+    }
+    setLoading(false);
   }
 
   return (

--- a/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
+++ b/src/features/reconsent/screens/ReconsentRequestConsentScreen.tsx
@@ -86,7 +86,7 @@ export default function ReconsentRequestConsentScreen() {
       <Text rhythm={16} style={styles.center} textClass="h2Light">
         {i18n.t('reconsent.request-consent.title')}
       </Text>
-      <Text rhythm={24} style={[styles.center, styles.subtitle]} textClass="pLight">
+      <Text rhythm={24} style={[styles.center, styles.secondaryColour]} textClass="pLight">
         {i18n.t('reconsent.request-consent.subtitle')}
       </Text>
       {renderCallouts()}
@@ -106,10 +106,13 @@ export default function ReconsentRequestConsentScreen() {
         style={styles.marginTop}
         testID="button-information-sheet"
       >
-        <Text style={styles.externalLink} textClass="pSmallLight">
+        <Text rhythm={24} style={styles.externalLink} textClass="pSmallLight">
           {i18n.t('reconsent.request-consent.information-sheet')}{' '}
         </Text>
       </TouchableOpacity>
+      <Text style={[styles.center, styles.secondaryColour]} textClass="pLight">
+        {i18n.t('reconsent.request-consent.primary-profile-only')}
+      </Text>
       <View style={styles.hr} />
       {error ? <ErrorText style={styles.errorText}>{error}</ErrorText> : null}
       <BrandedButton
@@ -162,8 +165,8 @@ const styles = StyleSheet.create({
   hr: {
     backgroundColor: colors.backgroundFour,
     height: 1,
-    marginBottom: sizes.l,
-    marginTop: sizes.xl,
+    marginBottom: sizes.xl,
+    marginTop: sizes.l,
     width: '100%',
   },
   marginTop: {
@@ -172,7 +175,7 @@ const styles = StyleSheet.create({
   page: {
     backgroundColor: colors.backgroundPrimary,
   },
-  subtitle: {
+  secondaryColour: {
     color: colors.secondary,
   },
 });

--- a/src/features/vaccines/VaccineListScreenUpdated.tsx
+++ b/src/features/vaccines/VaccineListScreenUpdated.tsx
@@ -1,8 +1,10 @@
-import { BrandedButton, RegularText, Text } from '@covid/components';
+import InfoCircle from '@assets/icons/InfoCircle';
+import { BrandedButton, HeaderText, LightText, Modal, RegularTextWithBoldInserts, Text } from '@covid/components';
 import { Loading } from '@covid/components/Loading';
 import { ProgressHeader } from '@covid/components/ProgressHeader';
 import { Screen } from '@covid/components/Screen';
 import { assessmentCoordinator } from '@covid/core/assessment/AssessmentCoordinator';
+import { isSECountry } from '@covid/core/localisation/LocalisationService';
 import { TDose, TVaccineRequest } from '@covid/core/vaccine/dto/VaccineRequest';
 import { vaccineService } from '@covid/core/vaccine/VaccineService';
 import { TScreenParamList } from '@covid/features/ScreenParamList';
@@ -13,7 +15,7 @@ import { RouteProp, useFocusEffect } from '@react-navigation/native';
 import { colors } from '@theme';
 import moment from 'moment';
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { VaccineDoseRow } from './components/VaccineDoseRow';
 
@@ -24,6 +26,7 @@ type TProps = {
 export const VaccineListScreenUpdated: React.FC<TProps> = ({ route }) => {
   const [vaccines, setVaccines] = React.useState<TVaccineRequest | undefined>();
   const [loading, setLoading] = React.useState<boolean>(true);
+  const [modalVisible, setModalVisible] = React.useState<boolean>(false);
 
   const patientId = route.params?.assessmentData?.patientData?.patientId;
 
@@ -150,19 +153,39 @@ export const VaccineListScreenUpdated: React.FC<TProps> = ({ route }) => {
     </View>
   );
 
+  const renderMoreInfoModal = () => (
+    <Modal onRequestClose={() => setModalVisible(false)} testID="vaccine-list-updated-modal" visible={modalVisible}>
+      <View style={styles.modalWrapper}>
+        <HeaderText style={styles.modalTitle}>{i18n.t('vaccines.vaccine-list-updated.modal-title')}</HeaderText>
+        <LightText style={styles.modalBody}>{i18n.t('vaccines.vaccine-list-updated.modal-body')}</LightText>
+        <BrandedButton onPress={() => setModalVisible(false)}>
+          {i18n.t('vaccines.vaccine-list-updated.modal-button')}
+        </BrandedButton>
+      </View>
+    </Modal>
+  );
+
   return (
     <Screen
       profile={route.params?.assessmentData?.patientData?.patientState?.profile}
       renderFooter={footer}
       testID="vaccine-list-screen"
     >
+      {renderMoreInfoModal()}
       <View>
         <ProgressHeader currentStep={0} maxSteps={1} title={i18n.t('vaccines.vaccine-list-updated.title')} />
       </View>
-      <View style={styles.introduction}>
-        <RegularText testID="vaccine-list-introduction">
-          {i18n.t('vaccines.vaccine-list-updated.description')}
-        </RegularText>
+      <View style={styles.introduction} testID="vaccine-list-introduction">
+        <Text>
+          <RegularTextWithBoldInserts text={i18n.t('vaccines.vaccine-list-updated.description')} />
+          {isSECountry() ? null : (
+            <TouchableOpacity onPress={() => setModalVisible(true)}>
+              <View style={styles.paddingLeft}>
+                <InfoCircle color={colors.primary} />
+              </View>
+            </TouchableOpacity>
+          )}
+        </Text>
       </View>
       <ListContent />
     </Screen>
@@ -177,12 +200,26 @@ const styles = StyleSheet.create({
     marginBottom: sizes.xxl,
     marginTop: sizes.l,
   },
+  modalBody: {
+    marginBottom: sizes.xl,
+  },
+  modalTitle: {
+    marginBottom: sizes.l,
+    textAlign: 'center',
+  },
+  modalWrapper: {
+    padding: sizes.xxs,
+    paddingBottom: sizes.xs,
+  },
   newButton: {
     backgroundColor: colors.backgroundTertiary,
     marginBottom: sizes.xl,
   },
   newText: {
     color: colors.primary,
+  },
+  paddingLeft: {
+    paddingLeft: sizes.xs,
   },
   rootContainer: {
     backgroundColor: colors.backgroundPrimary,


### PR DESCRIPTION
- Add clarification copy that user is only re-consenting for the primary user
- Save disease preferences in the event that no consent is provided
- Finish styling of info modal for new vaccine screens (informing user of ability to log vaccines as part of a trial)