### PR TITLE
2.6.0-ota-25

### DIFF
--- a/src/components/cards/estimated-case/TrendlineCard.tsx
+++ b/src/components/cards/estimated-case/TrendlineCard.tsx
@@ -29,12 +29,7 @@ const endDate = moment().toDate();
 export function TrendlineCard(props: IProps) {
   const navigation = useNavigation();
 
-  const localTrendline = useSelector<TRootState, ITrendLineData | undefined>((state) => ({
-    delta: state.content.localTrendline?.delta,
-    name: state.content.personalizedLocalData?.name,
-    timeseries: state.content.localTrendline?.timeseries,
-    today: state.content.personalizedLocalData?.cases,
-  }));
+  const localTrendline = useSelector<TRootState, ITrendLineData | undefined>((state) => state.content.localTrendline);
 
   const onPress = React.useCallback(() => {
     if (props.onPress) {

--- a/src/core/content/ContentApiClient.ts
+++ b/src/core/content/ContentApiClient.ts
@@ -5,7 +5,7 @@ import { TFeaturedContentResponse, TTrendLineResponse } from './dto/ContentAPICo
 
 interface IContentApiClient {
   getStartupInfo(): Promise<TStartupInfo>;
-  getTrendLines(lad?: string): Promise<TTrendLineResponse>;
+  getTrendLines(): Promise<TTrendLineResponse>;
   getFeaturedContent(): Promise<TFeaturedContentResponse>;
   signUpForDietNewsletter(signup: boolean): Promise<void>;
   signUpForDiseaseResearchNewsletter(signup: boolean): Promise<void>;
@@ -18,9 +18,8 @@ class ContentApiClient implements IContentApiClient {
     return apiClient.get<TStartupInfo>('/users/startup_info/');
   }
 
-  getTrendLines(lad?: string): Promise<TTrendLineResponse> {
-    const path = lad ? `/trendlines/?lad=${lad}` : `/trendlines/`;
-    return apiClient.get<TTrendLineResponse>(path);
+  getTrendLines(): Promise<TTrendLineResponse> {
+    return apiClient.get<TTrendLineResponse>('/trendlines/');
   }
 
   getFeaturedContent(): Promise<TFeaturedContentResponse> {

--- a/src/core/content/ContentService.ts
+++ b/src/core/content/ContentService.ts
@@ -18,7 +18,7 @@ export interface IContentService {
   setAskedToRateStatus(status: string): void;
   getUserCount(): Promise<string | null>;
   getStartupInfo(): Promise<TStartupInfo | undefined>;
-  getTrendLines(lad?: string): Promise<TTrendLineResponse>;
+  getTrendLines(): Promise<TTrendLineResponse>;
   getFeaturedContent(): Promise<TFeaturedContentResponse>;
   signUpForDietNewsletter(signup: boolean): Promise<void>;
   signUpForDiseaseResearchNewsletter(signup: boolean): Promise<void>;
@@ -115,8 +115,8 @@ class ContentService implements IContentService {
     AsyncStorageService.setAskedToRateStatus(status);
   }
 
-  public async getTrendLines(lad?: string): Promise<TTrendLineResponse> {
-    return contentApiClient.getTrendLines(lad);
+  public async getTrendLines(): Promise<TTrendLineResponse> {
+    return contentApiClient.getTrendLines();
   }
 
   public async getFeaturedContent(): Promise<TFeaturedContentResponse> {

--- a/src/features/AppCoordinator.ts
+++ b/src/features/AppCoordinator.ts
@@ -244,8 +244,8 @@ export class AppCoordinator extends Coordinator implements ISelectProfile, IEdit
     NavigatorService.navigate('CreateProfile', { avatarName });
   };
 
-  goToTrendline = (lad?: string) => {
-    NavigatorService.navigate('Trendline', { lad });
+  goToTrendline = () => {
+    NavigatorService.navigate('Trendline');
   };
 
   shouldShowTrendLine(): boolean {

--- a/src/features/ScreenParamList.tsx
+++ b/src/features/ScreenParamList.tsx
@@ -154,7 +154,7 @@ export type TScreenParamList = {
   Modal: undefined;
   Share: { sharable: TSharable | undefined; hideLabel: boolean; label: string };
   Splash: undefined;
-  Trendline: { lad?: string };
+  Trendline: undefined;
   VaccineListMissingModal: { vaccine: TVaccineRequest | undefined };
   VersionUpdateModal: undefined;
 };

--- a/src/features/dashboard/TrendlineScreen.tsx
+++ b/src/features/dashboard/TrendlineScreen.tsx
@@ -19,9 +19,7 @@ import { useDispatch, useSelector } from 'react-redux';
 export const TrendlineScreen: React.FC = () => {
   const dispatch = useDispatch();
   const viewRef = React.useRef<View>(null);
-  const localTrendline = useSelector<TRootState, ITrendLineData | undefined>((state) => ({
-    ...state.content.localTrendline,
-  }));
+  const localTrendline = useSelector<TRootState, ITrendLineData | undefined>((state) => state.content.localTrendline);
 
   const share = async () => {
     try {

--- a/src/features/multi-profile/edit-profile/EditLocationScreen.tsx
+++ b/src/features/multi-profile/edit-profile/EditLocationScreen.tsx
@@ -5,7 +5,7 @@ import { GenericTextField } from '@covid/components/GenericTextField';
 import { YesNoField } from '@covid/components/inputs/YesNoField';
 import { Screen } from '@covid/components/Screen';
 import { ErrorText, HeaderText, SecondaryText } from '@covid/components/Text';
-import { fetchLocalTrendLine } from '@covid/core/state/contentSlice';
+import { fetchLocalTrendLine, fetchStartUpInfo } from '@covid/core/state/contentSlice';
 import { TPatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { editProfileCoordinator } from '@covid/features/multi-profile/edit-profile/EditProfileCoordinator';
 import { TScreenParamList } from '@covid/features/ScreenParamList';
@@ -92,7 +92,10 @@ export const EditLocationScreen: React.FC<TProps> = (props) => {
 
     try {
       await editProfileCoordinator.updatePatientInfo(infos);
+      // Refresh the trend line data because a new postcode corresponds to different trend line data.
       await dispatch(fetchLocalTrendLine());
+      // Refresh the startup info because a new postcode corresponds to changes in the local data.
+      await dispatch(fetchStartUpInfo());
       editProfileCoordinator.gotoNextScreen(props.route.name);
     } catch (_) {
       setErrorMessage(i18n.t('something-went-wrong'));

--- a/src/features/multi-profile/edit-profile/EditLocationScreen.tsx
+++ b/src/features/multi-profile/edit-profile/EditLocationScreen.tsx
@@ -5,7 +5,7 @@ import { GenericTextField } from '@covid/components/GenericTextField';
 import { YesNoField } from '@covid/components/inputs/YesNoField';
 import { Screen } from '@covid/components/Screen';
 import { ErrorText, HeaderText, SecondaryText } from '@covid/components/Text';
-import { fetchStartUpInfo } from '@covid/core/state/contentSlice';
+import { fetchLocalTrendLine } from '@covid/core/state/contentSlice';
 import { TPatientInfosRequest } from '@covid/core/user/dto/UserAPIContracts';
 import { editProfileCoordinator } from '@covid/features/multi-profile/edit-profile/EditProfileCoordinator';
 import { TScreenParamList } from '@covid/features/ScreenParamList';
@@ -73,7 +73,7 @@ export const EditLocationScreen: React.FC<TProps> = (props) => {
     }),
   });
 
-  const onSubmit = (values: TEditLocationData) => {
+  const onSubmit = async (values: TEditLocationData) => {
     const infos: Partial<TPatientInfosRequest> = {};
 
     if (values.differentAddress === 'no') {
@@ -90,15 +90,13 @@ export const EditLocationScreen: React.FC<TProps> = (props) => {
       infos.current_country_code = values.currentCountry;
     }
 
-    editProfileCoordinator
-      .updatePatientInfo(infos)
-      .then(() => {
-        dispatch(fetchStartUpInfo());
-        editProfileCoordinator.gotoNextScreen(props.route.name);
-      })
-      .catch(() => {
-        setErrorMessage(i18n.t('something-went-wrong'));
-      });
+    try {
+      await editProfileCoordinator.updatePatientInfo(infos);
+      await dispatch(fetchLocalTrendLine());
+      editProfileCoordinator.gotoNextScreen(props.route.name);
+    } catch (_) {
+      setErrorMessage(i18n.t('something-went-wrong'));
+    }
   };
 
   const countryList: PickerItemProps[] = require('country-list')


### PR DESCRIPTION
# Description

- Fix for the not matching covid cases number with graph data.

## On what platform have you tested the change?

- [ ] Android - Emulator
- [ ] Android - Physical device
- [x] iOS - Emulator
- [ ] iOS - Physical device

## Out of scope and potential follow-up

[comment]: <> (Are there any related changes that you plan to do in a follow-up PR or voluntarily excluded from the scope?)

## Screenshots

[comment]: <> (Please attach screenshots showing the change, if relevant)

## Checklist (for submission)

- [ ] Analytics/tracking events have been added (if relevant)
- [ ] Added new screen(s) to `src/features/screens.ts` and new Redux slice(s) to `mocks/mockedInitialState.ts` (if relevant)

## Checklist (for reviewers)

- [ ] Checked against Figma designs (if relevant)
- [ ] Checked that data has been successfully saved to the backend (if relevant)

## Checklist (for merger)

- [ ] Make sure the right merge strategy is chosen, commit merge into master and squash merge into develop.
